### PR TITLE
Add beta development messaging and initialize CLI read filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Dakia is a privacy-minded desktop mail application for macOS. It combines multiple IMAP/SMTP accounts, local full-text search, downloadable offline email translation, and a scriptable CLI.
 
+> [!NOTE]
+> Dakia is still under rapid development, and bugs are expected.
+
 ## Current architecture
 
 - `crates/dakia-core` — accounts, provider discovery, SQLite/FTS search, mail transport, translation, and optional AI integrations

--- a/crates/dakia-cli/src/main.rs
+++ b/crates/dakia-cli/src/main.rs
@@ -278,6 +278,7 @@ async fn main() -> Result<()> {
                 mailbox: args.mailbox,
                 from: args.from,
                 unread_only: args.unread,
+                read_only: false,
                 flagged_only: false,
                 unflagged_only: false,
                 category: None,


### PR DESCRIPTION
## Summary

- Add a README notice that Dakia is under rapid development and may contain bugs.
- Initialize the CLI list command’s `read_only` filter explicitly.

## Testing

- Not run (not requested)