### PR TITLE
Update website for open-source launch

### DIFF
--- a/apps/site/src/home.test.tsx
+++ b/apps/site/src/home.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { offlineTranslationStory } from "./home";
+import { offlineTranslationStory, openSourceStory } from "./home";
 import { translationSceneCopy } from "./scenes";
 
 describe("public offline translation story", () => {
@@ -28,6 +28,17 @@ describe("public offline translation story", () => {
     );
     expect(translationSceneCopy.status).toBe(
       "Translated from Estonian on this device",
+    );
+  });
+});
+
+describe("public open-source story", () => {
+  it("states that Dakia is open source and invites public inspection", () => {
+    expect(openSourceStory.hero).toContain("open-source desktop app");
+    expect(openSourceStory.title).toContain("open by design");
+    expect(openSourceStory.description).toContain("source code is public");
+    expect(openSourceStory.description).toContain(
+      "inspect how it handles mail",
     );
   });
 });

--- a/apps/site/src/home.tsx
+++ b/apps/site/src/home.tsx
@@ -54,6 +54,13 @@ export const offlineTranslationStory = {
   ],
 } as const;
 
+export const openSourceStory = {
+  hero: "Dakia is a free, open-source desktop app that brings every account into one fast command center—without putting your mail on someone else’s servers or another subscription on your card. Even email translation runs privately on your Mac and keeps working offline.",
+  title: "Modern email, local by default and open by design.",
+  description:
+    "Dakia’s source code is public, so anyone can inspect how it handles mail, report an issue, or help improve the client.",
+} as const;
+
 function Reveal({
   children,
   className = "",
@@ -149,12 +156,7 @@ export function Home({ Link, DownloadButton }: HomeProps) {
               <br />
               <em>One command center.</em>
             </h1>
-            <p className="hero-summary">
-              Dakia brings every account into one fast desktop app, but without
-              putting your mail on someone else’s servers or putting another
-              subscription on your card. Even email translation runs privately
-              on your Mac and keeps working offline.
-            </p>
+            <p className="hero-summary">{openSourceStory.hero}</p>
             <div className="hero-actions">
               <DownloadButton />
               <Link to="/#features" className="button button-secondary">
@@ -179,14 +181,8 @@ export function Home({ Link, DownloadButton }: HomeProps) {
 
       <section className="manifesto-section">
         <Reveal className="shell manifesto-layout">
-          <h2>
-            The polish you expect from a modern mail client. The privacy and
-            freedom you don’t.
-          </h2>
-          <p>
-            Dakia is built for students, independent professionals, and anyone
-            whose life is split across more than one inbox.
-          </p>
+          <h2>{openSourceStory.title}</h2>
+          <p>{openSourceStory.description}</p>
         </Reveal>
       </section>
 
@@ -414,7 +410,7 @@ export function Home({ Link, DownloadButton }: HomeProps) {
       <section className="final-cta">
         <div className="shell final-cta-inner">
           <div className="final-cta-copy">
-            <p className="eyebrow">Free for macOS</p>
+            <p className="eyebrow">Free and open source for macOS</p>
             <h2>
               Put every inbox
               <br />

--- a/apps/site/src/site.css
+++ b/apps/site/src/site.css
@@ -160,6 +160,9 @@ img {
   gap: 24px;
 }
 .nav-links a {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
   color: var(--muted);
   font-size: 0.87rem;
   font-weight: 650;

--- a/apps/site/src/site.test.ts
+++ b/apps/site/src/site.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+import { footerCompanyLinks, headerNavigation, site } from "./site";
+
+describe("public GitHub links", () => {
+  it("links the public repository from the header and footer", () => {
+    expect(site.githubUrl).toBe("https://github.com/DakiaMail/dakia-desktop");
+    expect(headerNavigation).toContainEqual(["GitHub", site.githubUrl]);
+    expect(footerCompanyLinks).toContainEqual(["GitHub", site.githubUrl]);
+  });
+});

--- a/apps/site/src/site.tsx
+++ b/apps/site/src/site.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState, type ReactNode } from "react";
 import {
   IconArrowRight,
   IconBrandApple,
+  IconBrandGithub,
   IconChevronDown,
   IconMenu2,
   IconMoon,
@@ -10,7 +11,8 @@ import {
 } from "@tabler/icons-react";
 import { Home } from "./home";
 
-const site = {
+export const site = {
+  githubUrl: "https://github.com/DakiaMail/dakia-desktop",
   redditUrl: "https://www.reddit.com/r/Dakia/",
   supportEmail: "support@dakiamail.com",
   legalEmail: "support@dakiamail.com",
@@ -20,6 +22,22 @@ const site = {
     intel: "https://downloads.dakiamail.com/macos/latest/Dakia-Intel.dmg",
   },
 };
+
+export const headerNavigation = [
+  ["Features", "/#features"],
+  ["Privacy", "/privacy"],
+  ["Pricing", "/pricing"],
+  ["Security", "/security"],
+  ["Support", "/support"],
+  ["About", "/about"],
+  ["GitHub", site.githubUrl],
+] as const;
+
+export const footerCompanyLinks = [
+  ["About", "/about"],
+  ["GitHub", site.githubUrl],
+  ["Reddit", site.redditUrl],
+] as const;
 
 type Theme = "light" | "dark";
 
@@ -174,14 +192,6 @@ function Header({
       document.body.style.overflow = previous;
     };
   }, [open]);
-  const navigation = [
-    ["Features", "/#features"],
-    ["Privacy", "/privacy"],
-    ["Pricing", "/pricing"],
-    ["Security", "/security"],
-    ["Support", "/support"],
-    ["About", "/about"],
-  ];
   return (
     <>
       <header className="site-header">
@@ -191,9 +201,10 @@ function Header({
             className={open ? "nav-links open" : "nav-links"}
             aria-label="Main navigation"
           >
-            {navigation.map(([label, path]) => {
-              const active =
-                path === "/#features"
+            {headerNavigation.map(([label, path]) => {
+              const active = path.startsWith("https:")
+                ? false
+                : path === "/#features"
                   ? location === "/#features"
                   : location.split("#", 1)[0] === path;
               return (
@@ -203,7 +214,13 @@ function Header({
                   aria-current={active ? "page" : undefined}
                   key={path}
                 >
-                  {label}
+                  {label === "GitHub" ? (
+                    <>
+                      <IconBrandGithub size={16} /> {label}
+                    </>
+                  ) : (
+                    label
+                  )}
                 </AppLink>
               );
             })}
@@ -253,8 +270,8 @@ function Footer() {
         <div className="footer-lead">
           <Brand />
           <p>
-            A powerful multi-account email control center that keeps your mail
-            local.
+            A free, open-source multi-account email control center that keeps
+            your mail local.
           </p>
         </div>
         <FooterGroup
@@ -266,13 +283,7 @@ function Footer() {
             ["Support", "/support"],
           ]}
         />
-        <FooterGroup
-          title="Company"
-          links={[
-            ["About", "/about"],
-            ["Reddit", site.redditUrl],
-          ]}
-        />
+        <FooterGroup title="Company" links={footerCompanyLinks} />
         <FooterGroup
           title="Legal"
           links={[
@@ -288,7 +299,13 @@ function Footer() {
   );
 }
 
-function FooterGroup({ title, links }: { title: string; links: string[][] }) {
+function FooterGroup({
+  title,
+  links,
+}: {
+  title: string;
+  links: ReadonlyArray<readonly [string, string]>;
+}) {
   return (
     <div className="footer-group">
       <h2>{title}</h2>
@@ -316,12 +333,13 @@ const standardPages: Record<
     kicker: "About Dakia",
     title: "A postman for every part of your digital life.",
     intro:
-      "Dakia takes its name from the Urdu word for postman. It is built for people whose email life no longer fits neatly into one account—or one browser tab.",
+      "Dakia takes its name from the Urdu word for postman. It is an open-source mail client for people whose email life no longer fits neatly into one account—or one browser tab.",
     highlights: [
       ["Focus", "One personal command center"],
       ["Privacy", "Mail stays on your computer"],
-      ["Availability", "macOS first"],
+      ["Source", "Open on GitHub"],
     ],
+    action: { label: "View source on GitHub", href: site.githubUrl },
     sections: [
       [
         "Why Dakia exists",
@@ -329,7 +347,7 @@ const standardPages: Record<
           Modern email clients often ask people to choose between good design,
           privacy, and a fair price. Dakia is an attempt to remove that
           trade-off: a fast, thoughtful desktop client that keeps your mail
-          local and is free to use.
+          local, is free to use, and develops in public.
         </p>,
       ],
       [
@@ -339,6 +357,15 @@ const standardPages: Record<
           independent-project inboxes. It is not being built as a team
           collaboration suite. The focus is a superb personal command center for
           email.
+        </p>,
+      ],
+      [
+        "Built in the open",
+        <p key="open-source">
+          The source code, issue tracker, and contribution guide are public on{" "}
+          <a href={site.githubUrl}>GitHub</a>. You can inspect the
+          implementation, report a bug, propose an improvement, or build Dakia
+          yourself.
         </p>,
       ],
       [
@@ -724,8 +751,8 @@ function PageRouter() {
     document.title = `${labels[path] ?? "Dakia"} | Dakia`;
     const description =
       path === "/"
-        ? "A free, local-first multi-account email client for macOS. Your mail and credentials stay on your computer."
-        : "Dakia is the free, local-first multi-account email client for macOS.";
+        ? "A free, open-source, local-first multi-account email client for macOS. Your mail and credentials stay on your computer."
+        : "Dakia is the free, open-source, local-first multi-account email client for macOS.";
     document
       .querySelector('meta[name="description"]')
       ?.setAttribute("content", description);


### PR DESCRIPTION
## Summary
- add the public GitHub repository to the header and footer
- update homepage, About, footer, CTA, and metadata copy to present Dakia as open source
- add regression coverage for repository links and open-source messaging

## Verification
- 154 frontend tests passed
- site TypeScript and production Vite build passed
- explicit Prettier check passed