### PR TITLE
Allow verified legacy updater baselines

### DIFF
--- a/scripts/run-local-updater-acceptance.sh
+++ b/scripts/run-local-updater-acceptance.sh
@@ -32,6 +32,19 @@ case "$(uname -m)" in
   *) echo "Unsupported Mac architecture: $(uname -m)" >&2; exit 1 ;;
 esac
 
+version_is_before() {
+  local candidate="$1"
+  local boundary="$2"
+  local candidate_major candidate_minor candidate_patch
+  local boundary_major boundary_minor boundary_patch
+  IFS=. read -r candidate_major candidate_minor candidate_patch <<<"$candidate"
+  IFS=. read -r boundary_major boundary_minor boundary_patch <<<"$boundary"
+  ((candidate_major < boundary_major)) ||
+    ((candidate_major == boundary_major && candidate_minor < boundary_minor)) ||
+    ((candidate_major == boundary_major && candidate_minor == boundary_minor &&
+      candidate_patch < boundary_patch))
+}
+
 result_dir="$evidence_root/$arch/$mode"
 if [[ -e "$result_dir/result.json" ]]; then
   echo "Refusing to overwrite existing acceptance evidence: $result_dir/result.json" >&2
@@ -51,7 +64,13 @@ if [[ "${DAKIA_SKIP_FIXTURE_PUBLISH:-0}" != "1" ]]; then
     "$target_tag" "$mode" "$target_assets"
 fi
 
-"$root_dir/scripts/verify-macos-release-dmg.sh" "$baseline_dmg"
+baseline_version="${baseline_tag#v}"
+if version_is_before "$baseline_version" "0.2.9"; then
+  DAKIA_RELEASE_NOTICE_POLICY=legacy-pre-0.2.9 \
+    "$root_dir/scripts/verify-macos-release-dmg.sh" "$baseline_dmg"
+else
+  "$root_dir/scripts/verify-macos-release-dmg.sh" "$baseline_dmg"
+fi
 work_dir="$(mktemp -d "${TMPDIR:-/tmp}/dakia-updater-acceptance.XXXXXX")"
 work_dir="$(cd "$work_dir" && pwd -P)"
 mount_point=""
@@ -89,7 +108,6 @@ evidence="$work_dir/evidence.jsonl"
 output="$work_dir/app.log"
 profile_before="$work_dir/profile-before.txt"
 profile_after="$work_dir/profile-after.txt"
-baseline_version="${baseline_tag#v}"
 target_version="${target_tag#v}"
 
 actual_baseline="$(/usr/libexec/PlistBuddy -c \

--- a/scripts/verify-macos-release-app.sh
+++ b/scripts/verify-macos-release-app.sh
@@ -10,6 +10,15 @@ fi
 
 executable="$app/Contents/MacOS/dakia-desktop"
 runtime="$app/Contents/Frameworks/libonnxruntime.1.23.2.dylib"
