### PR TITLE
Prevent deleted Smart threads from reappearing

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -65,6 +65,7 @@ const mocks = vi.hoisted(() => {
     account,
     message,
     api: {
+      action: vi.fn(async () => undefined),
       aiAvailable: vi.fn(async () => false),
       accounts: vi.fn(async () => [account]),
       classifyPending: vi.fn(async () => 0),
@@ -200,6 +201,7 @@ describe("App read state", () => {
     mocks.accountUpdatedHandlers.length = 0;
     localStorage.clear();
     mocks.api.accounts.mockResolvedValue([mocks.account]);
+    mocks.api.action.mockResolvedValue(undefined);
     localStorage.setItem("dakia.mail-list-view", "list");
     mocks.api.classifyPending.mockResolvedValue(0);
     mocks.api.search.mockResolvedValue({
@@ -689,7 +691,7 @@ describe("App read state", () => {
     mocks.api.classifyPending.mockImplementationOnce(
       () => new Promise(() => undefined),
     );
-    mocks.api.search.mockImplementation((...args: unknown[]) => {
+    mocks.api.search.mockImplementation(async (...args: unknown[]) => {
       if (args[7] !== "people") {
         return Promise.resolve({ conversations: [], nextCursor: null });
       }
@@ -831,6 +833,75 @@ describe("App read state", () => {
         ),
       ).not.toBeInTheDocument(),
     );
+  });
+
+  it("does not reinsert a retained Smart thread after deleting it", async () => {
+    localStorage.setItem("dakia.mail-list-view", "smart");
+    mocks.api.classifyPending.mockImplementationOnce(
+      () => new Promise(() => undefined),
+    );
+    let peopleSearches = 0;
+    let resolveStalePeople:
+      | ((page: {
+          conversations: ReturnType<typeof groupMessages>;
+          nextCursor: null;
+        }) => void)
+      | undefined;
+    mocks.api.search.mockImplementation(async (...args: unknown[]) => {
+      if (args[7] !== "people") return { conversations: [], nextCursor: null };
+      peopleSearches += 1;
+      if (peopleSearches === 2) {
+        return new Promise((resolve) => {
+          resolveStalePeople = resolve;
+        });
+      }
+      return {
+        conversations:
+          peopleSearches === 1 ? groupMessages([mocks.message]) : [],
+        nextCursor: null,
+      };
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const list = document.querySelector<HTMLElement>(".mail-list-panel")!;
+    fireEvent.click(
+      (await within(list).findByText("Unread thread")).closest("button")!,
+    );
+    await waitFor(() =>
+      expect(mocks.api.setRead).toHaveBeenCalledWith("message-1", true),
+    );
+    await waitFor(() => expect(resolveStalePeople).toBeTypeOf("function"));
+    expect(within(list).getByText("Unread thread")).toBeVisible();
+
+    fireEvent.contextMenu(
+      within(list).getByText("Unread thread").closest("button")!,
+    );
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Delete", hidden: true }),
+    );
+
+    await waitFor(() =>
+      expect(within(list).queryByText("Unread thread")).not.toBeInTheDocument(),
+    );
+    expect(mocks.api.action).toHaveBeenCalledWith(
+      "account-1",
+      "INBOX",
+      1,
+      "trash",
+    );
+
+    await act(async () =>
+      resolveStalePeople!({
+        conversations: groupMessages([mocks.message]),
+        nextCursor: null,
+      }),
+    );
+    expect(within(list).queryByText("Unread thread")).not.toBeInTheDocument();
   });
 
   it("ignores an out-of-order Smart result after the view changes", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1108,8 +1108,13 @@ export default function App() {
       .filter((target) => target.messages.length > 0);
     if (!actionThreads.length || actionBusyRef.current) return;
     actionBusyRef.current = true;
+    // An open/read transition may already be refreshing Smart sections with
+    // the pre-action INBOX row. Make that result stale before moving the row.
+    loadRequestIdRef.current += 1;
+    smartLoadRequestIdRef.current += 1;
     const originalThreads = [...displayedThreads];
     const originalSmartSections = smartSections;
+    const originalRetainedSmartThreads = retainedSmartThreads;
     const actionTargets = actionThreads.flatMap((target) => target.messages);
     const targetIds = new Set(actionTargets.map((message) => message.id));
     const targetThreadIds = new Set(
@@ -1183,6 +1188,11 @@ export default function App() {
           ]),
         ) as Record<SmartSectionId, SmartSection>,
     );
+    setRetainedSmartThreads((current) => {
+      const next = new Map(current);
+      for (const id of targetThreadIds) next.delete(id);
+      return next;
+    });
     const results = await resultsPromise;
     const failedThreadIds = new Set(
       actionThreads
@@ -1228,6 +1238,14 @@ export default function App() {
             ]),
           ) as Record<SmartSectionId, SmartSection>,
       );
+      setRetainedSmartThreads((current) => {
+        const next = new Map(current);
+        for (const id of failedThreadIds) {
+          const retained = originalRetainedSmartThreads.get(id);
+          if (retained) next.set(id, retained);
+        }
+        return next;
+      });
       showStatus(
         actionOutcome(t, action, succeeded, failedThreadIds.size),
         "error",

--- a/crates/dakia-cli/src/main.rs
+++ b/crates/dakia-cli/src/main.rs
@@ -278,6 +278,7 @@ async fn main() -> Result<()> {
                 mailbox: args.mailbox,
                 from: args.from,
                 unread_only: args.unread,
+                read_only: false,
                 flagged_only: false,
                 unflagged_only: false,
                 category: None,


### PR DESCRIPTION
## Summary

- Invalidate stale Smart-section loads before message actions.
- Remove action targets from retained Smart threads and restore them on failure.
- Add regression coverage for deleted threads returning from stale results.
- Update the CLI search request to include the `read_only` field.

## Testing

- Added an App regression test covering stale Smart search results after deletion.
- Not run (not requested).