### PR TITLE
Include quoted message history in replies

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -994,7 +994,23 @@ describe("App read state", () => {
     expect(mocks.api.setRead).not.toHaveBeenCalled();
   });
 
-  it("opens a reply composer when the reader reply button is clicked", async () => {
+  it("hydrates only the selected reply message before opening a quoted reply composer", async () => {
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages([
+        mocks.message,
+        {
+          ...mocks.message,
+          id: "message-2",
+          from_address: "me@example.com",
+          received_at: "2026-07-19T11:00:00Z",
+        },
+      ]),
+      nextCursor: null,
+    });
+    mocks.api.content.mockResolvedValue({
+      body_text: "Provider body\r\n> Nested history",
+      attachments: [],
+    });
     render(
       <MantineProvider>
         <App />
@@ -1003,7 +1019,9 @@ describe("App read state", () => {
 
     const row = await screen.findByText("Unread thread");
     fireEvent.click(row.closest("button")!);
-    fireEvent.click(await screen.findByRole("button", { name: "Reply" }));
+    await screen.findByRole("button", { name: "Reply" });
+    mocks.api.content.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Reply" }));
 
     await waitFor(() =>
       expect(mocks.openComposeWindow).toHaveBeenCalledWith(
@@ -1011,9 +1029,15 @@ describe("App read state", () => {
           accountId: "account-1",
           to: "sender@example.com",
           subject: "Re: Unread thread",
+          body: expect.stringContaining("> > Nested history"),
+          bodyHtml: expect.stringContaining(
+            '<blockquote type="cite">Provider body<br>&gt; Nested history</blockquote>',
+          ),
         }),
       ),
     );
+    expect(mocks.api.content).toHaveBeenCalledTimes(1);
+    expect(mocks.api.content).toHaveBeenCalledWith("message-1");
   });
 
   it("opens Reply All with Reply-To and deduplicated non-self Cc recipients", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -29,6 +29,7 @@ import { replyRecipients } from "./recipients";
 import { confirmNativeAction, showNativeMessage } from "./nativeFeedback";
 import { groupMessages } from "./threads";
 import { forwardBody, forwardSubject } from "./forward";
+import { formatReplyHistory } from "./replyHistory";
 import {
   onNotificationAction,
   readNotificationSettings,
@@ -1280,7 +1281,7 @@ export default function App() {
       setAiLoading(false);
     }
   };
-  const openReply = (
+  const openReply = async (
     thread: MailThread | undefined = activeThread,
     replyAll = false,
   ) => {
@@ -1298,22 +1299,39 @@ export default function App() {
         ) ?? thread.latest;
     const recipients = replyRecipients(replyMessage, account?.email, replyAll);
     if (!recipients) return;
-    const prefix = t("reader.replyPrefix");
-    openComposeWindow({
-      accountId: replyMessage.account_id,
-      to: recipients.to,
-      ...(recipients.cc ? { cc: recipients.cc } : {}),
-      subject: replyMessage.subject
-        .toLowerCase()
-        .startsWith(prefix.toLowerCase())
-        ? replyMessage.subject
-        : `${prefix} ${replyMessage.subject}`,
-      inReplyTo: replyMessage.message_id,
-      references: [replyMessage.reference_ids, replyMessage.message_id]
-        .filter(Boolean)
-        .join(" "),
-      contextMessageIds: thread.messages.map((message) => message.id),
-    });
+    try {
+      const content = await api.content(replyMessage.id);
+      const replyHistory = formatReplyHistory({
+        message: replyMessage,
+        bodyText: content.body_text,
+        formatCitation: ({ date, sender }) =>
+          t("reader.replyCitation", { date, sender }),
+      });
+      const prefix = t("reader.replyPrefix");
+      openComposeWindow({
+        accountId: replyMessage.account_id,
+        to: recipients.to,
+        ...(recipients.cc ? { cc: recipients.cc } : {}),
+        subject: replyMessage.subject
+          .toLowerCase()
+          .startsWith(prefix.toLowerCase())
+          ? replyMessage.subject
+          : `${prefix} ${replyMessage.subject}`,
+        body: replyHistory.body,
+        bodyHtml: replyHistory.bodyHtml,
+        inReplyTo: replyMessage.message_id,
+        references: [replyMessage.reference_ids, replyMessage.message_id]
+          .filter(Boolean)
+          .join(" "),
+        contextMessageIds: thread.messages.map((message) => message.id),
+      });
+    } catch (error) {
+      await showNativeMessage(
+        t("reader.replyErrorTitle"),
+        error instanceof Error ? error.message : String(error),
+        "error",
+      );
+    }
   };
   const openForward = async (thread: MailThread | undefined = activeThread) => {
     const message = thread?.latest;

--- a/apps/desktop/src/components/Composer.test.tsx
+++ b/apps/desktop/src/components/Composer.test.tsx
@@ -185,6 +185,115 @@ describe("Composer send feedback", () => {
     );
   });
 
+  it("preserves edited Thunderbird quote markers and their plain-text alternative", () => {
+    const onSend = vi.fn();
+    const bodyHtml = [
+      "<p><br></p>",
+      '<div class="moz-cite-prefix">On July 19, Mara wrote:</div>',
+      '<blockquote type="cite">Original body</blockquote>',
+    ].join("");
+    render(
+      <Composer
+        {...props}
+        seed={{
+          to: "sender@example.com",
+          body: "Plain seed fallback",
+          bodyHtml,
+        }}
+        onSend={onSend}
+        sendState="idle"
+      />,
+    );
+
+    const editor = screen.getByLabelText("Write your message…");
+    expect(editor.innerHTML).toBe(bodyHtml);
+    editor.innerHTML = `<p>Authored text</p>${bodyHtml}`;
+    fireEvent.input(editor);
+    fireEvent.click(screen.getByRole("button", { name: /^Send/ }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body_html: expect.stringContaining('class="moz-cite-prefix"'),
+      }),
+    );
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body_html: expect.stringContaining(
+          '<blockquote type="cite">Original body</blockquote>',
+        ),
+        body_text: expect.stringContaining("Authored text"),
+      }),
+    );
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body_text: expect.stringContaining("On July 19, Mara wrote:"),
+      }),
+    );
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body_text: expect.stringContaining("> Original body"),
+      }),
+    );
+  });
+
+  it("sanitizes a hostile seeded reply before rendering and sends that unchanged sanitized HTML", () => {
+    const onSend = vi.fn();
+    const bodyHtml = [
+      "<p>Valid <strong>text</strong></p>",
+      '<div class="moz-cite-prefix" onclick="alert(\'xss\')">On July 19, Mara wrote:</div>',
+      '<blockquote type="cite" onmouseover="alert(\'xss\')">Quoted plain text</blockquote>',
+      "<script>alert('xss')</script>",
+      '<img src="https://example.com/tracker.png" onerror="alert(\'xss\')">',
+      "<p onfocus=\"alert('xss')\">Safe body text</p>",
+      "<a href=\"javascript:alert('xss')\">Dangerous link</a>",
+    ].join("");
+    const sanitizedBodyHtml = [
+      "<p>Valid <strong>text</strong></p>",
+      '<div class="moz-cite-prefix">On July 19, Mara wrote:</div>',
+      '<blockquote type="cite">Quoted plain text</blockquote>',
+      "<p>Safe body text</p>",
+      "Dangerous link",
+    ].join("");
+
+    render(
+      <Composer
+        {...props}
+        seed={{ to: "sender@example.com", bodyHtml }}
+        onSend={onSend}
+        sendState="idle"
+      />,
+    );
+
+    const editor = screen.getByLabelText("Write your message…");
+    expect(editor.innerHTML).toBe(sanitizedBodyHtml);
+
+    fireEvent.click(screen.getByRole("button", { name: /^Send/ }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body_html: sanitizedBodyHtml,
+        body_text:
+          "Valid text\nOn July 19, Mara wrote:\n> Quoted plain text\nSafe body text\nDangerous link",
+      }),
+    );
+  });
+
+  it("keeps an empty bodyHtml seed instead of falling back to its plain-text body", () => {
+    render(
+      <Composer
+        {...props}
+        seed={{
+          to: "sender@example.com",
+          body: "Plain seed fallback",
+          bodyHtml: "",
+        }}
+        sendState="idle"
+      />,
+    );
+
+    expect(screen.getByLabelText("Write your message…").innerHTML).toBe("");
+  });
+
   it("initializes and sends Reply All Cc recipients from the compose seed", () => {
     const onSend = vi.fn();
     render(

--- a/apps/desktop/src/components/Composer.tsx
+++ b/apps/desktop/src/components/Composer.tsx
@@ -21,6 +21,7 @@ import {
   isRichTextEmpty,
   plainTextFromRichText,
   richTextFromPlainText,
+  sanitizeRichText,
 } from "./richText";
 
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
@@ -53,7 +54,7 @@ export function Composer({
   const [bcc, setBcc] = useState("");
   const [subject, setSubject] = useState(seed?.subject ?? "");
   const [bodyHtml, setBodyHtml] = useState(() =>
-    richTextFromPlainText(seed?.body ?? ""),
+    sanitizeRichText(seed?.bodyHtml ?? richTextFromPlainText(seed?.body ?? "")),
   );
   const [showCopies, setShowCopies] = useState(Boolean(seed?.cc));
   const [aiLoading, setAiLoading] = useState(false);

--- a/apps/desktop/src/components/HtmlMessage.test.tsx
+++ b/apps/desktop/src/components/HtmlMessage.test.tsx
@@ -210,6 +210,28 @@ describe("HTML email appearance", () => {
     ).not.toContain("wrote:");
   });
 
+  it("moves an adjacent Thunderbird citation into the collapsed history", () => {
+    const email = buildEmailDocument(
+      [
+        "<p>Current reply</p>",
+        '<div class="moz-cite-prefix">On 19 Feb 2026 at 21:00 +0200, Romario Verbran &lt;romario.verbran@gmail.com&gt;, wrote:</div>',
+        '<blockquote type="cite"><p>Earlier message</p></blockquote>',
+      ].join(""),
+      false,
+    );
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    const details = document.querySelector("details.dakia-quoted-history");
+
+    expect(document.body.firstElementChild?.textContent).toBe("Current reply");
+    expect(details?.textContent).toContain(
+      "On 19 Feb 2026 at 21:00 +0200, Romario Verbran",
+    );
+    expect(details?.textContent).toContain("Earlier message");
+    expect(
+      document.body.textContent?.replace(details?.textContent ?? "", ""),
+    ).not.toContain("wrote:");
+  });
+
   it("collapses Apple Mail reply sections with their attribution", () => {
     const email = buildEmailDocument(
       [

--- a/apps/desktop/src/components/HtmlMessage.test.tsx
+++ b/apps/desktop/src/components/HtmlMessage.test.tsx
@@ -193,7 +193,7 @@ describe("HTML email appearance", () => {
     const email = buildEmailDocument(
       [
         "<p>Current reply</p>",
-        "<div>On 19 Feb 2026 at 21:00 +0200, Romario Verbran &lt;romario.verbran@gmail.com&gt;, wrote:</div>",
+        "<div>On 19 Feb 2026 at 21:00 +0200, Rowan Example &lt;rowan@example.test&gt;, wrote:</div>",
         '<blockquote type="cite"><p>Earlier message</p></blockquote>',
       ].join(""),
       false,
@@ -203,7 +203,7 @@ describe("HTML email appearance", () => {
 
     expect(document.body.firstElementChild?.textContent).toBe("Current reply");
     expect(details?.textContent).toContain(
-      "On 19 Feb 2026 at 21:00 +0200, Romario Verbran",
+      "On 19 Feb 2026 at 21:00 +0200, Rowan Example",
     );
     expect(details?.textContent).toContain("Earlier message");
     expect(
@@ -215,7 +215,7 @@ describe("HTML email appearance", () => {
     const email = buildEmailDocument(
       [
         "<p>Current reply</p>",
-        '<div class="moz-cite-prefix">On 19 Feb 2026 at 21:00 +0200, Romario Verbran &lt;romario.verbran@gmail.com&gt;, wrote:</div>',
+        '<div class="moz-cite-prefix">On 19 Feb 2026 at 21:00 +0200, Rowan Example &lt;rowan@example.test&gt;, wrote:</div>',
         '<blockquote type="cite"><p>Earlier message</p></blockquote>',
       ].join(""),
       false,
@@ -225,7 +225,7 @@ describe("HTML email appearance", () => {
 
     expect(document.body.firstElementChild?.textContent).toBe("Current reply");
     expect(details?.textContent).toContain(
-      "On 19 Feb 2026 at 21:00 +0200, Romario Verbran",
+      "On 19 Feb 2026 at 21:00 +0200, Rowan Example",
     );
     expect(details?.textContent).toContain("Earlier message");
     expect(
@@ -238,7 +238,7 @@ describe("HTML email appearance", () => {
       [
         "<p>Current reply</p>",
         '<div name="messageReplySection">',
-        "On 19 Feb 2026 at 21:00 +0200, Romario Verbran &lt;romario.verbran@gmail.com&gt;, wrote:<br>",
+        "On 19 Feb 2026 at 21:00 +0200, Rowan Example &lt;rowan@example.test&gt;, wrote:<br>",
         '<blockquote type="cite"><div>Earlier message</div></blockquote>',
         "</div>",
       ].join(""),
@@ -248,7 +248,7 @@ describe("HTML email appearance", () => {
     const details = document.querySelector("details.dakia-quoted-history");
 
     expect(details?.textContent).toContain(
-      "On 19 Feb 2026 at 21:00 +0200, Romario Verbran",
+      "On 19 Feb 2026 at 21:00 +0200, Rowan Example",
     );
     expect(details?.textContent).toContain("Earlier message");
     expect(

--- a/apps/desktop/src/components/HtmlMessage.test.tsx
+++ b/apps/desktop/src/components/HtmlMessage.test.tsx
@@ -289,7 +289,9 @@ describe("HTML email appearance", () => {
   it("collapses Word-generated Outlook history from its reply header through the quoted chain", () => {
     const email = buildEmailDocument(outlookWordReplySection, false);
     const document = new DOMParser().parseFromString(email.source, "text/html");
-    const disclosures = document.querySelectorAll("details.dakia-quoted-history");
+    const disclosures = document.querySelectorAll(
+      "details.dakia-quoted-history",
+    );
     expect(disclosures).toHaveLength(1);
     const details = disclosures[0];
     expect(details.hasAttribute("open")).toBe(false);
@@ -305,13 +307,13 @@ describe("HTML email appearance", () => {
     expect(details.textContent).toContain("From: Marten Mets");
     expect(details.textContent).toContain("Sent: Friday, July 24, 2026");
     expect(details.textContent).toContain("External email.");
-    expect(details.textContent).toContain("varasema päeva sõnum, mis kuulub ajalukku");
+    expect(details.textContent).toContain(
+      "varasema päeva sõnum, mis kuulub ajalukku",
+    );
     expect(details.textContent).toContain("wrote:");
     expect(details.textContent).toContain("-----Original Message-----");
     expect(details.textContent).toContain("Kõige vanem sõnum");
-    expect(
-      details.querySelector("[name='messageBodySection']"),
-    ).not.toBeNull();
+    expect(details.querySelector("[name='messageBodySection']")).not.toBeNull();
     expect(
       details.querySelector("[name='messageSignatureSection']"),
     ).not.toBeNull();
@@ -403,7 +405,9 @@ describe("HTML email appearance", () => {
       false,
     );
     const document = new DOMParser().parseFromString(email.source, "text/html");
-    const disclosures = document.querySelectorAll("details.dakia-quoted-history");
+    const disclosures = document.querySelectorAll(
+      "details.dakia-quoted-history",
+    );
     expect(disclosures).toHaveLength(1);
     const details = disclosures[0];
     const visible =

--- a/apps/desktop/src/components/richText.test.ts
+++ b/apps/desktop/src/components/richText.test.ts
@@ -23,12 +23,43 @@ describe("rich text conversion", () => {
     ).toBe('<b>Bold</b><span style="font-style: italic">Italic</span>');
   });
 
+  it("preserves only the Thunderbird citation markers used by reply history", () => {
+    expect(
+      sanitizeRichText(
+        '<div class="moz-cite-prefix" type="cite" data-test="remove">Citation</div><blockquote type="cite" class="remove">Original</blockquote>',
+      ),
+    ).toBe(
+      '<div class="moz-cite-prefix">Citation</div><blockquote type="cite">Original</blockquote>',
+    );
+    expect(
+      sanitizeRichText(
+        '<div class="moz-cite-prefix extra">Citation</div><blockquote type="other" class="moz-cite-prefix">Original</blockquote>',
+      ),
+    ).toBe("<div>Citation</div><blockquote>Original</blockquote>");
+  });
+
   it("creates a readable text alternative for structured content", () => {
     expect(
       plainTextFromRichText(
         "<p>Hello <strong>there</strong></p><ul><li>One</li><li>Two</li></ul><blockquote>Thanks</blockquote>",
       ),
-    ).toBe("Hello there\n• One\n• Two\nThanks");
+    ).toBe("Hello there\n• One\n• Two\n> Thanks");
+  });
+
+  it("prefixes non-empty lines within nested blockquotes by quote depth", () => {
+    expect(
+      plainTextFromRichText(
+        "<p>Current reply</p><blockquote>First line<br><blockquote>Nested line<br>Nested second line</blockquote>Final line<br></blockquote>",
+      ),
+    ).toBe(
+      [
+        "Current reply",
+        "> First line",
+        "> > Nested line",
+        "> > Nested second line",
+        "> Final line",
+      ].join("\n"),
+    );
   });
 
   it("converts plain-text seeds without treating them as markup", () => {

--- a/apps/desktop/src/components/richText.ts
+++ b/apps/desktop/src/components/richText.ts
@@ -71,9 +71,19 @@ export function plainTextFromRichText(html: string) {
   const addBreak = () => {
     if (output && !output.endsWith("\n")) output += "\n";
   };
-  const visit = (node: Node) => {
+  const appendText = (text: string, quoteDepth: number) => {
+    const lines = text.split("\n");
+    lines.forEach((line, index) => {
+      if (line && quoteDepth && (!output || output.endsWith("\n"))) {
+        output += "> ".repeat(quoteDepth);
+      }
+      output += line;
+      if (index < lines.length - 1) output += "\n";
+    });
+  };
+  const visit = (node: Node, quoteDepth = 0) => {
     if (node.nodeType === Node.TEXT_NODE) {
-      output += node.textContent ?? "";
+      appendText(node.textContent ?? "", quoteDepth);
       return;
     }
     if (node.nodeType !== Node.ELEMENT_NODE) return;
@@ -86,17 +96,31 @@ export function plainTextFromRichText(html: string) {
     }
     if (tag === "li") {
       addBreak();
-      output += "• ";
-      element.childNodes.forEach(visit);
+      appendText("• ", quoteDepth);
+      element.childNodes.forEach((child) => {
+        visit(child, quoteDepth);
+      });
+      addBreak();
+      return;
+    }
+    if (tag === "blockquote") {
+      addBreak();
+      element.childNodes.forEach((child) => {
+        visit(child, quoteDepth + 1);
+      });
       addBreak();
       return;
     }
     if (BLOCK_TAGS.has(tag)) addBreak();
-    element.childNodes.forEach(visit);
+    element.childNodes.forEach((child) => {
+      visit(child, quoteDepth);
+    });
     if (BLOCK_TAGS.has(tag)) addBreak();
   };
 
-  document.body.childNodes.forEach(visit);
+  document.body.childNodes.forEach((child) => {
+    visit(child);
+  });
   return output.replace(/\n{3,}/g, "\n\n").trim();
 }
 
@@ -133,11 +157,17 @@ function sanitizeChildren(parent: Element) {
         element.replaceWith(...[...element.childNodes]);
       }
     } else {
+      const citePrefix =
+        tag === "div" && element.getAttribute("class") === "moz-cite-prefix";
+      const citeBlock =
+        tag === "blockquote" && element.getAttribute("type") === "cite";
       const style = safeStyle(element);
       for (const attribute of [...element.attributes]) {
         element.removeAttribute(attribute.name);
       }
       if (style) element.setAttribute("style", style);
+      if (citePrefix) element.setAttribute("class", "moz-cite-prefix");
+      if (citeBlock) element.setAttribute("type", "cite");
     }
   }
 }

--- a/apps/desktop/src/composeWindow.ts
+++ b/apps/desktop/src/composeWindow.ts
@@ -9,6 +9,7 @@ export type ComposeSeed = {
   cc?: string;
   subject?: string;
   body?: string;
+  bodyHtml?: string;
   inReplyTo?: string;
   references?: string;
   contextMessageIds?: string[];

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -127,8 +127,10 @@ export const en = {
       translation: "English translation",
       summary: "Summary",
       replyPrefix: "Re:",
+      replyCitation: "On {{date}}, {{sender}} wrote:",
       forwardPrefix: "Fwd:",
       date: "Date",
+      replyErrorTitle: "Could not reply to message",
       forwardErrorTitle: "Could not forward message",
       loadingContent: "Fetching message…",
       loadContentError:

--- a/apps/desktop/src/replyHistory.test.ts
+++ b/apps/desktop/src/replyHistory.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import { formatReplyHistory } from "./replyHistory";
+import type { MailSummary } from "./types";
+
+const message = {
+  id: "message-1",
+  account_id: "account-1",
+  mailbox: "INBOX",
+  uid: 1,
+  thread_id: "thread-1",
+  subject: "Release plan",
+  from_name: "Mara",
+  from_address: "mara@example.com",
+  to_addresses: "me@example.com",
+  received_at: "2026-07-19T10:00:00Z",
+  snippet: "Untrusted summary preview",
+  body_text: "Cached summary body",
+  is_read: true,
+  is_flagged: false,
+  has_attachments: false,
+} satisfies MailSummary;
+
+describe("reply history", () => {
+  it("formats provider plain text as Thunderbird-compatible plain and HTML quotes", () => {
+    const quote = formatReplyHistory({
+      message,
+      bodyText: "First line\r\n> Earlier history\r\n<script>&",
+      formatCitation: ({ date, sender }) => `On ${date}, ${sender} wrote:`,
+    });
+    const date = new Date(message.received_at).toLocaleString();
+
+    expect(quote.body).toBe(
+      [
+        `On ${date}, Mara <mara@example.com> wrote:`,
+        "> First line",
+        "> > Earlier history",
+        "> <script>&",
+      ].join("\n"),
+    );
+    expect(quote.bodyHtml).toBe(
+      [
+        "<p><br></p>",
+        `<div class="moz-cite-prefix">On ${date}, Mara &lt;mara@example.com&gt; wrote:</div>`,
+        '<blockquote type="cite">First line<br>&gt; Earlier history<br>&lt;script&gt;&amp;</blockquote>',
+      ].join(""),
+    );
+  });
+
+  it("uses the sender address when the reply message has no display name", () => {
+    const { from_name: _fromName, ...messageWithoutName } = message;
+    const quote = formatReplyHistory({
+      message: messageWithoutName,
+      bodyText: "Original body",
+      formatCitation: ({ sender }) => `Citation: ${sender}`,
+    });
+
+    expect(quote.body).toContain("Citation: mara@example.com");
+    expect(quote.bodyHtml).toContain("Citation: mara@example.com");
+  });
+});

--- a/apps/desktop/src/replyHistory.ts
+++ b/apps/desktop/src/replyHistory.ts
@@ -1,0 +1,54 @@
+import type { MailSummary } from "./types";
+
+type ReplyCitation = {
+  readonly date: string;
+  readonly sender: string;
+};
+
+type ReplyHistoryInput = {
+  readonly message: Pick<
+    MailSummary,
+    "from_address" | "from_name" | "received_at"
+  >;
+  readonly bodyText: string;
+  readonly formatCitation: (citation: ReplyCitation) => string;
+};
+
+export function formatReplyHistory({
+  message,
+  bodyText,
+  formatCitation,
+}: ReplyHistoryInput) {
+  const citation = formatCitation({
+    date: new Date(message.received_at).toLocaleString(),
+    sender: formatSender(message),
+  });
+  const normalizedBody = bodyText.replace(/\r\n?/g, "\n");
+  const quotedBody = normalizedBody.split("\n").map((line) => `> ${line}`);
+
+  return {
+    body: [citation, ...quotedBody].join("\n"),
+    bodyHtml: [
+      "<p><br></p>",
+      `<div class="moz-cite-prefix">${escapeHtml(citation)}</div>`,
+      `<blockquote type="cite">${escapeHtml(normalizedBody).replaceAll("\n", "<br>")}</blockquote>`,
+    ].join(""),
+  };
+}
+
+function formatSender(
+  message: Pick<MailSummary, "from_address" | "from_name">,
+) {
+  return message.from_name
+    ? `${message.from_name} <${message.from_address}>`
+    : message.from_address;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}


### PR DESCRIPTION
## What changed

- Reply and Reply All now hydrate the selected prior message and seed Thunderbird-compatible plain-text and HTML quoted history while preserving recipients and threading headers.
- Compose treats `ComposeSeed.bodyHtml` as untrusted, sanitizing it before the editor first inserts HTML and sending the canonical sanitized value when no edits are made.
- Thunderbird citation markers survive editing, nested plain-text quote depth is retained, and existing generic plus Outlook history handling remains intact.

## Verification

- `npm test -- --maxWorkers=1` - 199 tests passed.
- `npm run typecheck`
- `npm run format:check`
- `npm run build:web`
- `npm run test:release-scripts` - 21 tests passed.
- `npm run test:translation-worker` - 5 language fixtures passed.
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace` - 201 tests passed.
- Browser QA covered Reply, Reply All, quote editing, and content-load failure using the fictional demo mailbox without sending mail.
- The hostile seeded-HTML regression verifies sanitization before initial rendering and unchanged Send.

## Privacy and security

- [x] No credentials, private mail, signing material, or personal data are included.
- [x] New network, file-system, IPC, or HTML-rendering behavior is documented.
- [x] Release publishing and signing remain local and require no CI secrets.

`ComposeSeed.bodyHtml` is passed through the existing allowlist sanitizer before `innerHTML`. Active elements, inline images, event handlers, unsupported attributes, and unsafe URLs are removed while exact Thunderbird `moz-cite-prefix` and `blockquote[type="cite"]` markers remain. This change adds no new network, file-system, release-secret, or external-service behavior.