### PR TITLE
Add Seen smart section and prevent stale starred counts

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -206,6 +206,7 @@ describe("App read state", () => {
       conversations: groupMessages([mocks.message]),
       nextCursor: null,
     });
+    mocks.api.starredCount.mockResolvedValue(0);
     mocks.api.content.mockResolvedValue({
       body_text: "Message body",
       attachments: [],
@@ -471,7 +472,7 @@ describe("App read state", () => {
       </MantineProvider>,
     );
 
-    await waitFor(() => expect(mocks.api.search).toHaveBeenCalledTimes(6));
+    await waitFor(() => expect(mocks.api.search).toHaveBeenCalledTimes(7));
     expect(mocks.api.search).toHaveBeenCalledWith(
       "",
       ["account-1", "account-2"],
@@ -482,6 +483,7 @@ describe("App read state", () => {
       null,
       "people",
       true,
+      false,
     );
     expect(mocks.api.search).toHaveBeenCalledWith(
       "",
@@ -493,7 +495,58 @@ describe("App read state", () => {
       null,
       undefined,
       false,
+      false,
     );
+  });
+
+  it("ignores an older all-account starred count after selecting one account", async () => {
+    const secondAccount = {
+      ...mocks.account,
+      id: "account-2",
+      email: "other@example.com",
+      account_name: "Other",
+    };
+    let resolveAllAccounts: (count: number) => void = () => undefined;
+    let resolveSelectedAccount: (count: number) => void = () => undefined;
+    mocks.api.accounts.mockResolvedValueOnce([mocks.account, secondAccount]);
+    mocks.api.starredCount.mockImplementation((...args: unknown[]) => {
+      const accountIds = args[0] as string[];
+      if (accountIds.length === 0) return Promise.resolve(0);
+      return new Promise<number>((resolve) => {
+        if (accountIds.length === 2) resolveAllAccounts = resolve;
+        else resolveSelectedAccount = resolve;
+      });
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mocks.api.starredCount).toHaveBeenCalledWith([
+        "account-1",
+        "account-2",
+      ]),
+    );
+    fireEvent.click(await screen.findByTitle("me@example.com"));
+    await waitFor(() =>
+      expect(mocks.api.starredCount).toHaveBeenCalledWith(["account-1"]),
+    );
+
+    await act(async () => resolveSelectedAccount(7));
+    expect(
+      await screen.findByLabelText("7 starred conversations"),
+    ).toHaveTextContent("7");
+
+    await act(async () => resolveAllAccounts(40));
+    expect(screen.getByLabelText("7 starred conversations")).toHaveTextContent(
+      "7",
+    );
+    expect(
+      screen.queryByLabelText("40 starred conversations"),
+    ).not.toBeInTheDocument();
   });
 
   it("keeps successful Smart sections visible when one category fails", async () => {
@@ -612,6 +665,7 @@ describe("App read state", () => {
       firstCursor,
       "people",
       true,
+      false,
     );
 
     fireEvent.click(screen.getByRole("button", { name: "Show more" }));
@@ -703,6 +757,7 @@ describe("App read state", () => {
       null,
       undefined,
       false,
+      false,
     );
 
     fireEvent.click(row.closest("button")!);
@@ -716,13 +771,28 @@ describe("App read state", () => {
     ).toBeVisible();
   });
 
-  it("removes an opened Smart thread as soon as it becomes read", async () => {
+  it("keeps an opened Smart thread until another opens, then animates it out", async () => {
     localStorage.setItem("dakia.mail-list-view", "smart");
     mocks.api.classifyPending.mockImplementationOnce(
       () => new Promise(() => undefined),
     );
     let peopleSearches = 0;
+    const nextMessage = {
+      ...mocks.message,
+      id: "message-2",
+      uid: 2,
+      thread_id: "thread-2",
+      subject: "Next unread thread",
+      received_at: "2026-07-19T09:00:00Z",
+      is_flagged: true,
+    };
     mocks.api.search.mockImplementation(async (...args: unknown[]) => {
+      if (args[4]) {
+        return {
+          conversations: groupMessages([nextMessage]),
+          nextCursor: null,
+        };
+      }
       if (args[7] !== "people") return { conversations: [], nextCursor: null };
       peopleSearches += 1;
       return {
@@ -745,21 +815,21 @@ describe("App read state", () => {
       expect(mocks.api.setRead).toHaveBeenCalledWith("message-1", true),
     );
     expect(
-      within(document.querySelector(".mail-list-panel")!).queryByText(
+      within(document.querySelector(".mail-list-panel")!).getByText(
         "Unread thread",
       ),
-    ).not.toBeInTheDocument();
-    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
-    expect(mocks.openComposeWindow).toHaveBeenCalledWith(
-      expect.objectContaining({
-        accountId: "account-1",
-        to: "sender@example.com",
-        subject: "Re: Unread thread",
-      }),
-    );
-    fireEvent.click(screen.getByRole("button", { name: "Mark as unread" }));
+    ).toBeVisible();
+
+    fireEvent.click(screen.getByText("Next unread thread").closest("button")!);
+    expect(
+      screen.getByText("Unread thread").closest(".mail-item"),
+    ).toHaveAttribute("data-smart-exiting", "true");
     await waitFor(() =>
-      expect(mocks.api.setRead).toHaveBeenCalledWith("message-1", false),
+      expect(
+        within(document.querySelector(".mail-list-panel")!).queryByText(
+          "Unread thread",
+        ),
+      ).not.toBeInTheDocument(),
     );
   });
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -90,6 +90,7 @@ const smartSectionIds: SmartSectionId[] = [
   "notifications",
   "newsletters",
   "other",
+  "seen",
 ];
 type MailViewRequest = {
   accountIds: string[];
@@ -159,6 +160,12 @@ export default function App() {
   const [pendingActions, setPendingActions] = useState<PendingMailActions>({});
   const [outbox, setOutbox] = useState<MailSummary[]>([]);
   const [starredCount, setStarredCount] = useState(0);
+  const [exitingSmartThreadIds, setExitingSmartThreadIds] = useState(
+    new Set<string>(),
+  );
+  const [retainedSmartThreads, setRetainedSmartThreads] = useState(
+    new Map<string, { sectionId: SmartSectionId; thread: MailThread }>(),
+  );
   const [actionStatus, setActionStatus] = useState<{
     id: number;
     message: string;
@@ -170,6 +177,7 @@ export default function App() {
   const actionBusyRef = useRef(false);
   const loadRequestIdRef = useRef(0);
   const smartLoadRequestIdRef = useRef(0);
+  const starredCountRequestIdRef = useRef(0);
   const nextCursorRef = useRef<MailCursor | null>(null);
   const loadingMoreRef = useRef(false);
   const smartLoadingMoreRef = useRef(new Set<SmartSectionId>());
@@ -177,6 +185,7 @@ export default function App() {
   const classifyingRef = useRef(false);
   const classificationRequestedRef = useRef(false);
   const manualUpdateCheckInFlightRef = useRef(false);
+  const smartExitTimersRef = useRef(new Map<string, number>());
   const accountsRef = useRef<Account[]>([]);
   const selectedAccountIdRef = useRef<string | undefined>(undefined);
   const removedAccountIdsRef = useRef(new Set<string>());
@@ -184,6 +193,13 @@ export default function App() {
 
   accountsRef.current = accounts;
   selectedAccountIdRef.current = selectedAccountId;
+
+  useEffect(
+    () => () => {
+      smartExitTimersRef.current.forEach((timer) => window.clearTimeout(timer));
+    },
+    [],
+  );
 
   const showStatus = useCallback(
     (message: string, tone: "success" | "error" = "success") => {
@@ -341,8 +357,12 @@ export default function App() {
     view: mailListView,
   };
   const refreshStarredCount = useCallback(async (accountIds: string[]) => {
+    const requestId = ++starredCountRequestIdRef.current;
     try {
-      setStarredCount(await api.starredCount(accountIds));
+      const count = await api.starredCount(accountIds);
+      if (requestId === starredCountRequestIdRef.current) {
+        setStarredCount(count);
+      }
     } catch {
       // The message list remains usable if a count refresh fails offline.
     }
@@ -393,16 +413,18 @@ export default function App() {
       if (smartInbox) {
         const pageResults = await Promise.allSettled(
           smartSectionIds.map(async (id) => {
+            const category = !["starred", "seen"].includes(id) ? id : undefined;
             const page = await api.search(
               "",
               accountIds,
               "INBOX",
-              id !== "starred",
+              !["starred", "seen"].includes(id),
               id === "starred",
               smartPageSize,
               null,
-              id === "starred" ? undefined : id,
-              id !== "starred",
+              category,
+              !["starred", "seen"].includes(id),
+              id === "seen",
             );
             return [id, page] as const;
           }),
@@ -658,12 +680,13 @@ export default function App() {
           "",
           currentView.accountIds,
           "INBOX",
-          id !== "starred",
+          !["starred", "seen"].includes(id),
           id === "starred",
           smartMorePageSize,
           section.nextCursor,
-          id === "starred" ? undefined : id,
-          id !== "starred",
+          !["starred", "seen"].includes(id) ? id : undefined,
+          !["starred", "seen"].includes(id),
+          id === "seen",
         );
         if (
           requestId !== smartLoadRequestIdRef.current ||
@@ -1160,7 +1183,6 @@ export default function App() {
           ]),
         ) as Record<SmartSectionId, SmartSection>,
     );
-
     const results = await resultsPromise;
     const failedThreadIds = new Set(
       actionThreads
@@ -1422,14 +1444,29 @@ export default function App() {
               {
                 ...current[id],
                 threads:
-                  read && id !== "starred"
-                    ? sectionThreads.filter((item) => item.unread)
-                    : sectionThreads,
+                  read && !["starred", "seen"].includes(id)
+                    ? sectionThreads.filter(
+                        (item) => item.unread || item.id === thread.id,
+                      )
+                    : !read && id === "seen"
+                      ? sectionThreads.filter((item) => item.unread)
+                      : sectionThreads,
               },
             ];
           }),
         ) as Record<SmartSectionId, SmartSection>,
     );
+    setRetainedSmartThreads((current) => {
+      const next = new Map(current);
+      const retained = next.get(thread.id);
+      if (retained) {
+        next.set(thread.id, {
+          ...retained,
+          thread: updateThreadReadState(retained.thread, ids, read),
+        });
+      }
+      return next;
+    });
     setActive((current) =>
       current ? updateMessageReadState(current, ids, read) : current,
     );
@@ -1776,7 +1813,20 @@ export default function App() {
         mailboxTitle={mailboxTitle}
         view={mailListView}
         smartInbox={smartInboxActive}
-        smartSections={smartSectionIds.map((id) => smartSections[id])}
+        smartSections={smartSectionIds.map((id) => {
+          const section = smartSections[id];
+          const retained = [...retainedSmartThreads.values()]
+            .filter((item) => item.sectionId === id)
+            .map((item) => item.thread)
+            .filter(
+              (thread) =>
+                !section.threads.some((item) => item.id === thread.id),
+            );
+          return retained.length
+            ? { ...section, threads: mergeThreads(section.threads, retained) }
+            : section;
+        })}
+        exitingThreadIds={exitingSmartThreadIds}
         onViewChange={changeMailListView}
         onCategorize={(message, category) => {
           void api
@@ -1818,6 +1868,64 @@ export default function App() {
         onToggleStar={(message, starred) => void toggleStar(message, starred)}
         onQuery={setQuery}
         onOpen={(thread) => {
+          const previousThread = activeThread;
+          if (smartInboxActive) {
+            const sectionId = smartSectionIds.find((id) =>
+              smartSections[id].threads.some((item) => item.id === thread.id),
+            );
+            if (sectionId && !["starred", "seen"].includes(sectionId)) {
+              setRetainedSmartThreads((current) => {
+                const next = new Map(current);
+                next.set(thread.id, { sectionId, thread });
+                return next;
+              });
+            }
+          }
+          if (
+            smartInboxActive &&
+            previousThread &&
+            previousThread.id !== thread.id &&
+            !previousThread.unread
+          ) {
+            const previousId = previousThread.id;
+            setExitingSmartThreadIds((current) =>
+              new Set(current).add(previousId),
+            );
+            const existingTimer = smartExitTimersRef.current.get(previousId);
+            if (existingTimer) window.clearTimeout(existingTimer);
+            smartExitTimersRef.current.set(
+              previousId,
+              window.setTimeout(() => {
+                setSmartSections(
+                  (current) =>
+                    Object.fromEntries(
+                      smartSectionIds.map((id) => [
+                        id,
+                        {
+                          ...current[id],
+                          threads: ["starred", "seen"].includes(id)
+                            ? current[id].threads
+                            : current[id].threads.filter(
+                                (item) => item.id !== previousId,
+                              ),
+                        },
+                      ]),
+                    ) as Record<SmartSectionId, SmartSection>,
+                );
+                setExitingSmartThreadIds((current) => {
+                  const next = new Set(current);
+                  next.delete(previousId);
+                  return next;
+                });
+                setRetainedSmartThreads((current) => {
+                  const next = new Map(current);
+                  next.delete(previousId);
+                  return next;
+                });
+                smartExitTimersRef.current.delete(previousId);
+              }, 180),
+            );
+          }
           setActive(thread.latest);
           setActiveThreadSnapshot(thread);
           setAiResult(undefined);

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -51,6 +51,7 @@ const desktopApi = {
     cursor?: MailCursor | null,
     category?: string,
     unflaggedOnly = false,
+    readOnly = false,
   ) =>
     invoke<MailThreadPage>("search", {
       query: {
@@ -59,6 +60,7 @@ const desktopApi = {
         mailbox,
         from: null,
         unread_only: unreadOnly,
+        read_only: readOnly,
         flagged_only: flaggedOnly,
         category,
         unflagged_only: unflaggedOnly,
@@ -403,6 +405,7 @@ const demoApi: typeof desktopApi = {
     _cursor,
     category,
     unflaggedOnly,
+    readOnly,
   ) => {
     const allowedAccounts = new Set(accountIds);
     const matches = demoMessages.filter(
@@ -410,6 +413,7 @@ const demoApi: typeof desktopApi = {
         (!allowedAccounts.size || allowedAccounts.has(message.account_id)) &&
         (!mailbox || mailboxFamily(message.mailbox) === mailbox) &&
         (!unreadOnly || !message.is_read) &&
+        (!readOnly || message.is_read) &&
         (!flaggedOnly || message.is_flagged) &&
         (!unflaggedOnly || !message.is_flagged) &&
         (!category || message.category === category) &&

--- a/apps/desktop/src/components/MailList.test.tsx
+++ b/apps/desktop/src/components/MailList.test.tsx
@@ -1,5 +1,5 @@
 import { MantineProvider } from "@mantine/core";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import "../i18n";
 import type { PendingMailActions } from "../mailActions";
@@ -251,7 +251,7 @@ describe("MailList action feedback", () => {
     expect(onSelect).toHaveBeenCalledWith(["account:1"], true);
   });
 
-  it("renders explicit unread smart sections without a seen bucket", () => {
+  it("renders Seen last and loads its next page near the scroll end", () => {
     const smartMessages: MailSummary[] = [
       ...["1", "2", "3", "4"].map((id) => ({
         ...messages[0],
@@ -292,6 +292,12 @@ describe("MailList action feedback", () => {
         id: "people",
         threads: groupMessages(smartMessages.slice(0, 4)),
         nextCursor: { received_at: "2026-07-19T09:00:00Z", id: "people-4" },
+        loadingMore: false,
+      },
+      {
+        id: "seen",
+        threads: groupMessages([smartMessages[4]]),
+        nextCursor: { received_at: "2026-07-19T08:00:00Z", id: "seen" },
         loadingMore: false,
       },
     ];
@@ -340,18 +346,26 @@ describe("MailList action feedback", () => {
     expect(screen.getByRole("region", { name: "Starred" })).toHaveTextContent(
       "Starred message",
     );
-    expect(
-      screen.queryByRole("region", { name: "Seen" }),
-    ).not.toBeInTheDocument();
-    expect(screen.queryByText("Seen message")).not.toBeInTheDocument();
+    const seen = screen.getByRole("region", { name: "Seen" });
+    expect(seen).toHaveTextContent("Seen message");
+    const regions = screen.getAllByRole("region");
+    expect(regions.at(-1)).toBe(seen);
     const people = screen.getByRole("region", { name: "People" });
     expect(people.querySelectorAll(".mail-item")).toHaveLength(4);
     expect(
       screen.queryByRole("button", { name: "More actions" }),
     ).not.toBeInTheDocument();
     expect(screen.getAllByText("Starred message")).toHaveLength(1);
-    fireEvent.click(screen.getByRole("button", { name: "Show more" }));
+    fireEvent.click(within(people).getByRole("button", { name: "Show more" }));
     expect(onLoadMoreSmart).toHaveBeenCalledWith("people");
+    const scroller = document.querySelector(".mail-scroll") as HTMLDivElement;
+    Object.defineProperties(scroller, {
+      scrollHeight: { configurable: true, value: 2_000 },
+      scrollTop: { configurable: true, value: 1_300 },
+      clientHeight: { configurable: true, value: 500 },
+    });
+    fireEvent.scroll(scroller);
+    expect(onLoadMoreSmart).toHaveBeenCalledWith("seen");
   });
 
   it("does not retain an active read thread in Smart", () => {

--- a/apps/desktop/src/components/MailList.tsx
+++ b/apps/desktop/src/components/MailList.tsx
@@ -67,6 +67,7 @@ type Props = {
   onToggleStar: (message: MailSummary, starred: boolean) => void;
   smartInbox: boolean;
   smartSections?: SmartSection[];
+  exitingThreadIds?: Set<string>;
   onQuery: (value: string) => void;
   onOpen: (thread: MailThread) => void;
   onSelect: (ids: string[], checked: boolean) => void;
@@ -110,6 +111,7 @@ export function MailList({
   onToggleStar,
   smartInbox,
   smartSections = [],
+  exitingThreadIds = new Set(),
   onQuery,
   onOpen,
   onSelect,
@@ -141,15 +143,26 @@ export function MailList({
     (event: UIEvent<HTMLDivElement>) => {
       const element = event.currentTarget;
       if (
-        !(view === "smart" && smartInbox) &&
-        hasMore &&
-        !loadingMore &&
-        element.scrollHeight - element.scrollTop - element.clientHeight < 800
+        element.scrollHeight - element.scrollTop - element.clientHeight <
+        800
       ) {
-        onLoadMore();
+        if (view === "smart" && smartInbox) {
+          const seen = smartSections.find((section) => section.id === "seen");
+          if (seen?.nextCursor && !seen.loadingMore) onLoadMoreSmart?.("seen");
+        } else if (hasMore && !loadingMore) {
+          onLoadMore();
+        }
       }
     },
-    [hasMore, loadingMore, onLoadMore, smartInbox, view],
+    [
+      hasMore,
+      loadingMore,
+      onLoadMore,
+      onLoadMoreSmart,
+      smartInbox,
+      smartSections,
+      view,
+    ],
   );
   return (
     <section className="mail-list-panel" aria-label={mailboxTitle}>
@@ -286,6 +299,7 @@ export function MailList({
         {view === "smart" && smartInbox ? (
           <SmartThreadSections
             sections={smartSections}
+            exitingThreadIds={exitingThreadIds}
             activeThreadId={activeThreadId}
             selected={selected}
             pendingActions={pendingActions}
@@ -303,6 +317,7 @@ export function MailList({
         ) : (
           <ThreadRows
             threads={threads}
+            exitingThreadIds={exitingThreadIds}
             activeThreadId={activeThreadId}
             selected={selected}
             pendingActions={pendingActions}
@@ -349,6 +364,7 @@ type RowsProps = Pick<
   | "onActionThread"
   | "onToggleReadThread"
   | "onToggleStarThread"
+  | "exitingThreadIds"
 > & { threads: MailThread[] };
 
 function SmartThreadSections(
@@ -365,6 +381,7 @@ function SmartThreadSections(
     notifications: "inbox.categoryNotifications",
     newsletters: "inbox.categoryNewsletters",
     other: "inbox.categoryOther",
+    seen: "inbox.seen",
   };
   return props.sections.map(({ id, threads, nextCursor, loadingMore }) => {
     if (!threads.length) return null;
@@ -402,6 +419,7 @@ function ThreadRows({
   onActionThread,
   onToggleReadThread,
   onToggleStarThread,
+  exitingThreadIds = new Set(),
 }: RowsProps) {
   const { t } = useTranslation();
   const [context, setContext] = useState<{
@@ -565,6 +583,7 @@ function ThreadRows({
             className="mail-item"
             data-active={activeThreadId === thread.id}
             data-unread={thread.unread}
+            data-smart-exiting={exitingThreadIds.has(thread.id)}
             data-action-phase={pending?.phase}
             data-action-kind={pending?.action}
             style={

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -707,6 +707,20 @@ textarea {
 .mail-item[data-unread="true"] .mail-subject {
   font-weight: 670;
 }
+.mail-item[data-smart-exiting="true"] {
+  pointer-events: none;
+  animation: smart-thread-exit 180ms ease-in forwards;
+}
+@keyframes smart-thread-exit {
+  to {
+    opacity: 0;
+    transform: translateX(-10px);
+    max-height: 0;
+    min-height: 0;
+    padding-block: 0;
+    border-width: 0;
+  }
+}
 .mail-check {
   padding-top: 2px;
 }

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -82,7 +82,7 @@ export type MailThreadPage = {
   conversations: MailThread[];
   nextCursor: MailCursor | null;
 };
-export type SmartSectionId = "starred" | MailCategory;
+export type SmartSectionId = "starred" | MailCategory | "seen";
 export type SmartSection = {
   id: SmartSectionId;
   threads: MailThread[];

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -184,6 +184,10 @@ pub struct SearchQuery {
     pub mailbox: Option<String>,
     pub from: Option<String>,
     pub unread_only: bool,
+    /// Include only conversations whose messages in the requested mailbox
+    /// scope have all been read.
+    #[serde(default)]
+    pub read_only: bool,
     pub flagged_only: bool,
     /// Exclude every conversation containing a flagged message. This is kept
     /// separate from `flagged_only` because Smart category views use it to
@@ -1793,6 +1797,9 @@ impl Store {
         if query.unread_only {
             sql.push_str(" AND m.is_read = 0");
         }
+        if query.read_only {
+            sql.push_str(" AND m.is_read = 1");
+        }
         if query.flagged_only {
             sql.push_str(" AND m.is_flagged = 1");
         }
@@ -2030,6 +2037,20 @@ impl Store {
             }
             sql.push(')');
         }
+        // A seen conversation has no unread member in the mailbox scope.
+        if query.read_only {
+            sql.push_str(" AND NOT EXISTS (SELECT 1 FROM messages unread WHERE unread.account_id = matching.account_id AND unread.thread_id = matching.thread_id AND unread.is_read = 0");
+            if let Some(mailbox) = query.mailbox.as_deref() {
+                if is_special_mailbox_family(mailbox) {
+                    sql.push_str(" AND (unread.mailbox = ? OR unread.mailbox LIKE ?)");
+                } else {
+                    sql.push_str(" AND unread.mailbox = ?");
+                }
+            } else {
+                sql.push_str(" AND unread.mailbox NOT IN ('Spam', 'Trash') AND unread.mailbox NOT LIKE 'Spam::%' AND unread.mailbox NOT LIKE 'Trash::%'");
+            }
+            sql.push(')');
+        }
         if query.cursor.is_some() {
             sql.push_str(" AND (received_at < ? OR (received_at = ? AND id < ?))");
         }
@@ -2054,7 +2075,7 @@ impl Store {
         if let Some(category) = &query.category {
             statement = statement.bind(category);
         }
-        if query.unread_only {
+        if query.unread_only || query.read_only {
             if let Some(mailbox) = query.mailbox.as_deref() {
                 statement = statement.bind(mailbox);
                 if is_special_mailbox_family(mailbox) {
@@ -3810,6 +3831,65 @@ mod tests {
             .unwrap();
         assert_eq!(updated.len(), 1);
         assert_eq!(updated[0].message_count, 3);
+    }
+
+    #[tokio::test]
+    async fn seen_conversations_require_every_scoped_message_to_be_read() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+
+        let mut seen = message("Seen", "Read inbox message");
+        seen.id = "seen-inbox".into();
+        seen.account_id = account_id.to_string();
+        seen.thread_id = "seen-thread".into();
+        seen.is_read = true;
+
+        let mut sent_unread = message("Re: Seen", "Unread sent copy");
+        sent_unread.id = "seen-sent".into();
+        sent_unread.account_id = account_id.to_string();
+        sent_unread.thread_id = seen.thread_id.clone();
+        sent_unread.mailbox = "Sent".into();
+        sent_unread.uid = 2;
+        sent_unread.is_read = false;
+
+        let mut mixed_read = message("Mixed", "Read member");
+        mixed_read.id = "mixed-read".into();
+        mixed_read.account_id = account_id.to_string();
+        mixed_read.thread_id = "mixed-thread".into();
+        mixed_read.uid = 3;
+        mixed_read.is_read = true;
+
+        let mut mixed_unread = message("Re: Mixed", "Unread member");
+        mixed_unread.id = "mixed-unread".into();
+        mixed_unread.account_id = account_id.to_string();
+        mixed_unread.thread_id = mixed_read.thread_id.clone();
+        mixed_unread.uid = 4;
+        mixed_unread.is_read = false;
+
+        store
+            .upsert_messages(&[seen, sent_unread, mixed_read, mixed_unread])
+            .await
+            .unwrap();
+
+        let page = store
+            .search_conversation_page(&SearchQuery {
+                account_ids: vec![account_id],
+                mailbox: Some("INBOX".into()),
+                read_only: true,
+                ..Default::default()
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(page.conversations.len(), 1);
+        assert!(page.conversations[0]
+            .messages
+            .iter()
+            .any(|message| message.id == "seen-inbox"));
+        assert!(page.conversations[0]
+            .messages
+            .iter()
+            .all(|message| !message.id.starts_with("mixed-")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add a Seen smart section backed by read-only conversation filtering.
- Preserve opened Smart threads until a replacement opens, then animate their removal.
- Prevent stale asynchronous starred-count responses from overwriting newer selections.
- Add coverage for Seen pagination, read-state behavior, and request ordering.

## Testing

- Added and updated React component tests for Smart sections and starred counts.
- Added Rust storage coverage ensuring Seen conversations contain no unread scoped messages.