### PR TITLE
Fix collapsing of Word-generated Outlook reply history

### DIFF
--- a/apps/desktop/src/components/HtmlMessage.test.tsx
+++ b/apps/desktop/src/components/HtmlMessage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import appleMailReplySection from "../test/fixtures/apple-mail-reply-section.html?raw";
+import outlookWordReplySection from "../test/fixtures/outlook-word-reply-section.html?raw";
 import { buildEmailDocument, HtmlMessage } from "./HtmlMessage";
 
 function renderedEmailRoot(message: HTMLElement) {
@@ -261,6 +262,134 @@ describe("HTML email appearance", () => {
     expect(details?.textContent).not.toContain("Authored footer");
     expect(document.body.textContent).toContain("Authored footer");
     expect(document.body.firstElementChild?.textContent).toBe("Fresh");
+  });
+
+  it("collapses Word-generated Outlook history from its reply header through the quoted chain", () => {
+    const email = buildEmailDocument(outlookWordReplySection, false);
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    const disclosures = document.querySelectorAll("details.dakia-quoted-history");
+    expect(disclosures).toHaveLength(1);
+    const details = disclosures[0];
+    expect(details.hasAttribute("open")).toBe(false);
+
+    const visible =
+      document.body.textContent?.replace(details.textContent ?? "", "") ?? "";
+    expect(visible).toContain("uus vastus, mis peab nähtavaks jääma");
+    expect(visible).toContain("Juhan Tamm");
+    expect(visible).not.toContain("From:");
+    expect(visible).not.toContain("External email");
+    expect(visible).not.toContain("wrote:");
+
+    expect(details.textContent).toContain("From: Marten Mets");
+    expect(details.textContent).toContain("Sent: Friday, July 24, 2026");
+    expect(details.textContent).toContain("External email.");
+    expect(details.textContent).toContain("varasema päeva sõnum, mis kuulub ajalukku");
+    expect(details.textContent).toContain("wrote:");
+    expect(details.textContent).toContain("-----Original Message-----");
+    expect(details.textContent).toContain("Kõige vanem sõnum");
+    expect(
+      details.querySelector("[name='messageBodySection']"),
+    ).not.toBeNull();
+    expect(
+      details.querySelector("[name='messageSignatureSection']"),
+    ).not.toBeNull();
+    expect(
+      details.querySelector("[name='messageReplySection']"),
+    ).not.toBeNull();
+  });
+
+  it("expands and collapses Word-generated Outlook history repeatedly", () => {
+    render(
+      <HtmlMessage
+        html={outlookWordReplySection}
+        title="Outlook history sizing"
+        showHistoryLabel="Show history"
+        hideHistoryLabel="Hide history"
+      />,
+    );
+
+    const message = screen.getByRole("document", {
+      name: "Outlook history sizing",
+    });
+    const root = renderedEmailRoot(message);
+    expect(root?.textContent).toContain("uus vastus, mis peab nähtavaks jääma");
+    const details = root?.querySelector<HTMLDetailsElement>(
+      "details.dakia-quoted-history",
+    );
+    expect(details).not.toBeNull();
+    if (!details) return;
+    expect(details.open).toBe(false);
+
+    for (let cycle = 0; cycle < 2; cycle += 1) {
+      fireEvent.click(details.querySelector("summary")!);
+      expect(details.open).toBe(true);
+      expect(details.textContent).toContain("Kõige vanem sõnum");
+
+      fireEvent.click(details.querySelector("summary")!);
+      expect(details.open).toBe(false);
+    }
+  });
+
+  it("does not collapse a Word reply header that has no quoted content after it", () => {
+    const email = buildEmailDocument(
+      [
+        "<p>Reply</p>",
+        '<div><div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0cm 0cm 0cm">',
+        "<p><b>From:</b> Old Sender &lt;old@example.test&gt;<br>",
+        "<b>Sent:</b> Friday, July 24, 2026 10:24 PM<br>",
+        "<b>To:</b> New Sender<br>",
+        "<b>Subject:</b> RE: Empty quote</p>",
+        "</div></div>",
+        "<p>&nbsp;</p>",
+      ].join(""),
+      false,
+    );
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    expect(document.querySelector("details.dakia-quoted-history")).toBeNull();
+    expect(document.body.textContent).toContain("From: Old Sender");
+  });
+
+  it("does not treat a bare border-top divider as a reply header", () => {
+    const email = buildEmailDocument(
+      [
+        "<p>Above the divider</p>",
+        '<div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0cm 0cm 0cm">',
+        "<p>Quarterly report highlights</p>",
+        "</div>",
+        "<p>Below the divider</p>",
+      ].join(""),
+      false,
+    );
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    expect(document.querySelector("details.dakia-quoted-history")).toBeNull();
+    expect(document.body.textContent).toContain("Below the divider");
+  });
+
+  it("collapses stacked Word reply headers into a single disclosure", () => {
+    const email = buildEmailDocument(
+      [
+        "<p>Fresh</p>",
+        '<div><div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0cm 0cm 0cm">',
+        "<p><b>From:</b> One<br><b>Sent:</b> Monday<br><b>To:</b> Two<br><b>Subject:</b> RE: A</p>",
+        "</div></div>",
+        "<p>First quoted body</p>",
+        '<div><div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0cm 0cm 0cm">',
+        "<p><b>From:</b> Two<br><b>Sent:</b> Tuesday<br><b>To:</b> One<br><b>Subject:</b> RE: A</p>",
+        "</div></div>",
+        "<p>Second quoted body</p>",
+      ].join(""),
+      false,
+    );
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    const disclosures = document.querySelectorAll("details.dakia-quoted-history");
+    expect(disclosures).toHaveLength(1);
+    const details = disclosures[0];
+    const visible =
+      document.body.textContent?.replace(details.textContent ?? "", "") ?? "";
+    expect(visible).toContain("Fresh");
+    expect(visible).not.toContain("quoted body");
+    expect(details.textContent).toContain("First quoted body");
+    expect(details.textContent).toContain("Second quoted body");
   });
 
   it("keeps the trusted history disclosure visible against hostile message CSS", () => {

--- a/apps/desktop/src/components/HtmlMessage.tsx
+++ b/apps/desktop/src/components/HtmlMessage.tsx
@@ -191,12 +191,26 @@ function collapseQuotedHistory(
       "#divRplyFwdMsg",
     ].join(","),
   );
+  const outlookHeader = findOutlookReplyHeader(document);
+  let outlookBoundary: HTMLElement | null = null;
   if (
+    outlookHeader &&
+    (!candidate ||
+      (candidate.compareDocumentPosition(outlookHeader) &
+        Node.DOCUMENT_POSITION_PRECEDING) !==
+        0)
+  ) {
+    if (outlookHeader.closest("details.dakia-quoted-history")) return;
+    const boundary = outlookQuoteBoundary(outlookHeader);
+    if (!hasMeaningfulFollowingContent(boundary)) return;
+    outlookBoundary = boundary;
+  } else if (
     !candidate ||
     candidate.closest("details.dakia-quoted-history") ||
     !hasMeaningfulQuotedContent(candidate)
-  )
+  ) {
     return;
+  }
 
   const details = document.createElement("details");
   details.className = "dakia-quoted-history";
@@ -238,7 +252,15 @@ function collapseQuotedHistory(
   const content = document.createElement("div");
   content.className = "dakia-history-content";
 
-  if (candidate.id === "divRplyFwdMsg") {
+  if (outlookBoundary) {
+    outlookBoundary.before(details);
+    let node: Node | null = outlookBoundary;
+    while (node) {
+      const next: Node | null = node.nextSibling;
+      content.append(node);
+      node = next;
+    }
+  } else if (candidate?.id === "divRplyFwdMsg") {
     const nodes: Node[] = [candidate];
     let node = candidate.nextElementSibling;
     while (
@@ -251,13 +273,62 @@ function collapseQuotedHistory(
     }
     candidate.before(details);
     nodes.forEach((item) => content.append(item));
-  } else {
+  } else if (candidate) {
     const citation = precedingCitation(candidate);
     candidate.before(details);
     if (citation) content.append(citation);
     content.append(candidate);
   }
   details.append(summary, content);
+}
+
+// Word-generated Outlook desktop replies mark the start of quoted history
+// with a top-border divider above a From/Sent/To/Subject header block.
+function findOutlookReplyHeader(document: Document) {
+  for (const element of document.querySelectorAll<HTMLElement>("div[style]")) {
+    if (!/border-top\s*:/i.test(element.getAttribute("style") ?? "")) continue;
+    const text = (element.textContent ?? "").replace(/\s+/g, " ").trim();
+    if (
+      /^From:\s*\S/i.test(text) &&
+      /(?:Sent|To|Cc|Subject):\s*\S/i.test(text)
+    ) {
+      return element;
+    }
+  }
+  return null;
+}
+
+// Word often nests the divider in layout-only wrapper divs; collapse from
+// the outermost wrapper that adds no content of its own.
+function outlookQuoteBoundary(element: HTMLElement) {
+  let boundary = element;
+  while (
+    boundary.parentElement &&
+    boundary.parentElement.childElementCount === 1 &&
+    (boundary.parentElement.textContent ?? "").trim() ===
+      (boundary.textContent ?? "").trim()
+  ) {
+    boundary = boundary.parentElement;
+  }
+  return boundary;
+}
+
+// The Outlook header separates new content from the quoted message below
+// it, so the header and everything after it belongs to the history. A
+// header with nothing meaningful after it (a stripped quote) stays visible.
+function hasMeaningfulFollowingContent(boundary: HTMLElement) {
+  let node = boundary.nextSibling;
+  while (node) {
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      const element = node as HTMLElement;
+      if (element.querySelector("img, table, blockquote")) return true;
+      if ((element.textContent ?? "").replace(/\s+/g, "")) return true;
+    } else if (node.nodeType === Node.TEXT_NODE && node.textContent?.trim()) {
+      return true;
+    }
+    node = node.nextSibling;
+  }
+  return false;
 }
 
 function hasMeaningfulQuotedContent(candidate: HTMLElement) {

--- a/apps/desktop/src/quotedHistory.test.ts
+++ b/apps/desktop/src/quotedHistory.test.ts
@@ -36,4 +36,51 @@ describe("splitQuotedText", () => {
     expect(splitQuotedText(prose)).toEqual({ visible: prose });
     expect(splitQuotedText(shortQuote)).toEqual({ visible: shortQuote });
   });
+
+  it("collapses an Outlook desktop reply header block", () => {
+    const text = [
+      "Uus vastus",
+      "",
+      "Juhan Tamm",
+      "",
+      "From: Marten Mets <marten.mets@example.com>",
+      "Sent: Friday, July 24, 2026 10:24 PM",
+      "To: Juhan Tamm <juhan.tamm@example.com>",
+      "Subject: RE: Kahjuteade VO1000042",
+      "",
+      "Varasem sisu",
+      "On 24 Jul 2026 at 15:59 +0300, juhan.tamm@example.com, wrote:",
+      "Veel vanem sisu",
+    ].join("\n");
+    expect(splitQuotedText(text)).toEqual({
+      visible: "Uus vastus\n\nJuhan Tamm",
+      history: [
+        "From: Marten Mets <marten.mets@example.com>",
+        "Sent: Friday, July 24, 2026 10:24 PM",
+        "To: Juhan Tamm <juhan.tamm@example.com>",
+        "Subject: RE: Kahjuteade VO1000042",
+        "",
+        "Varasem sisu",
+        "On 24 Jul 2026 at 15:59 +0300, juhan.tamm@example.com, wrote:",
+        "Veel vanem sisu",
+      ].join("\n"),
+    });
+  });
+
+  it("does not split on a From: line without adjacent mail header labels", () => {
+    const prose = [
+      "Reply",
+      "From: the letters of the archive we quote",
+      "a plain body line",
+      "another plain body line",
+    ].join("\n");
+    const blankBreak = [
+      "Reply",
+      "From: a standalone mention",
+      "",
+      "To: a label separated by a blank line is not a header",
+    ].join("\n");
+    expect(splitQuotedText(prose)).toEqual({ visible: prose });
+    expect(splitQuotedText(blankBreak)).toEqual({ visible: blankBreak });
+  });
 });

--- a/apps/desktop/src/quotedHistory.ts
+++ b/apps/desktop/src/quotedHistory.ts
@@ -7,6 +7,20 @@ const originalMessage =
   /^-{2,}\s*(?:Original Message|Forwarded message)\s*-{2,}\s*$/i;
 const beginForwarded = /^Begin forwarded message:\s*$/i;
 const wroteLine = /^On .+\bwrote:\s*$/i;
+const outlookHeaderStart = /^From:\s*\S/i;
+const outlookHeaderLabel = /^(?:Sent|To|Cc|Subject):\s*\S/i;
+
+// Outlook desktop replies separate new content from quoted history with a
+// From/Sent/To/Subject header block instead of ">" prefixes.
+function isOutlookHeaderStart(lines: string[], index: number): boolean {
+  if (!outlookHeaderStart.test(lines[index].trim())) return false;
+  for (const line of lines.slice(index + 1, index + 6)) {
+    const trimmed = line.trim();
+    if (!trimmed) return false;
+    if (outlookHeaderLabel.test(trimmed)) return true;
+  }
+  return false;
+}
 
 export function splitQuotedText(value: string): SplitMessageText {
   const lines = value.split(/\r?\n/);
@@ -14,6 +28,7 @@ export function splitQuotedText(value: string): SplitMessageText {
     (line, index) =>
       originalMessage.test(line.trim()) ||
       beginForwarded.test(line.trim()) ||
+      isOutlookHeaderStart(lines, index) ||
       (wroteLine.test(line.trim()) &&
         lines.slice(index + 1).some((next) => /^\s*>/.test(next))),
   );

--- a/apps/desktop/src/test/fixtures/outlook-word-reply-section.html
+++ b/apps/desktop/src/test/fixtures/outlook-word-reply-section.html
@@ -1,0 +1,96 @@
+<html xmlns:v="urn:schemas-microsoft-com:vml" xmlns:o="urn:schemas-microsoft-com:office:office" xmlns:w="urn:schemas-microsoft-com:office:word" xmlns:m="http://schemas.microsoft.com/office/2004/12/omml" xmlns="http://www.w3.org/TR/REC-html40">
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+<meta name="Generator" content="Microsoft Word 15 (filtered medium)">
+<style><!--
+p.MsoNormal, li.MsoNormal, div.MsoNormal
+	{margin:0cm;
+	font-size:12.0pt;
+	font-family:"Aptos",sans-serif;}
+span.EmailStyle20
+	{mso-style-type:personal-reply;
+	font-family:"Aptos",sans-serif;
+	color:windowtext;}
+@page WordSection1
+	{size:612.0pt 792.0pt;
+	margin:70.85pt 70.85pt 70.85pt 70.85pt;}
+div.WordSection1
+	{page:WordSection1;}
+--></style>
+</head>
+<body lang="ET" link="#467886" vlink="#96607D" style="word-wrap:break-word">
+<div class="WordSection1">
+<p class="MsoNormal"><span style="mso-fareast-language:EN-US">Tere,<o:p></o:p></span></p>
+<p class="MsoNormal"><span style="mso-fareast-language:EN-US"><o:p>&nbsp;</o:p></span></p>
+<p class="MsoNormal"><span style="mso-fareast-language:EN-US">See on uus vastus, mis peab nähtavaks jääma. Palun täpsustada kahjujuhtumi ametlikku otsust.<o:p></o:p></span></p>
+<p class="MsoNormal"><o:p>&nbsp;</o:p></p>
+<p class="MsoNormal"><span lang="LV" style="font-size:11.0pt">&nbsp;</span><o:p></o:p></p>
+<p class="MsoNormal"><span lang="LV" style="font-family:&quot;Arial&quot;,sans-serif;color:#512B2B">Parimate soovidega,</span><o:p></o:p></p>
+<p class="MsoNormal"><b><span lang="LV" style="font-family:&quot;Arial&quot;,sans-serif;color:#512B2B">Juhan Tamm</span></b><o:p></o:p></p>
+<p class="MsoNormal"><span lang="LV" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:#512B2B">Vanemkahjukäsitleja</span><o:p></o:p></p>
+<p class="MsoNormal"><span lang="LV" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:#512B2B">Kindlustus AS</span><o:p></o:p></p>
+<p class="MsoNormal"><span lang="LV" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:#512B2B">Tel: &#43;3725550101<o:p></o:p></span></p>
+<p class="MsoNormal"><span lang="LV" style="font-size:9.0pt;font-family:&quot;Arial&quot;,sans-serif;color:#512B2B"><img width="132" height="29" id="Picture_x0020_1" src="data:image/png;base64,iVBORw0KGgo="><o:p></o:p></span></p>
+<p class="MsoNormal"><span lang="LV" style="font-size:8.0pt;font-family:&quot;Arial&quot;,sans-serif;color:#512B2B">Sõnum võib sisaldada konfidentsiaalset infot.</span><o:p></o:p></p>
+<p class="MsoNormal"><o:p>&nbsp;</o:p></p>
+<p class="MsoNormal"><o:p>&nbsp;</o:p></p>
+<div>
+<div style="border:none;border-top:solid #E1E1E1 1.0pt;padding:3.0pt 0cm 0cm 0cm">
+<p class="MsoNormal"><b><span lang="EN-US" style="font-size:11.0pt;font-family:&quot;Calibri&quot;,sans-serif">From:</span></b><span lang="EN-US" style="font-size:11.0pt;font-family:&quot;Calibri&quot;,sans-serif"> Marten Mets &lt;marten.mets@example.com&gt;
+<br>
+<b>Sent:</b> Friday, July 24, 2026 10:24 PM<br>
+<b>To:</b> Juhan Tamm &lt;juhan.tamm@example.com&gt;<br>
+<b>Subject:</b> RE: Kahjuteade VO1000042, Metsa tn 1-1, Tallinn<o:p></o:p></span></p>
+</div>
+</div>
+<p class="MsoNormal"><o:p>&nbsp;</o:p></p>
+<p class="MsoNormal" style="mso-margin-top-alt:auto;mso-margin-bottom-alt:auto"><strong><span lang="EN-US" style="font-family:&quot;Arial&quot;,sans-serif;color:black;background:yellow">External email.
+</span></strong><span lang="EN-US" style="font-family:&quot;Arial&quot;,sans-serif;color:black;background:yellow">Do not click on links or attachments unless you recognize the sender.</span><o:p></o:p></p>
+<div name="messageBodySection">
+<p class="MsoNormal">Tere<br>
+<br>
+Tänan vastuse eest. See on varasema päeva sõnum, mis kuulub ajalukku.<br>
+<br>
+Lugupidamisega<o:p></o:p></p>
+</div>
+<div name="messageSignatureSection">
+<p class="MsoNormal"><o:p>&nbsp;</o:p></p>
+<p class="MsoNormal">Marten Mets<o:p></o:p></p>
+</div>
+<div name="messageReplySection">
+<p class="MsoNormal">On 24 Jul 2026 at 15:59 &#43;0300, <a href="mailto:juhan.tamm@example.com">
+juhan.tamm@example.com</a>, wrote:<br>
+<br>
+<o:p></o:p></p>
+<blockquote style="border:none;border-left:solid windowtext 1.0pt;padding:0cm 0cm 0cm 8.0pt;margin-left:3.75pt;margin-top:3.75pt;margin-right:3.75pt;margin-bottom:3.75pt">
+<p class="MsoNormal">Tere, hr Mets<br>
+<br>
+Oleme teinud järelepärimise arendajale, kuid vastus puudub.<br>
+<br>
+Parimate soovidega,<br>
+<br>
+Juhan Tamm<br>
+Vanemkahjukäsitleja<br>
+<br>
+Kindlustus AS<br>
+<br>
+Sõnum võib sisaldada konfidentsiaalset infot.<br>
+<br>
+-----Original Message-----<br>
+From: Marten Mets &lt;<a href="mailto:marten.mets@example.com">marten.mets@example.com</a>&gt;<br>
+Sent: Thursday, July 23, 2026 10:46 PM<br>
+To: Juhan Tamm &lt;<a href="mailto:juhan.tamm@example.com">juhan.tamm@example.com</a>&gt;<br>
+Subject: RE: Kahjuteade VO1000042, Metsa tn 1-1, Tallinn<br>
+<br>
+Tere, hr Tamm<br>
+<br>
+Kõige vanem sõnum ajaveebis.<br>
+<br>
+Parimate soovidega<br>
+<br>
+Marten Mets<o:p></o:p></p>
+</blockquote>
+</div>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

Quoted history in Word-generated Outlook desktop replies was not collapsed properly: only a deeply nested provider marker (e.g. `messageReplySection`) moved behind the disclosure, while the Outlook `From:/Sent:/To:/Subject:` header block, external-email banner, the full quoted previous message body, and the quoted signature stayed visible. This adds the missing marker to both collapse paths so the entire quoted chain collapses from the Outlook header downward.

## Changes

- HTML path (`HtmlMessage.tsx`): detect the Word/Outlook reply header — a `border-top` divider div whose text starts with `From:` and carries `Sent/To/Cc/Subject:` labels — lift layout-only wrapper divs, and collapse the header plus all following siblings. The earliest recognized marker in document order wins, so a `gmail_quote` wrapping such a header still collapses as one region.
- Plain-text path (`quotedHistory.ts`): split at a `From:` line when a contiguous `Sent/To/Cc/Subject:` label follows within the header block (Outlook desktop uses no `>` prefixes).
- New checked-in fixture `outlook-word-reply-section.html`: a redacted real Word/Outlook reply (based on the email that exposed the bug) preserving provider-specific nesting, attributes, and whitespace, including an embedded `messageBodySection`/`messageSignatureSection`/`messageReplySection` chain and a nested `-----Original Message-----` block.
- Adversarial coverage: header with no quoted content after it stays visible; decorative border-top dividers without mail labels are untouched; stacked Word headers collapse into a single disclosure; prose `From:` lines without adjacent labels and labels separated by blank lines do not split; expand-collapse-expand round trip through the rendered shadow DOM.

## Testing

- New regression tests fail on the previous implementation (visible region still contained `From:`/`External email`/`wrote:`; zero disclosures in the stacked-header case; no plain-text split), proving sensitivity to the defect.
- Full suite: 191/191 tests across 23 files; `tsc --noEmit` clean.
- Verified end-to-end against the real failing email body from the local store: exactly one disclosure, new reply and sender signature visible, everything from the `From:` header down collapsed.