+notice_policy=${DAKIA_RELEASE_NOTICE_POLICY:-current}
+
+case "$notice_policy" in
+  current|legacy-pre-0.2.9) ;;
+  *)
+    echo "Unsupported release notice policy: $notice_policy" >&2
+    exit 2
+    ;;
+esac
 
 require_sha256() {
   expected=$1
@@ -23,12 +32,6 @@ require_sha256() {
 
 for packaged_resource in \
   "$runtime" \
-  "$app/Contents/Resources/THIRD_PARTY_NOTICES.md" \
-  "$app/Contents/Resources/licenses/Apache-2.0.txt" \
-  "$app/Contents/Resources/licenses/MPL-2.0.txt" \
-  "$app/Contents/Resources/licenses/mmBERT-small-MIT-NOTICE.txt" \
-  "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-LICENSE.txt" \
-  "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-ThirdPartyNotices.txt" \
   "$app/Contents/Resources/resources/email-classifier-v2/MANIFEST.json" \
   "$app/Contents/Resources/resources/email-classifier-v2/model.onnx" \
   "$app/Contents/Resources/resources/email-classifier-v2/tokenizer.json"; do
@@ -37,30 +40,45 @@ for packaged_resource in \
     exit 1
   fi
 done
-require_sha256 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30 \
-  "$app/Contents/Resources/licenses/Apache-2.0.txt"
-require_sha256 3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04 \
-  "$app/Contents/Resources/licenses/MPL-2.0.txt"
-require_sha256 37bd7f5f301ccab826b60d0f225137e228505d3d3e0fb68bd33a8cdb33883e62 \
-  "$app/Contents/Resources/licenses/mmBERT-small-MIT-NOTICE.txt"
-require_sha256 2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c \
-  "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-LICENSE.txt"
-require_sha256 e9e90971a8e75a9a8ac0c6412e29c1202d079998389915aa485f46c816c3b4cc \
-  "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-ThirdPartyNotices.txt"
 if [ ! -x "$executable" ]; then
   echo "Missing packaged Dakia executable: $executable" >&2
   exit 1
 fi
-if ! grep -Fq "72de7110305b5e1d98d26aa0578482a230739c0c" \
-  "$app/Contents/Resources/THIRD_PARTY_NOTICES.md" ||
-  ! grep -Fq "jhu-clsp/mmBERT-small" \
+
+if [ "$notice_policy" = "current" ]; then
+  for packaged_resource in \
+    "$app/Contents/Resources/THIRD_PARTY_NOTICES.md" \
+    "$app/Contents/Resources/licenses/Apache-2.0.txt" \
+    "$app/Contents/Resources/licenses/MPL-2.0.txt" \
+    "$app/Contents/Resources/licenses/mmBERT-small-MIT-NOTICE.txt" \
+    "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-LICENSE.txt" \
+    "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-ThirdPartyNotices.txt"; do
+    if [ ! -s "$packaged_resource" ]; then
+      echo "Missing packaged release resource: $packaged_resource" >&2
+      exit 1
+    fi
+  done
+  require_sha256 cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30 \
+    "$app/Contents/Resources/licenses/Apache-2.0.txt"
+  require_sha256 3f3d9e0024b1921b067d6f7f88deb4a60cbe7a78e76c64e3f1d7fc3b779b9d04 \
+    "$app/Contents/Resources/licenses/MPL-2.0.txt"
+  require_sha256 37bd7f5f301ccab826b60d0f225137e228505d3d3e0fb68bd33a8cdb33883e62 \
+    "$app/Contents/Resources/licenses/mmBERT-small-MIT-NOTICE.txt"
+  require_sha256 2f07c72751aed99790b8a4869cf2311df85a860b22ded05fa22803587a48922c \
+    "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-LICENSE.txt"
+  require_sha256 e9e90971a8e75a9a8ac0c6412e29c1202d079998389915aa485f46c816c3b4cc \
+    "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-ThirdPartyNotices.txt"
+  if ! grep -Fq "72de7110305b5e1d98d26aa0578482a230739c0c" \
     "$app/Contents/Resources/THIRD_PARTY_NOTICES.md" ||
-  ! grep -Fq "ONNX Runtime 1.23.2" \
-    "$app/Contents/Resources/THIRD_PARTY_NOTICES.md" ||
-  ! grep -Fq "THIRD PARTY SOFTWARE NOTICES AND INFORMATION" \
-    "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-ThirdPartyNotices.txt"; then
-  echo "Packaged third-party notices are incomplete." >&2
-  exit 1
+    ! grep -Fq "jhu-clsp/mmBERT-small" \
+      "$app/Contents/Resources/THIRD_PARTY_NOTICES.md" ||
+    ! grep -Fq "ONNX Runtime 1.23.2" \
+      "$app/Contents/Resources/THIRD_PARTY_NOTICES.md" ||
+    ! grep -Fq "THIRD PARTY SOFTWARE NOTICES AND INFORMATION" \
+      "$app/Contents/Resources/licenses/ONNX-Runtime-1.23.2-ThirdPartyNotices.txt"; then
+    echo "Packaged third-party notices are incomplete." >&2
+    exit 1
+  fi
 fi
 
 smoke_root=$(mktemp -d "${TMPDIR:-/tmp}/dakia-release-smoke.XXXXXX")


### PR DESCRIPTION
## Summary
- keep full packaged-notice verification mandatory for v0.2.9 and newer artifacts
- permit only pre-v0.2.9 updater baselines to use their historically valid resource set during upgrade acceptance
- preserve code-signing, notarization, Gatekeeper, classifier, ONNX, and native startup checks for legacy baselines

## Verification
- v0.2.8 notarized baseline passes only with the version-bounded legacy policy
- the same baseline fails the default current policy because notices are absent
- v0.2.9 notarized artifact passes the full current policy
- shell syntax and diff checks pass