### PR TITLE
Add full email message export as raw .eml

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -52,6 +52,8 @@ const MESSAGE_HYDRATION_CONCURRENCY: usize = 4;
 const CLASSIFICATION_BATCH_SIZE: usize = 64;
 const CLASSIFICATION_RETRY_DELAYS: [Duration; 2] =
     [Duration::from_millis(100), Duration::from_millis(500)];
+const MAX_EXPORT_FILENAME_BYTES: usize = 255;
+const MAX_DOWNLOAD_COLLISION_SUFFIX_BYTES: usize = " (9999)".len();
 
 struct AppState {
     store: Store,
@@ -1156,6 +1158,51 @@ async fn save_attachment(
 }
 
 #[tauri::command]
+async fn export_message(
+    app: tauri::AppHandle,
+    state: State<'_, Arc<AppState>>,
+    message_id: String,
+) -> Result<String, String> {
+    let initial_message = state
+        .store
+        .message(&message_id)
+        .await
+        .map_err(error)?
+        .ok_or_else(|| "Message not found".to_owned())?;
+    let account_id = Uuid::parse_str(&initial_message.account_id).map_err(error)?;
+    let _operation = state.account_operations.acquire(account_id).await;
+    let message = state
+        .store
+        .message(&message_id)
+        .await
+        .map_err(error)?
+        .ok_or_else(|| "Message changed while it was being exported".to_owned())?;
+    if !same_export_identity(&initial_message, &message) {
+        return Err("Message changed while it was being exported".to_owned());
+    }
+    let account = state
+        .store
+        .account(account_id)
+        .await
+        .map_err(error)?
+        .ok_or_else(|| "Account not found".to_owned())?;
+    let uid = u32::try_from(message.uid).map_err(|_| "Message UID is invalid".to_owned())?;
+    let bytes = MailService::new(state.store.clone())
+        .fetch_raw_message(&account, &message.mailbox, uid)
+        .await
+        .map_err(error)?;
+    save_eml_to_downloads(&app, &message.subject, &bytes).map_err(error)
+}
+
+fn same_export_identity(before: &MailSummary, after: &MailSummary) -> bool {
+    before.account_id == after.account_id
+        && before.mailbox == after.mailbox
+        && before.uid == after.uid
+        && before.message_id == after.message_id
+        && before.received_at == after.received_at
+}
+
+#[tauri::command]
 async fn save_all_attachments(
     app: tauri::AppHandle,
     state: State<'_, Arc<AppState>>,
@@ -1618,8 +1665,64 @@ fn save_to_downloads(
     bytes: &[u8],
 ) -> anyhow::Result<String> {
     let downloads = app.path().download_dir()?;
-    std::fs::create_dir_all(&downloads)?;
     let filename = dakia_core::mail::safe_attachment_filename(&attachment.filename, 0);
+    Ok(save_private_download(&downloads, &filename, bytes)?
+        .to_string_lossy()
+        .into_owned())
+}
+
+fn save_eml_to_downloads(
+    app: &tauri::AppHandle,
+    subject: &str,
+    bytes: &[u8],
+) -> anyhow::Result<String> {
+    let downloads = app.path().download_dir()?;
+    Ok(
+        save_private_download(&downloads, &eml_export_filename(subject), bytes)?
+            .to_string_lossy()
+            .into_owned(),
+    )
+}
+
+fn eml_export_filename(subject: &str) -> String {
+    let sanitized = dakia_core::mail::safe_attachment_filename(subject, 0);
+    let fallback = subject
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or_default()
+        .chars()
+        .all(|character| {
+            character.is_control()
+                || character.is_whitespace()
+                || matches!(character, '.' | ':' | '<' | '>' | '"' | '|' | '?' | '*')
+        });
+    let stem = if fallback { "message" } else { &sanitized };
+    format!("{}.eml", truncate_utf8_filename_stem(stem))
+}
+
+fn truncate_utf8_filename_stem(stem: &str) -> &str {
+    let maximum_stem_bytes =
+        MAX_EXPORT_FILENAME_BYTES - ".eml".len() - MAX_DOWNLOAD_COLLISION_SUFFIX_BYTES;
+    if stem.len() <= maximum_stem_bytes {
+        return stem;
+    }
+    let mut end = 0;
+    for (index, character) in stem.char_indices() {
+        let next = index + character.len_utf8();
+        if next > maximum_stem_bytes {
+            break;
+        }
+        end = next;
+    }
+    &stem[..end]
+}
+
+fn save_private_download(
+    downloads: &Path,
+    filename: &str,
+    bytes: &[u8],
+) -> anyhow::Result<PathBuf> {
+    std::fs::create_dir_all(downloads)?;
     for counter in 0..10_000 {
         let candidate = downloads.join(download_name(&filename, counter));
         let mut options = OpenOptions::new();
@@ -1633,8 +1736,13 @@ fn save_to_downloads(
                     return Err(write_error.into());
                 }
                 #[cfg(unix)]
-                std::fs::set_permissions(&candidate, std::fs::Permissions::from_mode(0o600))?;
-                return Ok(candidate.to_string_lossy().into_owned());
+                if let Err(permission_error) =
+                    std::fs::set_permissions(&candidate, std::fs::Permissions::from_mode(0o600))
+                {
+                    let _ = std::fs::remove_file(&candidate);
+                    return Err(permission_error.into());
+                }
+                return Ok(candidate);
             }
             Err(open_error) if open_error.kind() == ErrorKind::AlreadyExists => continue,
             Err(open_error) => return Err(open_error.into()),
@@ -1658,6 +1766,110 @@ fn download_name(filename: &str, counter: usize) -> String {
     match extension {
         Some(extension) if !extension.is_empty() => format!("{stem} ({counter}).{extension}"),
         _ => format!("{stem} ({counter})"),
+    }
+}
+
+#[cfg(test)]
+mod download_tests {
+    use super::*;
+    use chrono::Utc;
+    use tempfile::tempdir;
+
+    #[test]
+    fn eml_export_filename_sanitizes_subjects_and_has_a_safe_fallback() {
+        assert_eq!(
+            eml_export_filename("Quarterly report: Tallinn"),
+            "Quarterly report Tallinn.eml"
+        );
+        assert_eq!(eml_export_filename("../../\r\n"), "message.eml");
+    }
+
+    #[test]
+    fn eml_export_filename_stays_within_the_filesystem_byte_limit() {
+        let filename = eml_export_filename(&"€".repeat(180));
+
+        assert!(filename.len() <= MAX_EXPORT_FILENAME_BYTES);
+        assert!(filename.ends_with(".eml"));
+        assert_eq!(filename.trim_end_matches(".eml").chars().count(), 81);
+        assert!(
+            download_name(&filename, 9999).len() <= MAX_EXPORT_FILENAME_BYTES,
+            "the longest collision suffix must still fit"
+        );
+    }
+
+    #[test]
+    fn private_download_keeps_bytes_and_chooses_a_unique_eml_name() {
+        let directory = tempdir().expect("temporary Downloads directory");
+        let raw = b"From: sender@example.test\r\nSubject: folded\r\n value\r\n\r\nopaque\0\xff";
+        let first =
+            save_private_download(directory.path(), "status.eml", raw).expect("first export");
+        let second = save_private_download(directory.path(), "status.eml", b"second")
+            .expect("second export");
+
+        assert_eq!(
+            first.file_name().and_then(|name| name.to_str()),
+            Some("status.eml")
+        );
+        assert_eq!(
+            second.file_name().and_then(|name| name.to_str()),
+            Some("status (1).eml")
+        );
+        assert_eq!(std::fs::read(&first).expect("first export bytes"), raw);
+        assert_eq!(
+            std::fs::read(&second).expect("second export bytes"),
+            b"second"
+        );
+        #[cfg(unix)]
+        assert_eq!(
+            std::fs::metadata(&first)
+                .expect("first export metadata")
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+    }
+
+    #[test]
+    fn export_identity_rejects_uid_reuse_after_a_mailbox_epoch_change() {
+        let before = MailSummary {
+            id: "message".into(),
+            account_id: Uuid::nil().to_string(),
+            mailbox: "INBOX".into(),
+            uid: 42,
+            message_id: Some("<old@example.test>".into()),
+            in_reply_to: None,
+            reference_ids: None,
+            thread_id: "thread".into(),
+            subject: "Old".into(),
+            from_name: None,
+            from_address: "old@example.test".into(),
+            to_addresses: "me@example.test".into(),
+            cc_addresses: String::new(),
+            bcc_addresses: String::new(),
+            reply_to_addresses: String::new(),
+            received_at: Utc::now(),
+            snippet: String::new(),
+            body_text: String::new(),
+            body_html: None,
+            content_state: "headers_only".into(),
+            unsubscribe_kind: None,
+            unsubscribe_url: None,
+            is_read: false,
+            is_flagged: false,
+            has_attachments: false,
+            category: None,
+            classification_confidence: None,
+            classification_source: None,
+            classification_signals: String::new(),
+            attachments: vec![],
+        };
+        let mut reused_uid = before.clone();
+        reused_uid.message_id = Some("<new@example.test>".into());
+        reused_uid.received_at += chrono::Duration::seconds(1);
+
+        assert!(same_export_identity(&before, &before));
+        assert!(!same_export_identity(&before, &reused_uid));
     }
 }
 
@@ -3268,6 +3480,7 @@ pub fn run() {
             remove_terminal_command,
             message_attachments,
             save_attachment,
+            export_message,
             save_all_attachments,
             forward_attachments,
             read_dropped_files,

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -142,6 +142,8 @@ const desktopApi = {
     invoke<string>("save_attachment", { messageId, attachmentId }),
   saveAllAttachments: (messageId: string) =>
     invoke<string[]>("save_all_attachments", { messageId }),
+  exportMessage: (messageId: string) =>
+    invoke<string>("export_message", { messageId }),
   forwardAttachments: (messageId: string) =>
     invoke<ComposeAttachment[]>("forward_attachments", { messageId }),
   readDroppedFiles: (receipt: string) =>
@@ -529,6 +531,7 @@ const demoApi: typeof desktopApi = {
     messageId === "demo-2"
       ? ["~/Downloads/field-notes.pdf"]
       : ["~/Downloads/invoice-0726.pdf"],
+  exportMessage: async (messageId) => `~/Downloads/${messageId}.eml`,
   forwardAttachments: async () => [],
   readDroppedFiles: async () => {
     throw new Error("Native file drop support is unavailable in the web demo");

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -92,6 +92,9 @@ describe("Reader unsubscribe action", () => {
       config: {},
     });
     vi.spyOn(api, "cancelTranslationModelInstall").mockResolvedValue();
+    vi.spyOn(api, "exportMessage").mockResolvedValue(
+      "/Users/alex/Downloads/weekly-notes.eml",
+    );
   });
 
   it("keeps AI controls and results hidden even when connected", () => {
@@ -184,6 +187,79 @@ describe("Reader unsubscribe action", () => {
     fireEvent.click(await screen.findByRole("menuitem", { name: "Forward" }));
     expect(props.onForward).toHaveBeenCalledOnce();
     expect(props.onForward.mock.calls[0]).toEqual([]);
+  });
+
+  it("exports the selected message once and reports the saved path", async () => {
+    render(
+      <MantineProvider>
+        <Reader {...props} message={message} />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Export message (.eml)" }),
+    );
+
+    await waitFor(() =>
+      expect(api.exportMessage).toHaveBeenCalledWith("message-1"),
+    );
+    expect(
+      await screen.findByText(
+        "Message exported to /Users/alex/Downloads/weekly-notes.eml",
+      ),
+    ).toBeVisible();
+  });
+
+  it("prevents a second export while the current export is pending", async () => {
+    let finishExport: ((path: string) => void) | undefined;
+    vi.mocked(api.exportMessage).mockImplementationOnce(
+      () =>
+        new Promise<string>((resolve) => {
+          finishExport = resolve;
+        }),
+    );
+    render(
+      <MantineProvider>
+        <Reader {...props} message={message} />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    const pendingExport = await screen.findByRole("menuitem", {
+      name: "Export message (.eml)",
+    });
+    fireEvent.click(pendingExport);
+    await waitFor(() => expect(pendingExport).toBeDisabled());
+    expect(pendingExport).toBeDisabled();
+    fireEvent.click(pendingExport);
+    expect(api.exportMessage).toHaveBeenCalledOnce();
+
+    finishExport?.("/Users/alex/Downloads/weekly-notes.eml");
+    expect(
+      await screen.findByText(
+        "Message exported to /Users/alex/Downloads/weekly-notes.eml",
+      ),
+    ).toBeVisible();
+  });
+
+  it("reports an export failure without claiming the message was saved", async () => {
+    vi.mocked(api.exportMessage).mockRejectedValueOnce(new Error("cancelled"));
+    render(
+      <MantineProvider>
+        <Reader {...props} message={message} />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Export message (.eml)" }),
+    );
+
+    expect(
+      await screen.findByText("Could not export this message."),
+    ).toBeVisible();
+    expect(screen.queryByText(/Message exported to/)).not.toBeInTheDocument();
   });
 
   it("runs archive from the reader toolbar", () => {

--- a/apps/desktop/src/components/Reader.tsx
+++ b/apps/desktop/src/components/Reader.tsx
@@ -452,6 +452,9 @@ function ThreadMessage({
   const [loadingAttachments, setLoadingAttachments] = useState(false);
   const [saving, setSaving] = useState<string>();
   const [saveStatus, setSaveStatus] = useState<string>();
+  const [exporting, setExporting] = useState(false);
+  const [exportStatus, setExportStatus] = useState<string>();
+  const exportInFlight = useRef(false);
   const [hydrationRequested, setHydrationRequested] = useState(false);
   const [recipientsExpanded, setRecipientsExpanded] = useState(false);
   const displayContent = translatedContent ?? content;
@@ -516,6 +519,21 @@ function ThreadMessage({
       setSaveStatus(t("attachments.saveError"));
     } finally {
       setSaving(undefined);
+    }
+  };
+  const exportMessage = async () => {
+    if (exportInFlight.current) return;
+    exportInFlight.current = true;
+    setExporting(true);
+    setExportStatus(undefined);
+    try {
+      const path = await api.exportMessage(message.id);
+      setExportStatus(t("reader.exportSuccess", { path }));
+    } catch {
+      setExportStatus(t("reader.exportError"));
+    } finally {
+      exportInFlight.current = false;
+      setExporting(false);
     }
   };
 
@@ -631,6 +649,15 @@ function ThreadMessage({
               {t("actions.forward")}
             </Menu.Item>
             <Menu.Item
+              leftSection={
+                exporting ? <Loader size={16} /> : <IconDownload size={16} />
+              }
+              onClick={() => void exportMessage()}
+              disabled={exporting}
+            >
+              {t("actions.exportMessage")}
+            </Menu.Item>
+            <Menu.Item
               leftSection={<IconArchive size={16} />}
               onClick={onArchive}
               disabled={actionsDisabled}
@@ -661,6 +688,11 @@ function ThreadMessage({
           </Menu.Dropdown>
         </Menu>
       </div>
+      {exportStatus ? (
+        <p className="attachment-status" role="status">
+          {exportStatus}
+        </p>
+      ) : null}
       {loadingContent ? (
         <div className="message-body" role="status">
           <Loader size="xs" />{" "}

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -41,6 +41,7 @@ export const en = {
       reply: "Reply",
       replyAll: "Reply all",
       forward: "Forward",
+      exportMessage: "Export message (.eml)",
       more: "More actions",
       star: "Star conversation",
       unstar: "Remove star",
@@ -135,6 +136,8 @@ export const en = {
       loadingContent: "Fetching message…",
       loadContentError:
         "This message could not be fetched from the mail server.",
+      exportSuccess: "Message exported to {{path}}",
+      exportError: "Could not export this message.",
     },
     translation: {
       translatedFrom: "Translated from {{language}} on this device",

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -924,6 +924,43 @@ impl MailService {
         Ok(message)
     }
 
+    /// Fetches the original RFC 822 bytes for an explicit export without
+    /// changing the message's `\\Seen` flag or retaining the bytes locally.
+    ///
+    /// The local mailbox catalogue remains the locator authority: its saved
+    /// UIDVALIDITY must still match the selected remote mailbox before a UID
+    /// can be used. This prevents a recycled UID from exporting a different
+    /// message after a mailbox rebuild.
+    pub async fn fetch_raw_message(
+        &self,
+        account: &Account,
+        mailbox: &str,
+        uid: u32,
+    ) -> Result<Vec<u8>> {
+        let state = self
+            .store
+            .mailbox_catalog_state(account.id, mailbox)
+            .await?
+            .context("mailbox catalogue is not initialized")?;
+        let secret = self.credentials.secret(account).await?;
+        let mut client = ImapClient::connect(account).await?;
+        client.authenticate(account, &secret).await?;
+        let selected = client
+            .command(&format!("SELECT {}", quote_imap(&state.remote_name)))
+            .await?;
+        let current_uid_validity = parse_uid_validity(&selected)
+            .context("IMAP server omitted UIDVALIDITY after SELECT")?;
+        if i64::from(current_uid_validity) != state.uid_validity {
+            bail!("mailbox identity changed; sync the account before exporting this message");
+        }
+        let response = client
+            .command_with_literal(&raw_message_fetch_command(uid))
+            .await?;
+        let raw = response.literal.context("message is no longer available")?;
+        let _ = client.command("LOGOUT").await;
+        Ok(raw)
+    }
+
     /// Searches message bodies on the authoritative server. Results are
     /// locators only; callers merge catalogue rows with the immediate local
     /// FTS results and retain those local results if the server is offline.
@@ -1741,6 +1778,10 @@ fn hydration_fetch_fields(account: &Account) -> &'static str {
 
 fn hydration_fetch_command(account: &Account, uid: u32) -> String {
     format!("UID FETCH {uid} ({})", hydration_fetch_fields(account))
+}
+
+fn raw_message_fetch_command(uid: u32) -> String {
+    format!("UID FETCH {uid} (BODY.PEEK[])")
 }
 
 fn set_read_command(uid: u32, read: bool) -> String {
@@ -3020,6 +3061,15 @@ mod tests {
             assert!(command.contains("BODY.PEEK[]"));
             assert!(!command.contains("RFC822"));
         }
+    }
+
+    #[test]
+    fn raw_export_fetch_is_read_neutral_and_requests_only_the_original_bytes() {
+        let command = raw_message_fetch_command(42);
+
+        assert_eq!(command, "UID FETCH 42 (BODY.PEEK[])");
+        assert!(!command.contains("RFC822"));
+        assert!(!command.contains("FLAGS"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add native export of the selected message as its original RFC 822 bytes.
- Validate mailbox identity and message stability before exporting to prevent UID reuse issues.
- Save sanitized, collision-safe `.eml` files privately in Downloads.
- Add Reader menu action, progress state, success/error feedback, and demo API support.

## Testing

- Added Rust tests for raw IMAP fetch semantics, filename sanitization and limits, collision handling, file permissions, byte preservation, and export identity validation.
- Added Reader tests for successful export, duplicate-click prevention, and failure feedback.