### PR TITLE
Collapse mixed-provider quoted email history into one disclosure

### DIFF
--- a/apps/desktop/src/components/HtmlMessage.test.tsx
+++ b/apps/desktop/src/components/HtmlMessage.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import appleMailReplySection from "../test/fixtures/apple-mail-reply-section.html?raw";
+import freshdeskReplySection from "../test/fixtures/freshdesk-reply-section.html?raw";
 import outlookWordReplySection from "../test/fixtures/outlook-word-reply-section.html?raw";
 import { buildEmailDocument, HtmlMessage } from "./HtmlMessage";
 
@@ -174,10 +175,45 @@ describe("HTML email appearance", () => {
     ).toBeNull();
   });
 
+  it("recognizes established provider markers without matching lookalike classes", () => {
+    for (const marker of [
+      '<div class="gmail_quote">Old Gmail reply</div>',
+      '<div class="yahoo_quoted">Old Yahoo reply</div>',
+      '<div id="AOLMsgPart_4f8c2d16">Old AOL reply</div>',
+      '<div id="AOLMsgPart_6a3b91e0">Another AOL reply</div>',
+    ]) {
+      const email = buildEmailDocument(`<p>Fresh</p>${marker}`, false);
+      const document = new DOMParser().parseFromString(
+        email.source,
+        "text/html",
+      );
+      expect(
+        document.querySelectorAll("details.dakia-quoted-history"),
+      ).toHaveLength(1);
+    }
+
+    for (const lookalike of [
+      '<div class="gmail_quote_extra">Authored content</div>',
+      '<div class="yahoo_quoted-note">Authored content</div>',
+      '<div id="NotAOLMsgPart_4f8c2d16">Authored content</div>',
+      '<div id="AOLMsgPartialSummary">Authored content</div>',
+      '<div id="AOLMsgPartHeader">Authored content</div>',
+    ]) {
+      const email = buildEmailDocument(`<p>Fresh</p>${lookalike}`, false);
+      const document = new DOMParser().parseFromString(
+        email.source,
+        "text/html",
+      );
+      expect(document.querySelector("details.dakia-quoted-history")).toBeNull();
+      expect(document.body.textContent).toContain("Authored content");
+    }
+  });
+
   it("does not show history for empty or citation-only provider containers", () => {
     for (const html of [
       '<p>Fresh</p><div class="gmail_quote"> \n </div>',
       '<p>Fresh</p><div class="gmail_quote">On 19 Feb 2026 at 21:00 +0200, Romario Verbran &lt;romario@example.com&gt;, wrote:</div>',
+      '<p>Fresh</p><div class="freshdesk_quote"><div class="freshdesk_attr">On 19 Feb 2026 at 21:00 +0200, Romario Verbran &lt;romario@example.com&gt; wrote:</div></div>',
       '<p>Fresh</p><blockquote type="cite">On 19 Feb 2026 at 21:00 +0200, Romario Verbran &lt;romario@example.com&gt;, wrote:</blockquote>',
     ]) {
       const email = buildEmailDocument(html, false);
@@ -187,6 +223,54 @@ describe("HTML email appearance", () => {
       );
       expect(document.querySelector("details.dakia-quoted-history")).toBeNull();
     }
+  });
+
+  it("skips empty provider markers before meaningful quoted history", () => {
+    const email = buildEmailDocument(
+      [
+        "<p>Fresh</p>",
+        '<div class="gmail_quote gmail_quote_container"><div class="gmail_attr"></div></div>',
+        '<div class="yahoo_quoted">Meaningful older reply</div>',
+      ].join(""),
+      false,
+    );
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    const details = document.querySelector("details.dakia-quoted-history");
+
+    expect(details).not.toBeNull();
+    expect(details?.textContent).toContain("Meaningful older reply");
+    expect(
+      document.body.textContent?.replace(details?.textContent ?? "", ""),
+    ).not.toContain("Meaningful older reply");
+  });
+
+  it("collapses adjacent provider markers as one history chain", () => {
+    const email = buildEmailDocument(
+      [
+        "<p>Fresh</p>",
+        '<div class="gmail_quote">On Monday, Pat wrote:</div>',
+        '<div class="freshdesk_quote">First older reply</div>',
+        '<div class="yahoo_quoted">Second older reply</div>',
+        "<p>Authored footer</p>",
+      ].join(""),
+      false,
+    );
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    const disclosures = document.querySelectorAll(
+      "details.dakia-quoted-history",
+    );
+    const details = disclosures[0];
+    const visible =
+      document.body.textContent?.replace(details?.textContent ?? "", "") ?? "";
+
+    expect(disclosures).toHaveLength(1);
+    expect(details?.textContent).toContain("On Monday, Pat wrote:");
+    expect(details?.textContent).toContain("First older reply");
+    expect(details?.textContent).toContain("Second older reply");
+    expect(visible).not.toContain("wrote:");
+    expect(visible).not.toContain("older reply");
+    expect(visible).toContain("Fresh");
+    expect(visible).toContain("Authored footer");
   });
 
   it("moves an adjacent wrote citation into the collapsed history", () => {
@@ -254,6 +338,64 @@ describe("HTML email appearance", () => {
     expect(
       document.body.querySelector(":scope > [name='messageReplySection']"),
     ).toBeNull();
+  });
+
+  it("collapses a Freshdesk mixed-provider quote without hiding the latest reply", () => {
+    const email = buildEmailDocument(freshdeskReplySection, false);
+    const document = new DOMParser().parseFromString(email.source, "text/html");
+    const disclosures = document.querySelectorAll(
+      "details.dakia-quoted-history",
+    );
+
+    expect(disclosures).toHaveLength(1);
+    const details = disclosures[0];
+    expect(details.hasAttribute("open")).toBe(false);
+
+    const visible =
+      document.body.textContent?.replace(details.textContent ?? "", "") ?? "";
+    expect(visible).toContain("Good afternoon, Customer");
+    expect(visible).toContain("Thank you for letting us know.");
+    expect(visible).toContain("Support Agent");
+    expect(visible).not.toContain("Please cancel the earlier request.");
+    expect(visible).not.toContain("Earlier support reply.");
+    expect(visible).not.toContain("Oldest customer request.");
+
+    expect(details.textContent).toContain("Customer <customer@example.test>");
+    expect(details.textContent).toContain("Please cancel the earlier request.");
+    expect(details.textContent).toContain("Earlier support reply.");
+    expect(details.textContent).toContain("Oldest customer request.");
+  });
+
+  it("expands, collapses, and re-expands a Freshdesk quote", () => {
+    render(
+      <HtmlMessage
+        html={freshdeskReplySection}
+        title="Freshdesk history sizing"
+        showHistoryLabel="Show history"
+        hideHistoryLabel="Hide history"
+      />,
+    );
+
+    const message = screen.getByRole("document", {
+      name: "Freshdesk history sizing",
+    });
+    const root = renderedEmailRoot(message);
+    const details = root?.querySelector<HTMLDetailsElement>(
+      "details.dakia-quoted-history",
+    );
+    expect(details).not.toBeNull();
+    if (!details) return;
+
+    expect(details.open).toBe(false);
+    expect(root?.textContent).toContain("Thank you for letting us know.");
+    for (let cycle = 0; cycle < 2; cycle += 1) {
+      fireEvent.click(details.querySelector("summary")!);
+      expect(details.open).toBe(true);
+      expect(details.textContent).toContain("Oldest customer request.");
+
+      fireEvent.click(details.querySelector("summary")!);
+      expect(details.open).toBe(false);
+    }
   });
 
   it("does not show history for an empty Apple Mail reply section", () => {

--- a/apps/desktop/src/components/HtmlMessage.tsx
+++ b/apps/desktop/src/components/HtmlMessage.tsx
@@ -13,6 +13,19 @@ type EmailDocument = {
   dark: boolean;
 };
 
+const providerQuoteSelector = [
+  ".gmail_quote",
+  ".yahoo_quoted",
+  ".freshdesk_quote",
+  "[id^='AOLMsgPart_']",
+].join(", ");
+const recognizedQuoteSelector = [
+  providerQuoteSelector,
+  "[name='messageReplySection']",
+  "blockquote[type='cite']",
+  "[data-marker='__QUOTED_TEXT__']",
+].join(", ");
+
 const blockedElements = [
   "script",
   "iframe",
@@ -181,16 +194,16 @@ function collapseQuotedHistory(
   document: Document,
   labels: { show: string; hide: string },
 ) {
-  const candidate = document.querySelector<HTMLElement>(
+  const candidate =
     [
-      ".gmail_quote",
-      ".yahoo_quoted",
-      "[name='messageReplySection']",
-      "blockquote[type='cite']",
-      "[data-marker='__QUOTED_TEXT__']",
-      "#divRplyFwdMsg",
-    ].join(","),
-  );
+      ...document.querySelectorAll<HTMLElement>(
+        [recognizedQuoteSelector, "#divRplyFwdMsg"].join(","),
+      ),
+    ].find(
+      (element) =>
+        !element.closest("details.dakia-quoted-history") &&
+        hasMeaningfulQuotedContent(element),
+    ) ?? null;
   const outlookHeader = findOutlookReplyHeader(document);
   let outlookBoundary: HTMLElement | null = null;
   if (
@@ -204,11 +217,7 @@ function collapseQuotedHistory(
     const boundary = outlookQuoteBoundary(outlookHeader);
     if (!hasMeaningfulFollowingContent(boundary)) return;
     outlookBoundary = boundary;
-  } else if (
-    !candidate ||
-    candidate.closest("details.dakia-quoted-history") ||
-    !hasMeaningfulQuotedContent(candidate)
-  ) {
+  } else if (!candidate || candidate.closest("details.dakia-quoted-history")) {
     return;
   }
 
@@ -265,7 +274,7 @@ function collapseQuotedHistory(
     let node = candidate.nextElementSibling;
     while (
       node?.matches(
-        "blockquote, .gmail_quote, .yahoo_quoted, [data-marker='__QUOTED_TEXT__']",
+        `blockquote, ${providerQuoteSelector}, [data-marker='__QUOTED_TEXT__']`,
       )
     ) {
       nodes.push(node);
@@ -274,12 +283,45 @@ function collapseQuotedHistory(
     candidate.before(details);
     nodes.forEach((item) => content.append(item));
   } else if (candidate) {
-    const citation = precedingCitation(candidate);
-    candidate.before(details);
+    const nodes = contiguousQuotedNodes(candidate);
+    const citation = precedingCitation(nodes[0] as HTMLElement);
+    nodes[0].before(details);
     if (citation) content.append(citation);
-    content.append(candidate);
+    nodes.forEach((node) => content.append(node));
   }
   details.append(summary, content);
+}
+
+function contiguousQuotedNodes(candidate: HTMLElement) {
+  const nodes: ChildNode[] = [candidate];
+  let previous = candidate.previousSibling;
+  while (previous) {
+    if (
+      (previous.nodeType === Node.TEXT_NODE && !previous.textContent?.trim()) ||
+      (previous.nodeType === Node.ELEMENT_NODE &&
+        (previous as Element).matches(recognizedQuoteSelector))
+    ) {
+      nodes.unshift(previous);
+      previous = previous.previousSibling;
+      continue;
+    }
+    break;
+  }
+
+  let next = candidate.nextSibling;
+  while (next) {
+    if (
+      (next.nodeType === Node.TEXT_NODE && !next.textContent?.trim()) ||
+      (next.nodeType === Node.ELEMENT_NODE &&
+        (next as Element).matches(recognizedQuoteSelector))
+    ) {
+      nodes.push(next);
+      next = next.nextSibling;
+      continue;
+    }
+    break;
+  }
+  return nodes;
 }
 
 // Word-generated Outlook desktop replies mark the start of quoted history
@@ -338,13 +380,13 @@ function hasMeaningfulQuotedContent(candidate: HTMLElement) {
   if (candidate.id === "divRplyFwdMsg") {
     return Boolean(
       candidate.nextElementSibling?.matches(
-        "blockquote, .gmail_quote, .yahoo_quoted, [data-marker='__QUOTED_TEXT__']",
+        `blockquote, ${providerQuoteSelector}, [data-marker='__QUOTED_TEXT__']`,
       ),
     );
   }
-  if (candidate.matches(".gmail_quote, .yahoo_quoted")) {
+  if (candidate.matches(providerQuoteSelector)) {
     const quote = candidate.querySelector(
-      "blockquote, [type='cite'], .gmail_quote, .yahoo_quoted",
+      `blockquote, [type='cite'], ${providerQuoteSelector}`,
     );
     if (quote && quote !== candidate && quote.textContent?.trim()) return true;
     return !isCitationLine(text);

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -3,6 +3,7 @@ import { MantineProvider } from "@mantine/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "../i18n";
 import { api } from "../api";
+import freshdeskReplySection from "../test/fixtures/freshdesk-reply-section.html?raw";
 import type { MailSummary } from "../types";
 import { Reader } from "./Reader";
 
@@ -269,6 +270,71 @@ describe("Reader unsubscribe action", () => {
     fireEvent.click(screen.getByText("Show history"));
     expect(details).toHaveAttribute("open");
     expect(screen.getByText(/On Monday, Pat wrote/)).toBeVisible();
+  });
+
+  it("collapses Freshdesk history in the latest message of a thread", async () => {
+    const older = {
+      ...message,
+      id: "message-older",
+      received_at: "2026-07-19T09:00:00Z",
+      subject: "Earlier reply",
+    };
+    const latest = {
+      ...message,
+      id: "message-latest",
+      received_at: "2026-07-19T10:00:00Z",
+      subject: "Latest Freshdesk reply",
+    };
+    vi.mocked(api.content).mockImplementation(async (messageId) =>
+      messageId === latest.id
+        ? {
+            body_text: "Latest fallback",
+            body_html: freshdeskReplySection,
+            attachments: [],
+          }
+        : {
+            body_text: "Earlier message remains independently visible.",
+            attachments: [],
+          },
+    );
+
+    render(
+      <MantineProvider>
+        <Reader {...props} message={latest} messages={[older, latest]} />
+      </MantineProvider>,
+    );
+
+    expect(
+      await screen.findByText("Earlier message remains independently visible."),
+    ).toBeVisible();
+    const latestMessage = await screen.findByRole("document", {
+      name: "Latest Freshdesk reply",
+    });
+    const surface = latestMessage.shadowRoot
+      ?.firstElementChild as HTMLElement | null;
+    const root = surface?.shadowRoot;
+    const details = root?.querySelector<HTMLDetailsElement>(
+      "details.dakia-quoted-history",
+    );
+
+    expect(details).not.toBeNull();
+    if (!details) return;
+    const visible = root?.textContent?.replace(details.textContent ?? "", "");
+    expect(visible).toContain("Good afternoon, Customer");
+    expect(visible).toContain("Thank you for letting us know.");
+    expect(visible).not.toContain("Earlier support reply.");
+    expect(details.open).toBe(false);
+
+    for (let cycle = 0; cycle < 2; cycle += 1) {
+      fireEvent.click(details.querySelector("summary")!);
+      expect(details.open).toBe(true);
+      expect(details.textContent).toContain("Earlier support reply.");
+
+      fireEvent.click(details.querySelector("summary")!);
+      expect(details.open).toBe(false);
+    }
+    expect(api.content).toHaveBeenCalledWith("message-older");
+    expect(api.content).toHaveBeenCalledWith("message-latest");
   });
 
   it("runs delete from the reader toolbar", () => {

--- a/apps/desktop/src/test/fixtures/freshdesk-reply-section.html
+++ b/apps/desktop/src/test/fixtures/freshdesk-reply-section.html
@@ -1,0 +1,113 @@
+<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+<div
+  style="
+    font-family:
+      -apple-system,
+      BlinkMacSystemFont,
+      Segoe UI,
+      Roboto,
+      Helvetica Neue,
+      Arial,
+      sans-serif;
+    font-size: 14px;
+  "
+>
+  <div
+    style="
+      font-family:
+        -apple-system,
+        BlinkMacSystemFont,
+        Segoe UI,
+        Roboto,
+        Helvetica Neue,
+        Arial,
+        sans-serif;
+      font-size: 14px;
+    "
+  >
+    <div dir="ltr">
+      <div>Good afternoon, Customer,</div>
+      <div><br /></div>
+      <div>Thank you for letting us know.</div>
+      <div><br /></div>
+      <div>We confirm that your service request has been canceled.</div>
+      <div dir="ltr"><br /></div>
+      <div dir="ltr"><br /></div>
+      &nbsp;
+    </div>
+    <div data-skip-ai-process="">
+      <div
+        style="
+          font-family: Arial, sans-serif;
+          font-size: 14px;
+          color: #242424;
+          line-height: 1.6;
+        "
+      >
+        <div>Kind regards!</div>
+        <div><strong>Support Agent</strong></div>
+        <div>Customer service</div>
+        <div>
+          <a href="mailto:support@example.test" rel="noreferrer"
+            >support@example.test</a
+          >
+        </div>
+      </div>
+    </div>
+    <div class="freshdesk_quote">
+      <div class="freshdesk_attr">
+        On Tue, 23 Jun at 2:35 PM
+        <span class="separator"
+          >, Customer &lt;customer@example.test&gt; wrote:</span
+        >
+      </div>
+      <blockquote
+        class="freshdesk_quote"
+        style="
+          margin: 0 0 0 0.8ex;
+          border-left: 1px solid #ccc;
+          padding-left: 1ex;
+        "
+      >
+        <div dir="ltr">
+          Please cancel the earlier request.<br /><br />
+          Best regards,<br /><br />
+          Customer<br /><br />
+        </div>
+        <br />
+        <div class="gmail_quote gmail_quote_container">
+          <div dir="ltr" class="gmail_attr"></div>
+        </div>
+        <div class="freshdesk_quote">
+          <blockquote class="freshdesk_quote">
+            <div>
+              On Tue, Jun 23, 2026 at 11:00 AM Support Agent &lt;<a
+                href="mailto:support@example.test"
+                rel="noreferrer"
+                >support@example.test</a
+              >&gt; wrote:<br />
+            </div>
+            <blockquote
+              class="gmail_quote"
+              style="
+                margin: 0 0 0 0.8ex;
+                border-left: 1px solid #ccc;
+                padding-left: 1ex;
+              "
+            >
+              <div>Earlier support reply.</div>
+              <div class="freshdesk_quote">
+                <div class="freshdesk_attr">
+                  On Mon, 22 Jun at 8:20 PM, Customer wrote:
+                </div>
+                <blockquote class="freshdesk_quote">
+                  <div>Oldest customer request.</div>
+                </blockquote>
+              </div>
+            </blockquote>
+          </blockquote>
+        </div>
+      </blockquote>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Recognize Freshdesk and AOL quote markers alongside existing providers.
- Collapse adjacent and nested provider quote sections into a single history disclosure.
- Ignore empty markers and lookalike classes while preserving the latest authored message.
- Add a redacted Freshdesk fixture and Reader/HTML message regression coverage.

## Testing

- Added component tests for provider detection, adjacent quote chaining, empty markers, and repeated expand/collapse cycles.
- Added Reader integration coverage verifying the latest thread message collapses history independently.