### PR TITLE
Focus the newest message when opening email threads

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -25,6 +25,12 @@ const mocks = vi.hoisted(() => {
   > = [];
   const hydratedHandlers: Array<() => void> = [];
   const nativeMenuHandlers: Array<(action: string) => void> = [];
+  const notificationActionHandlers: Array<
+    (extra: Record<string, unknown>) => void | Promise<void>
+  > = [];
+  const desktopNotificationActionHandlers: Array<
+    (extra: Record<string, unknown>) => void | Promise<void>
+  > = [];
   const accountRemovedHandlers: Array<(event: { accountId: string }) => void> =
     [];
   const accountUpdatedHandlers: Array<(account: Account) => void> = [];
@@ -70,10 +76,14 @@ const mocks = vi.hoisted(() => {
       accounts: vi.fn(async () => [account]),
       classifyPending: vi.fn(async () => 0),
       configureTray: vi.fn(async () => undefined),
-      content: vi.fn(async (): Promise<import("./types").MessageContent> => ({
-        body_text: "Message body",
-        attachments: [],
-      })),
+      content: vi.fn(
+        async (
+          _messageId: string,
+        ): Promise<import("./types").MessageContent> => ({
+          body_text: "Message body",
+          attachments: [],
+        }),
+      ),
       mailRebuildStatus: vi.fn(async () => []),
       recordNotificationDelivered: vi.fn(async () => undefined),
       search: vi.fn(async () => ({
@@ -82,6 +92,7 @@ const mocks = vi.hoisted(() => {
       })),
       searchRemote: vi.fn(async () => []),
       setRead: vi.fn(async () => undefined),
+      setStarred: vi.fn(async () => undefined),
       starredCount: vi.fn(async () => 0),
       startRealtimeSync: vi.fn(async () => undefined),
       sync: vi.fn(async () => ({ syncedCount: 0, newMessages: [] })),
@@ -122,6 +133,24 @@ const mocks = vi.hoisted(() => {
     rebuildProgressHandlers,
     hydratedHandlers,
     nativeMenuHandlers,
+    notificationActionHandlers,
+    desktopNotificationActionHandlers,
+    onNotificationAction: vi.fn(
+      async (
+        handler: (extra: Record<string, unknown>) => void | Promise<void>,
+      ) => {
+        notificationActionHandlers.push(handler);
+        return unlisten;
+      },
+    ),
+    onDesktopNotificationAction: vi.fn(
+      async (
+        handler: (extra: Record<string, unknown>) => void | Promise<void>,
+      ) => {
+        desktopNotificationActionHandlers.push(handler);
+        return unlisten;
+      },
+    ),
     onMailRebuildProgress: vi.fn(
       async (handler: (progress: MailRebuildProgress) => void) => {
         rebuildProgressHandlers.push(handler);
@@ -157,7 +186,7 @@ vi.mock("./nativeFeedback", () => ({
 }));
 
 vi.mock("./notifications", () => ({
-  onNotificationAction: mocks.noopListener,
+  onNotificationAction: mocks.onNotificationAction,
   readNotificationSettings: () => ({
     enabled: true,
     soundEnabled: true,
@@ -176,7 +205,7 @@ vi.mock("./nativeWindows", () => ({
   onMailIndexRebuilt: mocks.noopListener,
   onMailRebuildProgress: mocks.onMailRebuildProgress,
   onMailSyncState: mocks.noopListener,
-  onDesktopNotificationAction: mocks.noopListener,
+  onDesktopNotificationAction: mocks.onDesktopNotificationAction,
   onNativeMenuAction: mocks.onNativeMenuAction,
   onNotificationSettingsChanged: mocks.noopListener,
   onSettingsChanged: mocks.noopListener,
@@ -197,6 +226,8 @@ describe("App read state", () => {
     mocks.rebuildProgressHandlers.length = 0;
     mocks.hydratedHandlers.length = 0;
     mocks.nativeMenuHandlers.length = 0;
+    mocks.notificationActionHandlers.length = 0;
+    mocks.desktopNotificationActionHandlers.length = 0;
     mocks.accountRemovedHandlers.length = 0;
     mocks.accountUpdatedHandlers.length = 0;
     localStorage.clear();
@@ -293,6 +324,102 @@ describe("App read state", () => {
 
     await waitFor(() =>
       expect(mocks.api.setRead).toHaveBeenCalledWith("message-1", true),
+    );
+  });
+
+  it("opens a conversation with its newest message focused", async () => {
+    const older = {
+      ...mocks.message,
+      id: "message-older",
+      uid: 1,
+      received_at: "2026-07-19T09:00:00Z",
+      snippet: "Earlier preview",
+    };
+    const latest = {
+      ...mocks.message,
+      id: "message-latest",
+      uid: 2,
+      received_at: "2026-07-19T10:00:00Z",
+      snippet: "Newest preview",
+    };
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages([latest, older]),
+      nextCursor: null,
+    });
+    mocks.api.content.mockImplementation(async (id: string) => ({
+      body_text: id === latest.id ? "Newest body" : "Earlier body",
+      attachments: [],
+    }));
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const row = await screen.findByText("Unread thread");
+    fireEvent.click(row.closest("button")!);
+
+    expect(await screen.findByText("Newest body")).toBeVisible();
+    expect(mocks.api.content).toHaveBeenCalledWith(latest.id);
+    expect(mocks.api.content).not.toHaveBeenCalledWith(older.id);
+  });
+
+  it("focuses the newest thread message when an older notification is opened", async () => {
+    const older = {
+      ...mocks.message,
+      id: "message-notified",
+      uid: 1,
+      received_at: "2026-07-19T09:00:00Z",
+      snippet: "Notified preview",
+    };
+    const latest = {
+      ...mocks.message,
+      id: "message-after-notification",
+      uid: 2,
+      received_at: "2026-07-19T10:00:00Z",
+      snippet: "Newest preview",
+      unsubscribe_kind: "one_click" as const,
+    };
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages([latest, older]),
+      nextCursor: null,
+    });
+    mocks.api.content.mockImplementation(async (id: string) => ({
+      body_text: id === latest.id ? "Newest notification body" : "Older body",
+      attachments: [],
+    }));
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mocks.notificationActionHandlers).not.toHaveLength(0),
+    );
+    await act(async () => {
+      await mocks.notificationActionHandlers.at(-1)!({
+        accountId: mocks.account.id,
+        messageId: older.id,
+      });
+    });
+
+    expect(await screen.findByText("Newest notification body")).toBeVisible();
+    expect(mocks.api.content).toHaveBeenCalledWith(latest.id);
+    expect(mocks.api.content).not.toHaveBeenCalledWith(older.id);
+    fireEvent.click(
+      screen
+        .getAllByRole("button", { name: "Star conversation" })
+        .find((element) => element.tagName === "BUTTON")!,
+    );
+    await waitFor(() =>
+      expect(mocks.api.setStarred).toHaveBeenCalledWith(latest.id, true),
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Unsubscribe" }));
+    await waitFor(() =>
+      expect(mocks.api.unsubscribe).toHaveBeenCalledWith(latest.id),
     );
   });
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1012,10 +1012,7 @@ export default function App() {
       const clickedThread = inbox.conversations.find((thread) =>
         thread.messages.some((message) => message.id === messageId),
       );
-      const clickedMessage = clickedThread?.messages.find(
-        (message) => message.id === messageId,
-      );
-      setActive(clickedMessage);
+      setActive(clickedThread?.latest);
       setActiveThreadSnapshot(clickedThread);
       if (clickedThread) {
         void setThreadReadState(clickedThread, true, { silent: true });
@@ -1551,11 +1548,11 @@ export default function App() {
     }
     if (smartInboxActive) await loadMessages();
   };
-  const unsubscribe = async () => {
-    if (!active || unsubscribeLoading) return;
+  const unsubscribe = async (message: MailSummary) => {
+    if (unsubscribeLoading) return;
     setUnsubscribeLoading(true);
     try {
-      const result = await api.unsubscribe(active.id);
+      const result = await api.unsubscribe(message.id);
       if (result.kind === "opened_web") {
         showStatus(t("feedback.unsubscribeWeb"));
       } else {
@@ -2032,7 +2029,7 @@ export default function App() {
             )
         }
         unsubscribeLoading={unsubscribeLoading}
-        onUnsubscribe={() => void unsubscribe()}
+        onUnsubscribe={(message) => void unsubscribe(message)}
         onToggleStar={(message, starred) => void toggleStar(message, starred)}
       />
       {actionStatus ? (

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -131,7 +131,7 @@ describe("Reader unsubscribe action", () => {
   });
 
   it("disables unsubscribe while the request is in progress", () => {
-    render(
+    const { rerender } = render(
       <MantineProvider>
         <Reader
           {...props}
@@ -205,6 +205,291 @@ describe("Reader unsubscribe action", () => {
     fireEvent.click(screen.getByRole("button", { name: "Quick reply" }));
     expect(props.onReply).toHaveBeenCalledOnce();
     expect(props.onReply.mock.calls[0]).toEqual([]);
+  });
+
+  it("opens a conversation on its final message and fetches earlier messages only when expanded", async () => {
+    const earliest = {
+      ...message,
+      id: "message-0",
+      uid: 0,
+      from_name: "Earlier Sender",
+      received_at: "2026-07-19T08:00:00Z",
+      snippet: "Earlier preview",
+      has_attachments: true,
+    };
+    const middle = {
+      ...message,
+      id: "message-middle",
+      uid: 2,
+      from_name: "Middle Sender",
+      received_at: "2026-07-19T09:00:00Z",
+      snippet: "Middle preview",
+    };
+    const latest = {
+      ...message,
+      id: "message-latest",
+      uid: 3,
+      from_name: "Latest Sender",
+      received_at: "2026-07-19T11:00:00Z",
+      snippet: "Latest preview",
+      unsubscribe_kind: "one_click" as const,
+    };
+    vi.mocked(api.content).mockImplementation(async (id) => ({
+      body_text:
+        id === earliest.id
+          ? "Earlier full body"
+          : id === middle.id
+            ? "Middle full body"
+            : "Latest full body",
+      attachments: [],
+    }));
+
+    const { rerender } = render(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={earliest}
+          messages={[earliest, middle, latest]}
+        />
+      </MantineProvider>,
+    );
+
+    const earliestDisclosure = screen.getByRole("button", {
+      name: "Expand message from Earlier Sender",
+    });
+    expect(earliestDisclosure).toHaveAttribute("aria-expanded", "false");
+    expect(earliestDisclosure).toHaveAccessibleDescription(
+      /Earlier preview.*19 Jul at.*Has attachments/,
+    );
+    expect(screen.getByText("Earlier preview")).toBeVisible();
+    expect(screen.getByText("Middle preview")).toBeVisible();
+    expect(screen.getByLabelText("Has attachments")).toBeVisible();
+    expect(
+      screen.getByRole("button", {
+        name: "Collapse message from Latest Sender",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(await screen.findByText("Latest full body")).toBeVisible();
+    expect(api.content).toHaveBeenCalledTimes(1);
+    expect(api.content).toHaveBeenCalledWith(latest.id);
+
+    fireEvent.click(earliestDisclosure);
+    expect(await screen.findByText("Earlier full body")).toBeVisible();
+    expect(screen.queryByText("Latest full body")).not.toBeInTheDocument();
+    expect(api.content).toHaveBeenCalledTimes(2);
+    expect(api.content).toHaveBeenCalledWith(earliest.id);
+    expect(api.content).not.toHaveBeenCalledWith(middle.id);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Collapse message from Earlier Sender",
+      }),
+    );
+    expect(screen.queryByText("Earlier full body")).not.toBeInTheDocument();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand message from Earlier Sender",
+      }),
+    );
+    expect(await screen.findByText("Earlier full body")).toBeVisible();
+    expect(api.content).toHaveBeenCalledTimes(2);
+
+    rerender(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={earliest}
+          messages={[
+            { ...earliest, snippet: "Updated earlier preview" },
+            middle,
+            latest,
+          ]}
+        />
+      </MantineProvider>,
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Collapse message from Earlier Sender",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand message from Latest Sender",
+      }),
+    );
+    expect(await screen.findByText("Latest full body")).toBeVisible();
+    expect(screen.getByRole("button", { name: "Quick reply" })).toBeVisible();
+    expect(screen.getByRole("button", { name: "Unsubscribe" })).toBeVisible();
+    fireEvent.click(screen.getByRole("button", { name: "Unsubscribe" }));
+    expect(props.onUnsubscribe).toHaveBeenCalledWith(latest);
+    expect(api.content).toHaveBeenCalledTimes(2);
+    fireEvent.click(screen.getByText("Latest Sender"));
+    expect(screen.queryByText("Latest full body")).not.toBeInTheDocument();
+    expect(
+      screen.getByRole("button", {
+        name: "Expand message from Latest Sender",
+      }),
+    ).toHaveAttribute("aria-expanded", "false");
+
+    const nextEarlier = {
+      ...earliest,
+      id: "message-next-earlier",
+      thread_id: "thread-next",
+      from_name: "Next earlier sender",
+    };
+    const nextLatest = {
+      ...latest,
+      id: "message-next-latest",
+      thread_id: "thread-next",
+      from_name: "Next latest sender",
+    };
+    rerender(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={nextEarlier}
+          messages={[nextEarlier, nextLatest]}
+        />
+      </MantineProvider>,
+    );
+    expect(
+      screen.getByRole("button", {
+        name: "Expand message from Next earlier sender",
+      }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(await screen.findByText("Latest full body")).toBeVisible();
+    expect(api.content).toHaveBeenCalledTimes(3);
+    expect(api.content).toHaveBeenLastCalledWith(nextLatest.id);
+  });
+
+  it("keeps the selected expanded message open when a newer message arrives", async () => {
+    const earlier = {
+      ...message,
+      id: "message-earlier",
+      from_name: "Earlier Sender",
+    };
+    const latest = {
+      ...message,
+      id: "message-latest",
+      from_name: "Latest Sender",
+    };
+    const newer = {
+      ...message,
+      id: "message-newer",
+      from_name: "Newer Sender",
+    };
+    vi.mocked(api.content).mockResolvedValue({
+      body_text: "Full message body",
+      attachments: [],
+    });
+
+    const { rerender } = render(
+      <MantineProvider>
+        <Reader {...props} message={earlier} messages={[earlier, latest]} />
+      </MantineProvider>,
+    );
+    await screen.findByText("Full message body");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand message from Earlier Sender",
+      }),
+    );
+    await screen.findByText("Full message body");
+
+    rerender(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={earlier}
+          messages={[earlier, latest, newer]}
+        />
+      </MantineProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Collapse message from Earlier Sender",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", {
+        name: "Expand message from Newer Sender",
+      }),
+    ).toHaveAttribute("aria-expanded", "false");
+    expect(api.content).toHaveBeenCalledTimes(2);
+    expect(api.content).not.toHaveBeenCalledWith(newer.id);
+  });
+
+  it("resets expanded state for the same thread ID in another account", async () => {
+    const firstAccountEarlier = {
+      ...message,
+      id: "account-one-earlier",
+      account_id: "account-one",
+      from_name: "First account earlier",
+    };
+    const firstAccountLatest = {
+      ...message,
+      id: "account-one-latest",
+      account_id: "account-one",
+      from_name: "First account latest",
+    };
+    const secondAccountEarlier = {
+      ...message,
+      id: "account-two-earlier",
+      account_id: "account-two",
+      from_name: "Second account earlier",
+    };
+    const secondAccountLatest = {
+      ...message,
+      id: "account-two-latest",
+      account_id: "account-two",
+      from_name: "Second account latest",
+    };
+    vi.mocked(api.content).mockResolvedValue({
+      body_text: "Account-scoped body",
+      attachments: [],
+    });
+
+    const { rerender } = render(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={firstAccountLatest}
+          messages={[firstAccountEarlier, firstAccountLatest]}
+        />
+      </MantineProvider>,
+    );
+    await screen.findByText("Account-scoped body");
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand message from First account earlier",
+      }),
+    );
+
+    rerender(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={secondAccountLatest}
+          messages={[secondAccountEarlier, secondAccountLatest]}
+        />
+      </MantineProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Collapse message from Second account latest",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", {
+        name: "Expand message from Second account earlier",
+      }),
+    ).toHaveAttribute("aria-expanded", "false");
+    await waitFor(() =>
+      expect(api.content).toHaveBeenCalledWith(secondAccountLatest.id),
+    );
   });
 
   it("expands complete recipient details without inventing missing rows", () => {
@@ -440,6 +725,7 @@ describe("Reader unsubscribe action", () => {
       ...message,
       id: "message-0",
       uid: 0,
+      from_name: "Earlier Sender",
       body_text: "Varasem kiri",
     };
     vi.mocked(api.content).mockImplementation(async (id) => ({
@@ -456,8 +742,7 @@ describe("Reader unsubscribe action", () => {
       screen.getByRole("button", { name: "Translate to English" }),
     );
 
-    expect(await screen.findByText("EN: Esimene kiri")).toBeVisible();
-    expect(screen.getByText("EN: Teine kiri")).toBeVisible();
+    expect(await screen.findByText("EN: Teine kiri")).toBeVisible();
     expect(api.content).toHaveBeenCalledTimes(2);
     expect(api.content).toHaveBeenCalledWith("message-0");
     expect(api.content).toHaveBeenCalledWith("message-1");
@@ -471,6 +756,12 @@ describe("Reader unsubscribe action", () => {
       "Teine kiri",
       false,
     );
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Expand message from Earlier Sender",
+      }),
+    );
+    expect(await screen.findByText("EN: Esimene kiri")).toBeVisible();
   });
 
   it("translates HTML as HTML and renders it through the sanitized shadow tree", async () => {

--- a/apps/desktop/src/components/Reader.tsx
+++ b/apps/desktop/src/components/Reader.tsx
@@ -29,7 +29,14 @@ import {
 } from "@tabler/icons-react";
 import { AI_FEATURES_VISIBLE } from "../features";
 import { format } from "date-fns";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { useTranslation } from "react-i18next";
 import { api } from "../api";
 import { confirmNativeAction } from "../nativeFeedback";
@@ -62,7 +69,7 @@ type Props = {
   onSummarize: () => void;
   onCopyAi: () => void;
   unsubscribeLoading: boolean;
-  onUnsubscribe: () => void;
+  onUnsubscribe: (message: MailSummary) => void;
   onToggleStar: (message: MailSummary, starred: boolean) => void;
 };
 
@@ -106,9 +113,33 @@ export function Reader({
     () => (messages?.length ? messages : message ? [message] : []),
     [message, messages],
   );
+  const latestMessage = threadMessages.at(-1);
+  const threadKey = latestMessage
+    ? `${latestMessage.account_id}:${latestMessage.thread_id || latestMessage.id}`
+    : message
+      ? `${message.account_id}:${message.thread_id || message.id}`
+      : undefined;
+  const [expandedMessage, setExpandedMessage] = useState<{
+    threadKey?: string;
+    id?: string;
+  }>(() => ({ threadKey, id: latestMessage?.id }));
+  // Render the final chronological message immediately when a new conversation
+  // arrives. Keeping the chosen ID in state means later mailbox updates do not
+  // interrupt someone reading an earlier message.
+  const expandedMessageId =
+    expandedMessage?.threadKey === threadKey
+      ? expandedMessage?.id
+      : latestMessage?.id;
+  useEffect(() => {
+    setExpandedMessage((current) =>
+      current.threadKey === threadKey
+        ? current
+        : { threadKey, id: latestMessage?.id },
+    );
+  }, [threadKey]);
   const contentRequests = useMemo(
     () => new Map<string, Promise<MessageContent>>(),
-    [message?.thread_id],
+    [threadKey],
   );
   const loadContent = useCallback(
     (messageId: string) => {
@@ -131,6 +162,16 @@ export function Reader({
     setTranslationError(undefined);
     setTranslationProgress(undefined);
   }, [message?.thread_id, message?.id]);
+
+  const toggleExpandedMessage = useCallback(
+    (messageId: string) => {
+      setExpandedMessage({
+        threadKey,
+        id: expandedMessageId === messageId ? undefined : messageId,
+      });
+    },
+    [expandedMessageId, threadKey],
+  );
 
   if (!message)
     return (
@@ -387,7 +428,9 @@ export function Reader({
               threadMessage.from_address.toLowerCase() ===
                 accountEmail?.toLowerCase()
             }
-            isLatest={threadMessage.id === message.id}
+            isLatest={threadMessage.id === latestMessage?.id}
+            isExpanded={threadMessage.id === expandedMessageId}
+            onToggleExpanded={() => toggleExpandedMessage(threadMessage.id)}
             actionsDisabled={actionsDisabled}
             onArchive={onArchive}
             onSpam={onSpam}
@@ -412,6 +455,8 @@ function ThreadMessage({
   message,
   isSent,
   isLatest,
+  isExpanded,
+  onToggleExpanded,
   actionsDisabled,
   onArchive,
   onSpam,
@@ -429,6 +474,8 @@ function ThreadMessage({
   message: MailSummary;
   isSent: boolean;
   isLatest: boolean;
+  isExpanded: boolean;
+  onToggleExpanded: () => void;
   actionsDisabled: boolean;
   onArchive: () => void;
   onSpam: () => void;
@@ -439,7 +486,7 @@ function ThreadMessage({
   threadUnread: boolean;
   onToggleRead: (read: boolean) => void;
   unsubscribeLoading: boolean;
-  onUnsubscribe: () => void;
+  onUnsubscribe: (message: MailSummary) => void;
   translatedContent?: MessageContent;
   loadContent: (messageId: string) => Promise<MessageContent>;
 }) {
@@ -454,11 +501,13 @@ function ThreadMessage({
   const [saveStatus, setSaveStatus] = useState<string>();
   const [hydrationRequested, setHydrationRequested] = useState(false);
   const [recipientsExpanded, setRecipientsExpanded] = useState(false);
+  const summaryDescriptionId = useId();
   const displayContent = translatedContent ?? content;
   const recipients = useMemo(() => messageRecipients(message), [message]);
 
   useEffect(() => {
     if (
+      !isExpanded ||
       !message.content_state ||
       message.content_state === "complete" ||
       message.content_state === "hydrating" ||
@@ -467,11 +516,11 @@ function ThreadMessage({
       return;
     setHydrationRequested(true);
     void api.hydrateMessage(message.id).catch(() => undefined);
-  }, [hydrationRequested, message.content_state, message.id]);
+  }, [hydrationRequested, isExpanded, message.content_state, message.id]);
 
   useEffect(() => {
+    if (!isExpanded) return;
     let current = true;
-    setContent(undefined);
     setContentError(false);
     setLoadingContent(true);
     setLoadingAttachments(true);
@@ -492,7 +541,7 @@ function ThreadMessage({
     return () => {
       current = false;
     };
-  }, [contentAttempt, loadContent, message.id]);
+  }, [contentAttempt, isExpanded, loadContent, message.id]);
 
   const saveOne = async (attachment: Attachment) => {
     if (saving) return;
@@ -519,14 +568,84 @@ function ThreadMessage({
     }
   };
 
+  if (!isExpanded) {
+    return (
+      <section
+        className="thread-message thread-message-collapsed"
+        aria-label={t("reader.messageFrom", {
+          sender: message.from_name || message.from_address,
+        })}
+      >
+        <button
+          type="button"
+          className="thread-message-summary"
+          aria-expanded="false"
+          aria-label={t("reader.expandMessage", {
+            sender: message.from_name || message.from_address,
+          })}
+          aria-describedby={summaryDescriptionId}
+          onClick={onToggleExpanded}
+        >
+          <Avatar
+            className="sender-avatar thread-message-summary-avatar"
+            color="ember"
+            radius="md"
+            aria-hidden="true"
+          >
+            {(message.from_name || message.from_address)[0]?.toUpperCase()}
+          </Avatar>
+          <span className="thread-message-summary-meta">
+            <span className="thread-message-summary-sender">
+              {message.from_name || message.from_address}
+              {isSent ? (
+                <span className="sent-by-you">{t("reader.sentByYou")}</span>
+              ) : null}
+            </span>
+            <span className="thread-message-summary-snippet">
+              {message.snippet}
+            </span>
+            <span className="reader-visually-hidden" id={summaryDescriptionId}>
+              {message.snippet}.{" "}
+              {format(new Date(message.received_at), "EEEE d MMM 'at' HH:mm")}
+              {message.has_attachments ? `. ${t("inbox.attachment")}` : ""}
+            </span>
+          </span>
+          {message.has_attachments ? (
+            <span
+              className="thread-message-summary-attachment"
+              role="img"
+              aria-label={t("inbox.attachment")}
+            >
+              <IconPaperclip size={16} aria-hidden="true" />
+            </span>
+          ) : null}
+          <time className="reader-date">
+            {format(new Date(message.received_at), "EEEE d MMM 'at' HH:mm")}
+          </time>
+        </button>
+      </section>
+    );
+  }
+
   return (
     <section
-      className="thread-message"
+      className="thread-message thread-message-expanded"
       aria-label={t("reader.messageFrom", {
         sender: message.from_name || message.from_address,
       })}
     >
-      <div className="sender-card" data-sent={isSent}>
+      <div
+        className="sender-card sender-card-collapsible"
+        data-sent={isSent}
+        onClick={(event) => {
+          if (
+            event.target instanceof Element &&
+            event.target.closest("button, a, [role='menuitem']")
+          )
+            return;
+          onToggleExpanded();
+        }}
+      >
         <Avatar className="sender-avatar" color="ember" radius="md">
           {(message.from_name || message.from_address)[0]?.toUpperCase()}
         </Avatar>
@@ -580,7 +699,7 @@ function ThreadMessage({
               color="gray"
               size="compact-xs"
               loading={unsubscribeLoading}
-              onClick={onUnsubscribe}
+              onClick={() => onUnsubscribe(message)}
             >
               {t("actions.unsubscribe")}
             </Button>
@@ -660,6 +779,24 @@ function ThreadMessage({
             </Menu.Item>
           </Menu.Dropdown>
         </Menu>
+        <Tooltip
+          label={t("reader.collapseMessage", {
+            sender: message.from_name || message.from_address,
+          })}
+        >
+          <ActionIcon
+            className="reader-header-action"
+            variant="subtle"
+            color="gray"
+            aria-expanded="true"
+            aria-label={t("reader.collapseMessage", {
+              sender: message.from_name || message.from_address,
+            })}
+            onClick={onToggleExpanded}
+          >
+            <IconChevronDown size={19} stroke={1.9} />
+          </ActionIcon>
+        </Tooltip>
       </div>
       {loadingContent ? (
         <div className="message-body" role="status">

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -122,6 +122,8 @@ export const en = {
       showHistory: "Show history",
       hideHistory: "Hide history",
       messageFrom: "Message from {{sender}}",
+      expandMessage: "Expand message from {{sender}}",
+      collapseMessage: "Collapse message from {{sender}}",
       sentByYou: "Sent by you",
       originalMessage: "Original message",
       translation: "English translation",

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -846,6 +846,9 @@ textarea {
   gap: 9px;
   margin-bottom: 18px;
 }
+.sender-card-collapsible {
+  cursor: pointer;
+}
 .thread-message {
   padding: 18px 0 24px;
   border-top: 1px solid var(--dakia-divider);
@@ -853,6 +856,69 @@ textarea {
 .thread-message:first-of-type {
   border-top: 0;
   padding-top: 0;
+}
+.thread-message-collapsed {
+  padding: 0;
+}
+.thread-message-summary {
+  width: 100%;
+  padding: 14px 0;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  border: 0;
+  color: inherit;
+  background: transparent;
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.thread-message-summary:hover,
+.thread-message-summary:focus-visible {
+  background: color-mix(in srgb, var(--mantine-color-gray-1) 58%, transparent);
+}
+.thread-message-summary:focus-visible {
+  outline: 2px solid var(--mantine-color-ember-5);
+  outline-offset: -2px;
+}
+.thread-message-summary-avatar {
+  flex: none;
+}
+.thread-message-summary-meta {
+  min-width: 0;
+  flex: 1;
+  display: grid;
+  gap: 2px;
+}
+.thread-message-summary-sender {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 14px;
+  font-weight: 650;
+}
+.thread-message-summary-snippet {
+  overflow: hidden;
+  color: var(--mantine-color-dimmed);
+  font-size: 13px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.thread-message-summary-attachment {
+  flex: none;
+  display: grid;
+  place-items: center;
+  color: var(--mantine-color-dimmed);
+}
+.reader-visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 .sender-avatar {
   width: 34px !important;


### PR DESCRIPTION
## Summary

- Open threads and notification actions on the newest chronological message.
- Add collapsible thread-message summaries that load content only when expanded.
- Preserve the user’s expanded message across mailbox updates and scope state by account and thread.
- Keep message-specific star and unsubscribe actions targeted to the selected message.
- Add accessible labels and metadata for collapsed messages.

## Testing

- Added App and Reader regression coverage for newest-message focus, notification opening, lazy content loading, expansion state persistence, account isolation, and message-specific actions.
- Verified expand/collapse round trips and thread updates in component tests.