### PR TITLE
Cache recent message bodies proactively

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod realtime;
 mod translation;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
+use dakia_core::storage::MessageContentFetchAcquire;
 use dakia_core::{
     ai::{AiConfig, AiProvider, AiService},
     mailbox_action_destination, provider, remote_mailbox, Account, AccountAuth, AccountDraft,
@@ -1070,17 +1071,9 @@ async fn message_attachments(
     state: State<'_, Arc<AppState>>,
     message_id: String,
 ) -> Result<Vec<Attachment>, String> {
-    Ok(fetch_remote_message(state.inner(), &message_id)
+    Ok(load_message_content(state.inner(), &message_id)
         .await?
-        .attachments
-        .into_iter()
-        // `is_inline` describes MIME transport, not whether a part belongs in
-        // a user-facing attachment list. Never let an embedded CID resource
-        // escape through a command even if an older cache or parser supplied
-        // it here.
-        .filter(|item| is_downloadable_attachment(&item.attachment))
-        .map(|item| item.attachment)
-        .collect())
+        .attachments)
 }
 
 #[tauri::command]
@@ -1088,50 +1081,37 @@ async fn message_content(
     state: State<'_, Arc<AppState>>,
     message_id: String,
 ) -> Result<MessageContent, String> {
-    if let Some((body_text, body_html)) =
-        state.store.starred_body(&message_id).await.map_err(error)?
-    {
-        let content = MessageContent {
+    load_message_content(state.inner(), &message_id).await
+}
+
+async fn cached_message_content(
+    store: &Store,
+    message_id: &str,
+) -> Result<Option<MessageContent>, String> {
+    if let Some((body_text, body_html)) = store.starred_body(message_id).await.map_err(error)? {
+        return Ok(Some(MessageContent {
             body_text,
             body_html,
-            unsubscribe_kind: state
-                .store
-                .message(&message_id)
+            unsubscribe_kind: store
+                .message(message_id)
                 .await
                 .map_err(error)?
                 .and_then(|message| message.unsubscribe_kind),
-            attachments: state
-                .store
-                .starred_attachment_metadata(&message_id)
+            attachments: store
+                .starred_attachment_metadata(message_id)
                 .await
                 .map_err(error)?
                 .into_iter()
                 .filter(is_downloadable_attachment)
                 .collect(),
-        };
-        if !looks_like_misclassified_text_body(&content) {
-            return Ok(content);
-        }
-        let message = refetch_and_persist_message(state.inner(), &message_id).await?;
-        return Ok(MessageContent {
-            body_text: message.body_text,
-            body_html: message.body_html,
-            unsubscribe_kind: message.unsubscribe_kind,
-            attachments: message
-                .attachments
-                .into_iter()
-                .map(|item| item.attachment)
-                .filter(is_downloadable_attachment)
-                .collect(),
-        });
+        }));
     }
-    if let Some(cached) = state
-        .store
-        .cached_message_content(&message_id)
+    if let Some(cached) = store
+        .cached_message_content(message_id)
         .await
         .map_err(error)?
     {
-        let content = MessageContent {
+        return Ok(Some(MessageContent {
             body_text: cached.body_text,
             body_html: cached.body_html,
             unsubscribe_kind: cached.unsubscribe_kind,
@@ -1140,39 +1120,112 @@ async fn message_content(
                 .into_iter()
                 .filter(is_downloadable_attachment)
                 .collect(),
-        };
-        if !looks_like_misclassified_text_body(&content) {
-            return Ok(content);
+        }));
+    }
+    Ok(None)
+}
+
+async fn load_message_content(
+    state: &Arc<AppState>,
+    message_id: &str,
+) -> Result<MessageContent, String> {
+    if let Some(cached) = cached_message_content(&state.store, message_id).await? {
+        if !looks_like_misclassified_text_body(&cached) {
+            return Ok(cached);
         }
     }
-    let message = fetch_remote_message(state.inner(), &message_id).await?;
-    let cached = CachedMessageContent {
-        body_text: message.body_text.clone(),
-        body_html: message.body_html.clone(),
-        unsubscribe_kind: message.unsubscribe_kind.clone(),
-        attachments: message
-            .attachments
-            .iter()
-            .filter(|item| is_downloadable_attachment(&item.attachment))
-            .map(|item| item.attachment.clone())
-            .collect(),
-    };
-    let still_starred = persist_foreground_message_content(&state.store, &message, &cached).await?;
-    if !still_starred {
-        if let Err(cache_error) = state
+
+    // Background warming and a foreground open share this durable claim. A
+    // foreground request waits for the warmer's cache commit, but takes over
+    // immediately if the warmer failed and released the claim.
+    let mut waited = Duration::ZERO;
+    let claim = loop {
+        match state
             .store
-            .cache_message_content(&message_id, false, cached.clone())
+            .acquire_message_content_fetch_outcome(message_id)
             .await
+            .map_err(error)?
         {
-            tracing::warn!(%cache_error, %message_id, "could not persist foreground message cache");
+            MessageContentFetchAcquire::Claimed(claim) => break claim,
+            MessageContentFetchAcquire::Missing => return Err("Message not found".to_owned()),
+            MessageContentFetchAcquire::Busy => {}
         }
+        if let Some(cached) = cached_message_content(&state.store, message_id).await? {
+            if !looks_like_misclassified_text_body(&cached) {
+                return Ok(cached);
+            }
+        }
+        if waited >= Duration::from_secs(60) {
+            return Err("Timed out waiting for message content".to_owned());
+        }
+        let delay = Duration::from_millis(50);
+        tokio::time::sleep(delay).await;
+        waited += delay;
+    };
+
+    let result = async {
+        // The winner must re-check after claiming: another fetch can commit
+        // content immediately before releasing its claim.
+        let cached_before_fetch = cached_message_content(&state.store, message_id).await?;
+        if let Some(cached) = &cached_before_fetch {
+            if !looks_like_misclassified_text_body(cached) {
+                return Ok(MessageContent {
+                    body_text: cached.body_text.clone(),
+                    body_html: cached.body_html.clone(),
+                    unsubscribe_kind: cached.unsubscribe_kind.clone(),
+                    attachments: cached.attachments.clone(),
+                });
+            }
+        }
+        let message = if cached_before_fetch
+            .as_ref()
+            .is_some_and(looks_like_misclassified_text_body)
+        {
+            // PR #42 repairs legacy rows under the account-operation lock so
+            // a concurrent move or action cannot redirect the refetch.
+            refetch_and_persist_message(state, message_id).await?
+        } else {
+            fetch_remote_message(state, message_id).await?
+        };
+        let cached = CachedMessageContent {
+            body_text: message.body_text.clone(),
+            body_html: message.body_html.clone(),
+            unsubscribe_kind: message.unsubscribe_kind.clone(),
+            attachments: message
+                .attachments
+                .iter()
+                .filter(|item| is_downloadable_attachment(&item.attachment))
+                .map(|item| item.attachment.clone())
+                .collect(),
+        };
+        let still_starred =
+            persist_foreground_message_content(&state.store, &message, &cached).await?;
+        if !still_starred {
+            if let Err(cache_error) = state
+                .store
+                .cache_message_content(message_id, false, cached.clone())
+                .await
+            {
+                tracing::warn!(%cache_error, %message_id, "could not persist foreground message cache");
+            }
+        }
+        state
+            .store
+            .set_message_content_state(message_id, "complete")
+            .await
+            .map_err(error)?;
+        Ok(MessageContent {
+            body_text: cached.body_text,
+            body_html: cached.body_html,
+            unsubscribe_kind: cached.unsubscribe_kind,
+            attachments: cached.attachments,
+        })
     }
-    Ok(MessageContent {
-        body_text: cached.body_text,
-        body_html: cached.body_html,
-        unsubscribe_kind: cached.unsubscribe_kind,
-        attachments: cached.attachments,
-    })
+    .await;
+    if let Err(release_error) = claim.release().await {
+        tracing::warn!(%release_error, %message_id, "could not release message-content fetch claim");
+    }
+    result
 }
 
 fn looks_like_misclassified_text_body(content: &MessageContent) -> bool {
@@ -1192,6 +1245,24 @@ fn looks_like_misclassified_text_body(content: &MessageContent) -> bool {
 mod message_content_repair_tests {
     use super::*;
     use dakia_core::AttachmentPresentation;
+
+    fn message_content_test_state(store: Store) -> Arc<AppState> {
+        let resources =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/email-classifier-v2");
+        Arc::new(AppState {
+            realtime: RealtimeSyncManager::new(store.clone()),
+            store,
+            data_dir: PathBuf::new(),
+            classifier: Mutex::new(
+                LocalEmailClassifier::from_dir(resources).expect("bundled test classifier"),
+            ),
+            classification: Arc::new(ClassificationScheduler::default()),
+            mail_rebuilds: Mutex::new(HashMap::new()),
+            account_operations: AccountOperationLocks::default(),
+            remote_operation_slots: Arc::new(Semaphore::new(MESSAGE_HYDRATION_CONCURRENCY)),
+            translation_downloads: Mutex::new(HashMap::new()),
+        })
+    }
 
     fn attachment(filename: &str, mime_type: &str, is_inline: bool) -> Attachment {
         Attachment {
@@ -1236,6 +1307,20 @@ mod message_content_repair_tests {
 
         assert!(!looks_like_misclassified_text_body(&named_attachment));
     }
+
+    #[tokio::test]
+    async fn deleted_message_content_fails_without_waiting_for_a_fetch_claim() {
+        let state = message_content_test_state(Store::in_memory().await.expect("test store"));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(250),
+            load_message_content(&state, "deleted-message"),
+        )
+        .await
+        .expect("a deleted message must not wait for the claim timeout");
+
+        assert!(matches!(result, Err(error) if error == "Message not found"));
+    }
 }
 
 #[tauri::command]
@@ -1245,13 +1330,16 @@ async fn save_attachment(
     message_id: String,
     attachment_id: String,
 ) -> Result<String, String> {
-    let attachment = fetch_remote_message(state.inner(), &message_id)
-        .await?
-        .attachments
-        .into_iter()
-        .filter(|item| is_downloadable_attachment(&item.attachment))
-        .find(|item| item.attachment.id == attachment_id)
-        .ok_or_else(|| "Attachment not found".to_owned())?;
+    let (summary, account) = remote_message_locator(state.inner(), &message_id).await?;
+    let attachment = MailService::new(state.store.clone())
+        .fetch_attachment(
+            &account,
+            &summary.mailbox,
+            summary.uid as u32,
+            &attachment_id,
+        )
+        .await
+        .map_err(error)?;
     save_to_downloads(&app, &attachment.attachment, &attachment.bytes).map_err(error)
 }
 
@@ -1306,7 +1394,7 @@ async fn save_all_attachments(
     state: State<'_, Arc<AppState>>,
     message_id: String,
 ) -> Result<Vec<String>, String> {
-    let attachments = fetch_remote_message(state.inner(), &message_id)
+    let attachments = fetch_full_remote_message(state.inner(), &message_id)
         .await?
         .attachments
         .into_iter()
@@ -1326,7 +1414,7 @@ async fn forward_attachments(
     state: State<'_, Arc<AppState>>,
     message_id: String,
 ) -> Result<Vec<DroppedAttachment>, String> {
-    let attachments = fetch_remote_message(state.inner(), &message_id)
+    let attachments = fetch_full_remote_message(state.inner(), &message_id)
         .await?
         .attachments
         .into_iter()
@@ -1645,6 +1733,28 @@ async fn fetch_remote_message(
     state: &Arc<AppState>,
     message_id: &str,
 ) -> Result<MailSummary, String> {
+    let (summary, account) = remote_message_locator(state, message_id).await?;
+    MailService::new(state.store.clone())
+        .fetch_message(&account, &summary.mailbox, summary.uid as u32)
+        .await
+        .map_err(error)
+}
+
+async fn fetch_full_remote_message(
+    state: &Arc<AppState>,
+    message_id: &str,
+) -> Result<MailSummary, String> {
+    let (summary, account) = remote_message_locator(state, message_id).await?;
+    MailService::new(state.store.clone())
+        .fetch_full_message(&account, &summary.mailbox, summary.uid as u32)
+        .await
+        .map_err(error)
+}
+
+async fn remote_message_locator(
+    state: &Arc<AppState>,
+    message_id: &str,
+) -> Result<(MailSummary, Account), String> {
     let summary = state
         .store
         .messages_by_ids(&[message_id.to_owned()])
@@ -1660,10 +1770,7 @@ async fn fetch_remote_message(
         .await
         .map_err(error)?
         .ok_or_else(|| "Account not found".to_owned())?;
-    MailService::new(state.store.clone())
-        .fetch_message(&account, &summary.mailbox, summary.uid as u32)
-        .await
-        .map_err(error)
+    Ok((summary, account))
 }
 
 async fn refetch_and_persist_message(
@@ -3186,58 +3293,41 @@ async fn hydrate_message(
     state: State<'_, Arc<AppState>>,
     message_id: String,
 ) -> Result<dakia_core::MailSummary, String> {
-    let message = state
+    let message = hydrated_message(state.inner(), &message_id).await?;
+    let account_id = Uuid::parse_str(&message.account_id).map_err(error)?;
+    kick_classification(state.inner().clone());
+    let _ = app.emit(
+        "mail-hydrated",
+        serde_json::json!({
+            "accountId": account_id,
+            "messageId": message.id,
+        }),
+    );
+    Ok(message)
+}
+
+async fn hydrated_message(state: &Arc<AppState>, message_id: &str) -> Result<MailSummary, String> {
+    let content = load_message_content(state, message_id).await?;
+    let mut message = state
         .store
-        .message(&message_id)
+        .message(message_id)
         .await
         .map_err(error)?
         .ok_or_else(|| "Message not found".to_owned())?;
-    if matches!(message.content_state.as_str(), "complete" | "hydrating") {
-        return Ok(message);
-    }
-    let account_id = Uuid::parse_str(&message.account_id).map_err(error)?;
-    let account = state
-        .store
-        .account(account_id)
-        .await
-        .map_err(error)?
-        .ok_or_else(|| "Account not found".to_owned())?;
-    if !state
-        .store
-        .claim_message_hydration(&message_id)
-        .await
-        .map_err(error)?
-    {
-        return state
-            .store
-            .message(&message_id)
-            .await
-            .map_err(error)?
-            .ok_or_else(|| "Message not found".to_owned());
-    }
-    match MailService::new(state.store.clone())
-        .hydrate_message(&account, &message.mailbox, message.uid as u32)
-        .await
-    {
-        Ok(hydrated) => {
-            kick_classification(state.inner().clone());
-            let _ = app.emit(
-                "mail-hydrated",
-                serde_json::json!({
-                    "accountId": account_id,
-                    "messageId": hydrated.id,
-                }),
-            );
-            Ok(hydrated)
-        }
-        Err(failure) => {
-            let _ = state
-                .store
-                .set_message_content_state(&message_id, "failed")
-                .await;
-            Err(error(failure))
-        }
-    }
+    message.body_text = content.body_text;
+    message.body_html = content.body_html;
+    message.unsubscribe_kind = content.unsubscribe_kind;
+    message.content_state = "complete".into();
+    message.attachments = content
+        .attachments
+        .into_iter()
+        .map(|attachment| dakia_core::storage::AttachmentData {
+            attachment,
+            bytes: Vec::new(),
+        })
+        .collect();
+    message.has_attachments = !message.attachments.is_empty();
+    Ok(message)
 }
 
 fn publish_mail_rebuild_progress(
@@ -3540,7 +3630,7 @@ async fn hydrate_messages(
         state.remote_operation_slots.clone(),
         move |message_id| {
             let state = hydration_state.clone();
-            async move { fetch_remote_message(&state, &message_id).await }
+            async move { hydrated_message(&state, &message_id).await }
         },
     )
     .await

--- a/apps/desktop/src-tauri/src/realtime.rs
+++ b/apps/desktop/src-tauri/src/realtime.rs
@@ -1,10 +1,10 @@
-use dakia_core::{Account, MailService, MailSummary, RealtimeMode, Store};
+use dakia_core::{Account, CachedMessageContent, MailService, MailSummary, RealtimeMode, Store};
 use serde::Serialize;
 use std::{
     collections::HashMap,
     future::Future,
     sync::{Arc, RwLock as StdRwLock},
-    time::Duration,
+    time::{Duration, Instant},
 };
 use tauri::{AppHandle, Emitter};
 use tokio::sync::{mpsc, watch, Mutex, OwnedMutexGuard, RwLock, Semaphore};
@@ -13,7 +13,12 @@ use uuid::Uuid;
 const REALTIME_BATCH_LIMIT: u32 = 300;
 const FALLBACK_POLL_INTERVAL: Duration = Duration::from_secs(5 * 60);
 const HYDRATION_CONCURRENCY: usize = 3;
-const HYDRATION_QUEUE_CAPACITY: usize = 2;
+const HYDRATION_MAINTENANCE_QUEUE_CAPACITY: usize = 1;
+const BODY_CACHE_WARM_INTERVAL: Duration = Duration::from_secs(15 * 60);
+const BODY_CACHE_WARM_BATCH_LIMIT: u32 = 100;
+const BODY_CACHE_WARM_CANDIDATE_PAGES_PER_CYCLE: u32 = 3;
+const BODY_CACHE_WARM_LOOKBACK_DAYS: i64 = 30;
+const BODY_CACHE_FAILURE_COOLDOWN: Duration = Duration::from_secs(60 * 60);
 
 type HydrationCompleteHook = Arc<dyn Fn() + Send + Sync>;
 type HydrationCompleteHookStore = Arc<StdRwLock<Option<HydrationCompleteHook>>>;
@@ -223,21 +228,26 @@ async fn run_watcher(
     hydration_complete: HydrationCompleteHookStore,
 ) {
     let mut failures = 0_usize;
-    // A single owned worker serializes cycle batches for this account. The
-    // bounded channel provides backpressure instead of dropping later arrivals
-    // or accumulating detached tasks while an earlier batch is still active.
-    let (hydration_sender, hydration_receiver) =
-        mpsc::channel::<Vec<MailSummary>>(HYDRATION_QUEUE_CAPACITY);
+    // Arrivals must never wait behind a long cache-warm pass. Keep their queue
+    // separate and prioritize it in the worker; maintenance is coalesced to a
+    // single pending pass because an extra empty IDLE renewal has no payload.
+    let (arrival_sender, arrival_receiver) = mpsc::unbounded_channel::<HydrationBatch>();
+    let (maintenance_sender, maintenance_receiver) =
+        mpsc::channel::<HydrationBatch>(HYDRATION_MAINTENANCE_QUEUE_CAPACITY);
     let (hydration_cancel, hydration_cancel_receiver) = watch::channel(false);
     let hydration_handle = tauri::async_runtime::spawn(run_hydration_worker(
         app.clone(),
         store.clone(),
         account.clone(),
-        hydration_receiver,
+        HydrationWorkerQueues {
+            arrivals: arrival_receiver,
+            maintenance: maintenance_receiver,
+        },
         hydration_cancel_receiver,
         hydration_slots,
         hydration_complete,
     ));
+    let mut last_body_cache_warm = None;
     loop {
         if *cancel.borrow() {
             break;
@@ -275,22 +285,36 @@ async fn run_watcher(
                         },
                     );
                 }
-                // Queue every cycle, including an empty pending list, because
-                // the worker also revisits uncached starred messages. If the
-                // small queue is full, wait with cancellation rather than lose
-                // a cycle's only copy of its new-message hydration candidates.
-                let pending_hydration = cycle.pending_hydration;
-                tokio::select! {
-                    sent = hydration_sender.send(pending_hydration) => {
-                        if sent.is_err() {
-                            tracing::warn!(
-                                account_id = %account.id,
-                                "background hydration worker stopped unexpectedly"
-                            );
-                            break;
-                        }
-                    }
-                    _ = wait_for_cancellation(&mut cancel) => break,
+                // Only a real arrival enters the unbounded priority queue. A
+                // non-warm empty renewal is intentionally dropped, and a warm
+                // request supersedes an already queued maintenance request.
+                let now = Instant::now();
+                let warm_recent = body_cache_warm_due(last_body_cache_warm, now);
+                if warm_recent {
+                    last_body_cache_warm = Some(now);
+                }
+                if !cycle.pending_hydration.is_empty()
+                    && arrival_sender
+                        .send(HydrationBatch {
+                            pending: cycle.pending_hydration,
+                            warm_recent: false,
+                        })
+                        .is_err()
+                {
+                    tracing::warn!(
+                        account_id = %account.id,
+                        "background hydration worker stopped unexpectedly"
+                    );
+                    break;
+                }
+                if warm_recent {
+                    // Full means a maintenance pass is already queued. It is
+                    // equivalent to this one, so coalescing preserves the
+                    // cadence without letting the IDLE watcher block.
+                    let _ = maintenance_sender.try_send(HydrationBatch {
+                        pending: Vec::new(),
+                        warm_recent: true,
+                    });
                 }
                 if cycle.mode == RealtimeMode::Poll
                     && wait_or_cancel(poll_delay(account.id), &mut cancel).await
@@ -341,13 +365,15 @@ async fn run_watcher(
         }
     }
     let _ = hydration_cancel.send(true);
-    drop(hydration_sender);
+    drop(arrival_sender);
+    drop(maintenance_sender);
     let _ = hydration_handle.await;
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum HydrationKind {
     Pending,
+    Recent,
     Starred,
 }
 
@@ -355,6 +381,22 @@ enum HydrationKind {
 struct HydrationTarget {
     kind: HydrationKind,
     message: MailSummary,
+}
+
+struct HydrationBatch {
+    pending: Vec<MailSummary>,
+    warm_recent: bool,
+}
+
+struct HydrationWorkerQueues {
+    arrivals: mpsc::UnboundedReceiver<HydrationBatch>,
+    maintenance: mpsc::Receiver<HydrationBatch>,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ContentCacheDestination {
+    Regular,
+    Starred,
 }
 
 struct HydrationResult {
@@ -372,9 +414,18 @@ struct HydrationContext {
     account: Account,
     slots: Arc<Semaphore>,
     complete: HydrationCompleteHookStore,
+    recent_failures: Arc<Mutex<HashMap<String, Instant>>>,
+    // Each worker walks a bounded window of the ordered candidate set. A
+    // cooling newest prefix must not keep later messages beyond the first few
+    // pages unreachable forever.
+    recent_candidate_offset: Arc<Mutex<u32>>,
 }
 
-fn hydration_plan(pending: Vec<MailSummary>, starred: Vec<MailSummary>) -> Vec<HydrationTarget> {
+fn hydration_plan(
+    pending: Vec<MailSummary>,
+    recent: Vec<MailSummary>,
+    starred: Vec<MailSummary>,
+) -> Vec<HydrationTarget> {
     let mut seen = std::collections::HashSet::new();
     pending
         .into_iter()
@@ -382,19 +433,101 @@ fn hydration_plan(pending: Vec<MailSummary>, starred: Vec<MailSummary>) -> Vec<H
             kind: HydrationKind::Pending,
             message,
         })
+        .chain(recent.into_iter().map(|message| HydrationTarget {
+            kind: HydrationKind::Recent,
+            message,
+        }))
         .chain(starred.into_iter().map(|message| HydrationTarget {
             kind: HydrationKind::Starred,
             message,
         }))
-        .filter(|target| seen.insert(target.message.id.clone()))
+        .filter(|target| seen.insert(hydration_dedupe_key(&target.message)))
         .collect()
+}
+
+fn hydration_dedupe_key(message: &MailSummary) -> String {
+    // MailService parses Message-ID values into their canonical form before
+    // persistence. Lower-casing follows the storage/threading identity rules
+    // and also handles rows that predate canonical storage. A blank or
+    // malformed value is not an identity, so use the durable local id instead.
+    match message
+        .message_id
+        .as_deref()
+        .and_then(canonical_hydration_message_id)
+    {
+        Some(message_id) => format!("message-id:{message_id}"),
+        _ => format!("id:{}", message.id),
+    }
+}
+
+fn canonical_hydration_message_id(value: &str) -> Option<String> {
+    let value = value.trim();
+    let start = value.find('<')?;
+    let end = value[start..].find('>')? + start;
+    (end > start + 1).then(|| value[start..=end].to_ascii_lowercase())
+}
+
+fn body_cache_warm_due(last_warm: Option<Instant>, now: Instant) -> bool {
+    last_warm
+        .map(|last_warm| now.saturating_duration_since(last_warm) >= BODY_CACHE_WARM_INTERVAL)
+        .unwrap_or(true)
+}
+
+fn select_recent_candidate_page(
+    candidates: Vec<MailSummary>,
+    failures: &mut HashMap<String, Instant>,
+    selected: &mut Vec<MailSummary>,
+) {
+    let remaining = BODY_CACHE_WARM_BATCH_LIMIT.saturating_sub(selected.len() as u32) as usize;
+    if remaining == 0 {
+        return;
+    }
+    candidates
+        .into_iter()
+        .filter(|message| !failures.contains_key(&message.id))
+        .take(remaining)
+        .for_each(|message| selected.push(message));
+}
+
+fn next_recent_candidate_offset(
+    start_offset: u32,
+    pages_examined: u32,
+    saw_empty_page: bool,
+    batch_is_full: bool,
+) -> u32 {
+    if saw_empty_page || batch_is_full {
+        0
+    } else {
+        start_offset.saturating_add(pages_examined.saturating_mul(BODY_CACHE_WARM_BATCH_LIMIT))
+    }
+}
+
+fn content_cache_destination(message: &MailSummary) -> ContentCacheDestination {
+    if message.is_flagged {
+        ContentCacheDestination::Starred
+    } else {
+        ContentCacheDestination::Regular
+    }
+}
+
+fn display_cache_content(message: &MailSummary) -> CachedMessageContent {
+    CachedMessageContent {
+        body_text: message.body_text.clone(),
+        body_html: message.body_html.clone(),
+        unsubscribe_kind: message.unsubscribe_kind.clone(),
+        attachments: message
+            .attachments
+            .iter()
+            .map(|attachment| attachment.attachment.clone())
+            .collect(),
+    }
 }
 
 async fn run_hydration_worker(
     app: AppHandle,
     store: Store,
     account: Account,
-    receiver: mpsc::Receiver<Vec<MailSummary>>,
+    queues: HydrationWorkerQueues,
     cancel: watch::Receiver<bool>,
     hydration_slots: Arc<Semaphore>,
     hydration_complete: HydrationCompleteHookStore,
@@ -407,18 +540,26 @@ async fn run_hydration_worker(
         account,
         slots: hydration_slots,
         complete: hydration_complete,
+        recent_failures: Arc::new(Mutex::new(HashMap::new())),
+        recent_candidate_offset: Arc::new(Mutex::new(0)),
     };
-    run_queued_hydration_batches(receiver, cancel, move |pending, cancel| {
-        let context = context.clone();
-        async move {
-            hydrate_after_sync(context, pending, cancel).await;
-        }
-    })
+    run_prioritized_hydration_batches(
+        queues.arrivals,
+        queues.maintenance,
+        cancel,
+        move |batch, cancel| {
+            let context = context.clone();
+            async move {
+                hydrate_after_sync(context, batch, cancel).await;
+            }
+        },
+    )
     .await;
 }
 
-async fn run_queued_hydration_batches<T, F, Fut>(
-    mut receiver: mpsc::Receiver<T>,
+async fn run_prioritized_hydration_batches<T, F, Fut>(
+    mut arrival_receiver: mpsc::UnboundedReceiver<T>,
+    mut maintenance_receiver: mpsc::Receiver<T>,
     mut cancel: watch::Receiver<bool>,
     mut operation: F,
 ) where
@@ -426,14 +567,36 @@ async fn run_queued_hydration_batches<T, F, Fut>(
     F: FnMut(T, watch::Receiver<bool>) -> Fut,
     Fut: Future<Output = ()>,
 {
+    let mut arrivals_closed = false;
+    let mut maintenance_closed = false;
     loop {
+        if arrivals_closed && maintenance_closed {
+            break;
+        }
         let item = tokio::select! {
             biased;
             _ = wait_for_cancellation(&mut cancel) => break,
-            item = receiver.recv() => item,
+            item = arrival_receiver.recv(), if !arrivals_closed => {
+                match item {
+                    Some(item) => Some(item),
+                    None => {
+                        arrivals_closed = true;
+                        None
+                    }
+                }
+            },
+            item = maintenance_receiver.recv(), if !maintenance_closed => {
+                match item {
+                    Some(item) => Some(item),
+                    None => {
+                        maintenance_closed = true;
+                        None
+                    }
+                }
+            },
         };
         let Some(item) = item else {
-            break;
+            continue;
         };
         operation(item, cancel.clone()).await;
     }
@@ -441,9 +604,46 @@ async fn run_queued_hydration_batches<T, F, Fut>(
 
 async fn hydrate_after_sync(
     context: HydrationContext,
-    pending: Vec<MailSummary>,
+    batch: HydrationBatch,
     cancel: watch::Receiver<bool>,
 ) {
+    if *cancel.borrow() {
+        return;
+    }
+    let recent_cutoff = chrono::Utc::now() - chrono::Duration::days(BODY_CACHE_WARM_LOOKBACK_DAYS);
+    let recent = if batch.warm_recent {
+        let refresh_cancel = cancel.clone();
+        let refresh = context.service.refresh_recent_main_mailboxes(
+            &context.account,
+            recent_cutoff,
+            BODY_CACHE_WARM_BATCH_LIMIT * 3,
+        );
+        let Some(refresh_result) = run_cancellable(refresh, refresh_cancel).await else {
+            return;
+        };
+        match refresh_result {
+            Ok(messages) if !messages.is_empty() => {
+                let _ = context.app.emit(
+                    "mail-changed",
+                    serde_json::json!({ "accountId": context.account.id }),
+                );
+            }
+            Ok(_) => {}
+            Err(error) => {
+                // Existing catalogue rows remain valid warm candidates. A
+                // provider or UIDVALIDITY failure must not turn a cache
+                // refresh into destructive catalogue recovery.
+                tracing::warn!(
+                    account_id = %context.account.id,
+                    error = %error,
+                    "could not refresh recent primary-folder headers before body-cache warming"
+                );
+            }
+        }
+        load_recent_warm_candidates(&context, recent_cutoff, &cancel).await
+    } else {
+        Vec::new()
+    };
     let starred = match context
         .store
         .uncached_starred_messages(context.account.id, 25)
@@ -459,7 +659,10 @@ async fn hydrate_after_sync(
             Vec::new()
         }
     };
-    let plan = hydration_plan(pending, starred);
+    // New arrivals take precedence, followed by recent primary-folder bodies,
+    // then the durable starred backlog. `hydration_plan` deduplicates their
+    // provider identity so a Gmail label duplicate is fetched once.
+    let plan = hydration_plan(batch.pending, recent, starred);
     let hydration_account = context.account.clone();
     let hydration_context = context.clone();
     let results = run_bounded_cancellable_ordered(
@@ -499,8 +702,20 @@ async fn hydrate_after_sync(
                 );
                 notify_hydration_complete(&context.complete);
             }
-            Ok(_) => {}
+            Ok(_) => {
+                context
+                    .recent_failures
+                    .lock()
+                    .await
+                    .remove(&outcome.target.message.id);
+            }
             Err(error) => {
+                if outcome.target.kind == HydrationKind::Recent {
+                    context.recent_failures.lock().await.insert(
+                        outcome.target.message.id.clone(),
+                        Instant::now() + BODY_CACHE_FAILURE_COOLDOWN,
+                    );
+                }
                 tracing::warn!(
                     account_id = %context.account.id,
                     message_id = %outcome.target.message.id,
@@ -510,6 +725,71 @@ async fn hydrate_after_sync(
             }
         }
     }
+}
+
+async fn load_recent_warm_candidates(
+    context: &HydrationContext,
+    cutoff: chrono::DateTime<chrono::Utc>,
+    cancel: &watch::Receiver<bool>,
+) -> Vec<MailSummary> {
+    let start_offset = *context.recent_candidate_offset.lock().await;
+    let now = Instant::now();
+    let mut failures = {
+        let mut failures = context.recent_failures.lock().await;
+        failures.retain(|_, retry_at| *retry_at > now);
+        failures.clone()
+    };
+    let mut selected = Vec::new();
+    let mut pages_examined = 0;
+    let mut saw_empty_page = false;
+    let mut page_query_failed = false;
+
+    while pages_examined < BODY_CACHE_WARM_CANDIDATE_PAGES_PER_CYCLE
+        && selected.len() < BODY_CACHE_WARM_BATCH_LIMIT as usize
+    {
+        if *cancel.borrow() {
+            return Vec::new();
+        }
+        let offset =
+            start_offset.saturating_add(pages_examined.saturating_mul(BODY_CACHE_WARM_BATCH_LIMIT));
+        let candidates = match context
+            .store
+            .recent_body_cache_candidates_page(
+                context.account.id,
+                cutoff,
+                BODY_CACHE_WARM_BATCH_LIMIT,
+                offset,
+            )
+            .await
+        {
+            Ok(messages) => messages,
+            Err(error) => {
+                tracing::warn!(
+                    account_id = %context.account.id,
+                    offset,
+                    error = %error,
+                    "could not load a recent body-cache candidate page"
+                );
+                page_query_failed = true;
+                break;
+            }
+        };
+        pages_examined += 1;
+        if candidates.is_empty() {
+            saw_empty_page = true;
+            break;
+        }
+        select_recent_candidate_page(candidates, &mut failures, &mut selected);
+    }
+
+    let batch_is_full = selected.len() == BODY_CACHE_WARM_BATCH_LIMIT as usize;
+    *context.recent_candidate_offset.lock().await = if page_query_failed {
+        start_offset
+    } else {
+        next_recent_candidate_offset(start_offset, pages_examined, saw_empty_page, batch_is_full)
+    };
+    *context.recent_failures.lock().await = failures;
+    selected
 }
 
 fn notify_hydration_complete(hydration_complete: &HydrationCompleteHookStore) {
@@ -529,7 +809,7 @@ async fn hydrate_target(
     target: HydrationTarget,
     mut cancel: watch::Receiver<bool>,
 ) -> HydrationResult {
-    let started = std::time::Instant::now();
+    let started = Instant::now();
     if *cancel.borrow() {
         return HydrationResult {
             target,
@@ -539,63 +819,115 @@ async fn hydrate_target(
         };
     }
 
-    if target.kind == HydrationKind::Pending {
-        match store.claim_message_hydration(&target.message.id).await {
-            Ok(true) => {}
-            Ok(false) => {
-                return HydrationResult {
-                    target,
-                    started,
-                    result: Ok(None),
-                    cancelled: false,
-                };
-            }
-            Err(error) => {
-                return HydrationResult {
-                    target,
-                    started,
-                    result: Err(error),
-                    cancelled: false,
-                };
-            }
+    let claim = match store
+        .acquire_message_content_fetch(&target.message.id)
+        .await
+    {
+        Ok(Some(claim)) => claim,
+        // A foreground read owns the fetch/cache claim. It will either commit
+        // the cache or release the claim for a later background cycle.
+        Ok(None) => {
+            return HydrationResult {
+                target,
+                started,
+                result: Ok(None),
+                cancelled: false,
+            };
         }
-    }
+        Err(error) => {
+            return HydrationResult {
+                target,
+                started,
+                result: Err(error),
+                cancelled: false,
+            };
+        }
+    };
 
     let (result, cancelled) = {
-        let hydration = async {
-            match target.kind {
-                HydrationKind::Pending => {
-                    service
-                        .hydrate_inbox_message(&account, target.message.uid as u32)
-                        .await
-                }
-                HydrationKind::Starred => {
-                    service
-                        .hydrate_message(
-                            &account,
-                            &target.message.mailbox,
-                            target.message.uid as u32,
-                        )
-                        .await
-                }
-            }
-        };
-        tokio::pin!(hydration);
+        let fetch_and_cache = fetch_and_cache_target(&store, &service, &account, &target);
+        tokio::pin!(fetch_and_cache);
         tokio::select! {
-            result = &mut hydration => (result.map(Some), false),
+            result = &mut fetch_and_cache => (result, false),
             _ = wait_for_cancellation(&mut cancel) => (Ok(None), true),
         }
     };
-    if target.kind == HydrationKind::Pending && (cancelled || result.is_err()) {
-        let _ = store
-            .set_message_content_state(&target.message.id, "failed")
-            .await;
+    if let Err(error) = claim.release().await {
+        tracing::warn!(
+            message_id = %target.message.id,
+            error = %error,
+            "could not release background body-cache fetch claim"
+        );
     }
     HydrationResult {
         target,
         started,
         result,
         cancelled,
+    }
+}
+
+async fn fetch_and_cache_target(
+    store: &Store,
+    service: &MailService,
+    account: &Account,
+    target: &HydrationTarget,
+) -> anyhow::Result<Option<MailSummary>> {
+    let message = service
+        .fetch_message(account, &target.message.mailbox, target.message.uid as u32)
+        .await?;
+    if persist_display_cache(store, &message).await? {
+        // Cache readiness is local state. Do not upsert the provider snapshot
+        // here: a star/read operation may have finished while this body fetch
+        // was in flight, and stale FLAGS must not undo that user action.
+        store
+            .set_message_content_state(&message.id, "complete")
+            .await?;
+        Ok(Some(message))
+    } else {
+        Ok(None)
+    }
+}
+
+async fn persist_display_cache(store: &Store, message: &MailSummary) -> anyhow::Result<bool> {
+    if !store
+        .update_message_attachment_state(&message.id, message.has_attachments)
+        .await?
+    {
+        return Ok(false);
+    }
+    let content = display_cache_content(message);
+
+    if content_cache_destination(message) == ContentCacheDestination::Starred
+        && store
+            .cache_starred_message_content(&message.id, content.clone())
+            .await?
+    {
+        return Ok(true);
+    }
+
+    // A concurrent unstar makes the regular cache authoritative. Conversely,
+    // if a message was starred while this selective fetch was in flight, the
+    // regular-cache write declines and the final starred attempt owns it.
+    store
+        .cache_message_content(&message.id, false, content.clone())
+        .await?;
+    if store.cached_message_content(&message.id).await?.is_some() {
+        return Ok(true);
+    }
+    store
+        .cache_starred_message_content(&message.id, content)
+        .await
+}
+
+async fn run_cancellable<F, T>(future: F, mut cancel: watch::Receiver<bool>) -> Option<T>
+where
+    F: Future<Output = T>,
+{
+    tokio::pin!(future);
+    tokio::select! {
+        result = &mut future => Some(result),
+        _ = wait_for_cancellation(&mut cancel) => None,
     }
 }
 
@@ -804,10 +1136,17 @@ mod tests {
     }
 
     #[test]
-    fn hydration_plan_prioritizes_pending_and_deduplicates_starred() {
+    fn hydration_plan_prioritizes_pending_recent_and_starred_by_canonical_identity() {
+        let mut pending_duplicate = message("pending-duplicate");
+        pending_duplicate.message_id = Some("<SAME@example.test>".into());
+        let mut recent_duplicate = message("recent-duplicate");
+        recent_duplicate.message_id = Some("<same@example.test>".into());
+        let mut recent = message("recent-1");
+        recent.message_id = Some("<recent@example.test>".into());
         let plan = hydration_plan(
-            vec![message("pending-1"), message("both")],
-            vec![message("both"), message("starred-1")],
+            vec![message("pending-1"), pending_duplicate],
+            vec![recent_duplicate, recent],
+            vec![message("pending-1"), message("starred-1")],
         );
         assert_eq!(
             plan.iter()
@@ -815,10 +1154,165 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![
                 ("pending-1", HydrationKind::Pending),
-                ("both", HydrationKind::Pending),
+                ("pending-duplicate", HydrationKind::Pending),
+                ("recent-1", HydrationKind::Recent),
                 ("starred-1", HydrationKind::Starred),
             ]
         );
+    }
+
+    #[test]
+    fn body_cache_warming_runs_immediately_then_every_fifteen_minutes() {
+        let start = Instant::now();
+        assert!(body_cache_warm_due(None, start));
+        assert!(!body_cache_warm_due(
+            Some(start),
+            start + BODY_CACHE_WARM_INTERVAL - Duration::from_secs(1),
+        ));
+        assert!(body_cache_warm_due(
+            Some(start),
+            start + BODY_CACHE_WARM_INTERVAL,
+        ));
+    }
+
+    #[test]
+    fn recent_body_failures_advance_past_more_than_twelve_hundred_cooling_messages() {
+        let now = Instant::now();
+        let cooling_count =
+            BODY_CACHE_WARM_BATCH_LIMIT * BODY_CACHE_WARM_CANDIDATE_PAGES_PER_CYCLE * 5;
+        let candidates = (0..=cooling_count)
+            .map(|index| message(&format!("recent-{index}")))
+            .collect::<Vec<_>>();
+        let mut failures = (0..cooling_count)
+            .map(|index| (format!("recent-{index}"), now + BODY_CACHE_FAILURE_COOLDOWN))
+            .collect::<HashMap<_, _>>();
+        let mut offset = 0;
+        let window = BODY_CACHE_WARM_BATCH_LIMIT * BODY_CACHE_WARM_CANDIDATE_PAGES_PER_CYCLE;
+
+        // Five bounded warm cycles traverse 1,500 cooling rows without ever
+        // scheduling one. The persisted cursor advances by one page window
+        // each time instead of repeatedly re-querying the newest 300 rows.
+        while offset < cooling_count {
+            let start_offset = offset;
+            let mut selected = Vec::new();
+            for page in 0..BODY_CACHE_WARM_CANDIDATE_PAGES_PER_CYCLE {
+                let page_offset = start_offset + page * BODY_CACHE_WARM_BATCH_LIMIT;
+                let page = candidates
+                    .iter()
+                    .skip(page_offset as usize)
+                    .take(BODY_CACHE_WARM_BATCH_LIMIT as usize)
+                    .cloned()
+                    .collect();
+                select_recent_candidate_page(page, &mut failures, &mut selected);
+            }
+            assert!(selected.is_empty());
+            offset = next_recent_candidate_offset(
+                start_offset,
+                BODY_CACHE_WARM_CANDIDATE_PAGES_PER_CYCLE,
+                false,
+                false,
+            );
+            assert_eq!(offset, start_offset + window);
+        }
+
+        let start_offset = offset;
+        let mut selected = Vec::new();
+        let mut pages_examined = 0;
+        let mut saw_empty_page = false;
+        for page in 0..BODY_CACHE_WARM_CANDIDATE_PAGES_PER_CYCLE {
+            let page_offset = start_offset + page * BODY_CACHE_WARM_BATCH_LIMIT;
+            let page = candidates
+                .iter()
+                .skip(page_offset as usize)
+                .take(BODY_CACHE_WARM_BATCH_LIMIT as usize)
+                .cloned()
+                .collect::<Vec<_>>();
+            pages_examined += 1;
+            if page.is_empty() {
+                saw_empty_page = true;
+                break;
+            }
+            select_recent_candidate_page(page, &mut failures, &mut selected);
+        }
+
+        let expected = format!("recent-{cooling_count}");
+        assert_eq!(
+            selected
+                .iter()
+                .map(|message| message.id.as_str())
+                .collect::<Vec<_>>(),
+            vec![expected.as_str()]
+        );
+        assert!(saw_empty_page);
+        assert_eq!(
+            next_recent_candidate_offset(start_offset, pages_examined, saw_empty_page, false),
+            0,
+            "an empty page wraps the worker cursor for the next warm cycle"
+        );
+    }
+
+    #[tokio::test]
+    async fn cancellation_drops_a_stalled_recent_header_refresh() {
+        let (cancel, receiver) = watch::channel(false);
+        cancel.send(true).unwrap();
+        assert!(run_cancellable(std::future::pending::<()>(), receiver)
+            .await
+            .is_none());
+
+        let (_cancel, receiver) = watch::channel(false);
+        assert_eq!(run_cancellable(async { 42 }, receiver).await, Some(42));
+    }
+
+    #[test]
+    fn display_cache_decision_uses_the_authoritative_flagged_cache() {
+        let regular = message("regular");
+        assert_eq!(
+            content_cache_destination(&regular),
+            ContentCacheDestination::Regular
+        );
+        let mut starred = regular.clone();
+        starred.is_flagged = true;
+        starred.body_text = "display body".into();
+        starred.body_html = Some("<p>display body</p>".into());
+        starred.unsubscribe_kind = Some("mailto".into());
+        assert_eq!(
+            content_cache_destination(&starred),
+            ContentCacheDestination::Starred
+        );
+        let content = display_cache_content(&starred);
+        assert_eq!(content.body_text, "display body");
+        assert_eq!(content.body_html.as_deref(), Some("<p>display body</p>"));
+        assert_eq!(content.unsubscribe_kind.as_deref(), Some("mailto"));
+    }
+
+    #[tokio::test]
+    async fn background_cache_commit_preserves_concurrent_star_changes() {
+        let store = Store::in_memory().await.unwrap();
+        let local = message("star-race");
+        store
+            .upsert_messages(std::slice::from_ref(&local))
+            .await
+            .unwrap();
+
+        let mut stale_starred = local.clone();
+        stale_starred.is_flagged = true;
+        stale_starred.body_text = "fetched while starred".into();
+        assert!(persist_display_cache(&store, &stale_starred).await.unwrap());
+        assert!(!store.message(&local.id).await.unwrap().unwrap().is_flagged);
+        assert!(store
+            .cached_message_content(&local.id)
+            .await
+            .unwrap()
+            .is_some());
+
+        store.set_message_flagged(&local.id, true).await.unwrap();
+        let mut stale_unstarred = local.clone();
+        stale_unstarred.body_text = "fetched before star".into();
+        assert!(persist_display_cache(&store, &stale_unstarred)
+            .await
+            .unwrap());
+        assert!(store.message(&local.id).await.unwrap().unwrap().is_flagged);
+        assert!(store.starred_body(&local.id).await.unwrap().is_some());
     }
 
     #[test]
@@ -837,41 +1331,53 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hydration_worker_queues_a_second_cycle_while_the_first_is_active() {
-        let (sender, receiver) = mpsc::channel(1);
+    async fn stalled_warm_batch_does_not_block_the_next_idle_arrival() {
+        let (arrival_sender, arrival_receiver) = mpsc::unbounded_channel();
+        let (maintenance_sender, maintenance_receiver) = mpsc::channel(1);
         let (_cancel, cancel_receiver) = watch::channel(false);
         let started = Arc::new(tokio::sync::Notify::new());
         let release = Arc::new(tokio::sync::Notify::new());
         let processed = Arc::new(Mutex::new(Vec::new()));
-        let worker = tokio::spawn(run_queued_hydration_batches(receiver, cancel_receiver, {
-            let started = started.clone();
-            let release = release.clone();
-            let processed = processed.clone();
-            move |batch: Vec<u32>, _| {
+        let worker = tokio::spawn(run_prioritized_hydration_batches(
+            arrival_receiver,
+            maintenance_receiver,
+            cancel_receiver,
+            {
                 let started = started.clone();
                 let release = release.clone();
                 let processed = processed.clone();
-                async move {
-                    if batch == [1] {
-                        started.notify_one();
-                        release.notified().await;
+                move |batch: Vec<u32>, _| {
+                    let started = started.clone();
+                    let release = release.clone();
+                    let processed = processed.clone();
+                    async move {
+                        if batch == [99] {
+                            started.notify_one();
+                            release.notified().await;
+                        }
+                        processed.lock().await.extend(batch);
                     }
-                    processed.lock().await.extend(batch);
                 }
-            }
-        }));
+            },
+        ));
 
-        sender.send(vec![1]).await.unwrap();
+        maintenance_sender.send(vec![99]).await.unwrap();
         started.notified().await;
-        sender
-            .send(vec![2])
-            .await
-            .expect("the later realtime cycle must be queued");
-        drop(sender);
+        // This is the next ~5-second IDLE cycle. Unlike the former bounded
+        // combined queue, sending its arrival cannot await the stalled warm.
+        arrival_sender
+            .send(vec![1])
+            .expect("the next arrival must queue without waiting for warming");
+        maintenance_sender
+            .try_send(vec![100])
+            .expect("one maintenance request may wait behind the active warm");
+        assert!(maintenance_sender.try_send(vec![101]).is_err());
+        drop(arrival_sender);
+        drop(maintenance_sender);
         release.notify_one();
         worker.await.unwrap();
 
-        assert_eq!(*processed.lock().await, vec![1, 2]);
+        assert_eq!(*processed.lock().await, vec![99, 1, 100]);
     }
 
     #[tokio::test]

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -24,6 +24,7 @@ const mocks = vi.hoisted(() => {
     (progress: MailRebuildProgress) => void
   > = [];
   const hydratedHandlers: Array<() => void> = [];
+  const mailChangedHandlers: Array<() => void> = [];
   const nativeMenuHandlers: Array<(action: string) => void> = [];
   const notificationActionHandlers: Array<
     (extra: Record<string, unknown>) => void | Promise<void>
@@ -132,6 +133,7 @@ const mocks = vi.hoisted(() => {
     accountUpdatedHandlers,
     rebuildProgressHandlers,
     hydratedHandlers,
+    mailChangedHandlers,
     nativeMenuHandlers,
     notificationActionHandlers,
     desktopNotificationActionHandlers,
@@ -159,6 +161,10 @@ const mocks = vi.hoisted(() => {
     ),
     onMailHydrated: vi.fn(async (handler: () => void) => {
       hydratedHandlers.push(handler);
+      return unlisten;
+    }),
+    onMailChanged: vi.fn(async (handler: () => void) => {
+      mailChangedHandlers.push(handler);
       return unlisten;
     }),
   };
@@ -201,6 +207,7 @@ vi.mock("./nativeWindows", () => ({
   onAccountRemoved: mocks.onAccountRemoved,
   onAccountUpdated: mocks.onAccountUpdated,
   onMailArrived: mocks.noopListener,
+  onMailChanged: mocks.onMailChanged,
   onMailHydrated: mocks.onMailHydrated,
   onMailIndexRebuilt: mocks.noopListener,
   onMailRebuildProgress: mocks.onMailRebuildProgress,
@@ -225,6 +232,7 @@ describe("App read state", () => {
     vi.clearAllMocks();
     mocks.rebuildProgressHandlers.length = 0;
     mocks.hydratedHandlers.length = 0;
+    mocks.mailChangedHandlers.length = 0;
     mocks.nativeMenuHandlers.length = 0;
     mocks.notificationActionHandlers.length = 0;
     mocks.desktopNotificationActionHandlers.length = 0;
@@ -523,6 +531,26 @@ describe("App read state", () => {
     finishFirstPass(0);
     await waitFor(() =>
       expect(mocks.api.classifyPending).toHaveBeenCalledTimes(2),
+    );
+  });
+
+  it("reloads the visible catalogue after a quiet background mail refresh", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    await screen.findByText("Unread thread");
+    await waitFor(() =>
+      expect(mocks.mailChangedHandlers.length).toBeGreaterThan(0),
+    );
+    const searchesBeforeRefresh = mocks.api.search.mock.calls.length;
+    act(() => mocks.mailChangedHandlers.at(-1)!());
+    await waitFor(() =>
+      expect(mocks.api.search.mock.calls.length).toBeGreaterThan(
+        searchesBeforeRefresh,
+      ),
     );
   });
 

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -41,6 +41,7 @@ import {
   onAccountRemoved,
   onAccountUpdated,
   onMailArrived,
+  onMailChanged,
   onMailHydrated,
   onMailIndexRebuilt,
   onMailRebuildProgress,
@@ -935,6 +936,9 @@ export default function App() {
       }),
       onMailHydrated(() => {
         void classifyPending();
+      }),
+      onMailChanged(() => {
+        void loadMessages().catch(showError);
       }),
       onMailSyncState(() => undefined),
     ])

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -81,6 +81,7 @@ describe("Reader unsubscribe action", () => {
       body_text: "Tere maailm",
       attachments: [],
     });
+    vi.spyOn(api, "hydrateMessage").mockResolvedValue(message);
     vi.spyOn(api, "translationModels").mockResolvedValue([
       {
         source: "et",
@@ -170,7 +171,20 @@ describe("Reader unsubscribe action", () => {
     expect(screen.getByText("Sent by you")).toBeVisible();
   });
 
-  it("shows a localized loading state for header-first arrivals", () => {
+  it("loads an expanded complete message through content without foreground hydration", async () => {
+    render(
+      <MantineProvider>
+        <Reader {...props} message={message} />
+      </MantineProvider>,
+    );
+
+    expect(await screen.findByText("Tere maailm")).toBeVisible();
+    expect(api.content).toHaveBeenCalledTimes(1);
+    expect(api.content).toHaveBeenCalledWith(message.id);
+    expect(api.hydrateMessage).not.toHaveBeenCalled();
+  });
+
+  it("loads header-first arrivals through content without foreground hydration", async () => {
     render(
       <MantineProvider>
         <Reader
@@ -182,6 +196,38 @@ describe("Reader unsubscribe action", () => {
     expect(screen.getByRole("status")).toHaveTextContent(
       "Loading the full message",
     );
+    expect(await screen.findByText("Tere maailm")).toBeVisible();
+    expect(api.content).toHaveBeenCalledTimes(1);
+    expect(api.content).toHaveBeenCalledWith(message.id);
+    expect(api.hydrateMessage).not.toHaveBeenCalled();
+  });
+
+  it("retries content without foreground hydration after a load failure", async () => {
+    vi.mocked(api.content)
+      .mockRejectedValueOnce(new Error("content unavailable"))
+      .mockResolvedValueOnce({ body_text: "Recovered body", attachments: [] });
+    render(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={{ ...message, body_text: "", content_state: "headers_only" }}
+        />
+      </MantineProvider>,
+    );
+
+    expect(
+      await screen.findByText(
+        "This message could not be fetched from the mail server.",
+      ),
+    ).toBeVisible();
+    expect(api.content).toHaveBeenCalledTimes(1);
+    expect(api.hydrateMessage).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
+    expect(await screen.findByText("Recovered body")).toBeVisible();
+    expect(api.content).toHaveBeenCalledTimes(2);
+    expect(api.content).toHaveBeenLastCalledWith(message.id);
+    expect(api.hydrateMessage).not.toHaveBeenCalled();
   });
 
   it("offers forwarding from the message actions menu", async () => {

--- a/apps/desktop/src/components/Reader.tsx
+++ b/apps/desktop/src/components/Reader.tsx
@@ -537,7 +537,6 @@ function ThreadMessage({
   const [exporting, setExporting] = useState(false);
   const [exportStatus, setExportStatus] = useState<string>();
   const exportInFlight = useRef(false);
-  const [hydrationRequested, setHydrationRequested] = useState(false);
   const [recipientsExpanded, setRecipientsExpanded] = useState(false);
   const summaryDescriptionId = useId();
   const displayContent = translatedContent ?? content;
@@ -554,19 +553,6 @@ function ThreadMessage({
     setAttachments([]);
     setAttachmentsAuthoritative(false);
   }, [message.id]);
-
-  useEffect(() => {
-    if (
-      !isExpanded ||
-      !message.content_state ||
-      message.content_state === "complete" ||
-      message.content_state === "hydrating" ||
-      hydrationRequested
-    )
-      return;
-    setHydrationRequested(true);
-    void api.hydrateMessage(message.id).catch(() => undefined);
-  }, [hydrationRequested, isExpanded, message.content_state, message.id]);
 
   useEffect(() => {
     if (!isExpanded) return;

--- a/apps/desktop/src/nativeWindows.ts
+++ b/apps/desktop/src/nativeWindows.ts
@@ -195,6 +195,15 @@ export function onMailHydrated(
   );
 }
 
+export function onMailChanged(
+  handler: (accountId: string) => void,
+): Promise<UnlistenFn> {
+  if (!isTauri()) return Promise.resolve(() => undefined);
+  return listen<{ accountId: string }>("mail-changed", (event) =>
+    handler(event.payload.accountId),
+  );
+}
+
 export function onMailIndexRebuilt(
   handler: (accountId: string) => void,
 ): Promise<UnlistenFn> {

--- a/crates/dakia-cli/src/main.rs
+++ b/crates/dakia-cli/src/main.rs
@@ -635,11 +635,24 @@ async fn download_attachment(
     args: DownloadAttachmentArgs,
     json: bool,
 ) -> Result<()> {
-    let message = fetch_message(store, &args.message_id).await?;
-    let attachment = message
-        .attachments
-        .into_iter()
-        .find(|item| item.attachment.id == args.attachment_id)
+    let summary = store
+        .message(&args.message_id)
+        .await?
+        .context("message not found")?;
+    let account_id =
+        Uuid::parse_str(&summary.account_id).context("stored message has an invalid account ID")?;
+    let account = store
+        .account(account_id)
+        .await?
+        .context("account not found")?;
+    let attachment = MailService::new(store.clone())
+        .fetch_attachment(
+            &account,
+            &summary.mailbox,
+            u32::try_from(summary.uid).context("stored message has an invalid UID")?,
+            &args.attachment_id,
+        )
+        .await
         .context("attachment not found")?;
     let mut output = OpenOptions::new()
         .write(true)

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -3,7 +3,8 @@ use crate::storage::ThreadingHeaders;
 use crate::{
     flowed::decode_format_flowed,
     mime_budget::{
-        preflight_raw_message, validate_header_bytes, validate_structure, MAX_RAW_MESSAGE_BYTES,
+        preflight_raw_message, validate_header_bytes, validate_structure, MAX_MIME_HEADER_BYTES,
+        MAX_MIME_PARTS, MAX_MULTIPART_NESTING, MAX_RAW_MESSAGE_BYTES,
     },
     oauth::OAuthTokens,
     provider::Security,
@@ -33,7 +34,11 @@ use mail_parser::{
 use percent_encoding::percent_decode_str;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{net::IpAddr, sync::Arc};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    net::IpAddr,
+    sync::Arc,
+};
 use tokio::{
     io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
     net::TcpStream,
@@ -54,6 +59,22 @@ const DKIM_VERIFY_TIMEOUT: Duration = Duration::from_secs(5);
 const UNSUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_ATTACHMENT_BYTES: usize = 25 * 1024 * 1024;
 const MAX_ATTACHMENT_TOTAL_BYTES: usize = 50 * 1024 * 1024;
+/// Display hydration is deliberately sectioned.  These limits apply before a
+/// server literal is allocated, so a malformed BODYSTRUCTURE cannot turn an
+/// ordinary message open into an unbounded allocation.
+const MAX_DISPLAY_PART_BYTES: usize = 25 * 1024 * 1024;
+const MAX_DISPLAY_TOTAL_BYTES: usize = 50 * 1024 * 1024;
+/// Base64 transport and line folding can make a valid 25 MiB attachment
+/// appreciably larger on the wire.  The decoded limit remains authoritative.
+const MAX_TARGETED_ATTACHMENT_ENCODED_BYTES: usize = 36 * 1024 * 1024;
+/// Do not let a malicious BODYSTRUCTURE response grow an unbounded String
+/// before the MIME parser has a chance to enforce its structural limits.
+const MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES: usize = MAX_MIME_HEADER_BYTES;
+const MAX_IMAP_RESPONSE_LITERALS: usize = 64;
+/// Explicit raw export/full-forward operations may need transport encoding
+/// overhead beyond decoded attachment limits, but never receive an unbounded
+/// server response.
+const MAX_IMAP_RESPONSE_LITERAL_BYTES: usize = 100 * 1024 * 1024;
 const MAX_ATTACHMENT_COUNT: usize = 50;
 const MIME_CONTENT_UNDECODABLE: &str = "mime_content_undecodable";
 const MAX_OUTBOUND_ATTACHMENT_BYTES: usize = 25 * 1024 * 1024;
@@ -396,10 +417,13 @@ impl MailService {
         let highest_processed_uid = uids.iter().copied().max();
         for uid in uids {
             let fields = "FLAGS INTERNALDATE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)]";
-            let response = client
-                .command_with_literal(&format!("UID FETCH {uid} ({fields})"))
+            let mut response = client
+                .command_with_literal_limited(
+                    &format!("UID FETCH {uid} ({fields})"),
+                    MAX_MIME_HEADER_BYTES,
+                )
                 .await?;
-            if let Some(raw) = response.literal {
+            if let Some(raw) = response.take_header_literal_for(uid) {
                 match parse_header_message(account, "INBOX", uid, &response.lines, &raw) {
                     Ok(message) => messages.push(message),
                     Err(error) => {
@@ -433,34 +457,10 @@ impl MailService {
         mailbox: &str,
         uid: u32,
     ) -> Result<MailSummary> {
-        let secret = self.credentials.secret(account).await?;
-        let mut client = ImapClient::connect(account).await?;
-        client.authenticate(account, &secret).await?;
-        client
-            .command(&format!(
-                "SELECT {}",
-                quote_imap(&remote_mailbox(account, mailbox))
-            ))
-            .await?;
-        let response = client
-            .command_with_literal(&hydration_fetch_command(account, uid))
-            .await?;
-        let raw = response
-            .literal
-            .context("IMAP server did not return the requested message")?;
-        let message = parse_message(
-            account,
-            mailbox,
-            uid,
-            &response.lines,
-            &raw,
-            self.dkim_authenticator.as_ref(),
-        )
-        .await?;
+        let message = self.fetch_message(account, mailbox, uid).await?;
         self.store
             .upsert_messages(std::slice::from_ref(&message))
             .await?;
-        let _ = client.command("LOGOUT").await;
         Ok(message)
     }
 
@@ -799,10 +799,13 @@ impl MailService {
                     } else {
                         "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
                     };
-                    let response = client
-                        .command_with_literal(&format!("UID FETCH {uid} ({fields})"))
+                    let mut response = client
+                        .command_with_literal_limited(
+                            &format!("UID FETCH {uid} ({fields})"),
+                            MAX_MIME_HEADER_BYTES,
+                        )
                         .await?;
-                    if let Some(headers) = response.literal {
+                    if let Some(headers) = response.take_header_literal_for(*uid) {
                         if !item.plan.skip_gmail_system_labels
                             || gmail_all_mail_is_archive(&response.lines)
                         {
@@ -812,7 +815,9 @@ impl MailService {
                                 ))
                                 .await
                                 .ok()
-                                .and_then(|response| response.literal)
+                                .and_then(|mut response| {
+                                    response.take_body_literal_for(*uid, "TEXT")
+                                })
                                 .map(|raw| snippet_from_partial(&raw))
                                 .unwrap_or_default();
                             match parse_catalog_message(
@@ -901,9 +906,137 @@ impl MailService {
         })
     }
 
-    /// Fetches a complete message only for an explicit foreground action.
-    /// The returned body and attachment bytes are transient and are never
-    /// written back to the catalogue.
+    /// Refreshes a small, recent catalogue window for the primary reader
+    /// folders without hydrating message bodies. `max_messages` is an account
+    /// total (not a per-folder multiplier): work is allocated round-robin in
+    /// INBOX, Sent, Archive order, while each mailbox contributes its newest
+    /// UIDs first. This keeps a busy INBOX from starving Sent and Archive.
+    ///
+    /// The method deliberately requires established catalogue identities. A
+    /// UIDVALIDITY change is reported to the caller for a full sync; this
+    /// refresh never resets a mailbox or marks historical work complete.
+    pub async fn refresh_recent_main_mailboxes(
+        &self,
+        account: &Account,
+        cutoff: chrono::DateTime<Utc>,
+        max_messages: u32,
+    ) -> Result<Vec<MailSummary>> {
+        if max_messages == 0 {
+            return Ok(Vec::new());
+        }
+        let secret = self.credentials.secret(account).await?;
+        let mut client = ImapClient::connect(account).await?;
+        client.authenticate(account, &secret).await?;
+        let listing = client.command("LIST \"\" \"*\"").await.unwrap_or_default();
+        let plans =
+            refresh_main_mailbox_plans(resolve_special_mailboxes(mailbox_plans(account), &listing));
+        let since = imap_since_date(cutoff);
+        let mut work = Vec::new();
+
+        // First establish every selected mailbox identity and its recent UID
+        // set. No catalogue writes occur until all UIDVALIDITY checks pass.
+        for plan in plans {
+            let selected = match client
+                .command(&format!("SELECT {}", quote_imap(&plan.remote)))
+                .await
+            {
+                Ok(selected) => selected,
+                Err(error) if plan.local != "INBOX" => {
+                    tracing::debug!(%error, mailbox = %plan.remote, "recent refresh mailbox unavailable");
+                    continue;
+                }
+                Err(error) => return Err(error).context("IMAP server does not expose an inbox"),
+            };
+            let uid_validity = parse_uid_validity(&selected)
+                .context("IMAP server omitted UIDVALIDITY after SELECT")?;
+            let state = match self.store.mailbox_catalog_state(account.id, &plan.storage).await? {
+                Some(state) => state,
+                None if plan.local != "INBOX" => continue,
+                None => bail!("mailbox catalogue is not initialized; sync the account before refreshing recent mail"),
+            };
+            verify_mailbox_uid_validity(uid_validity, state.uid_validity, "refreshing recent")?;
+            let search = client.command(&recent_uid_search_command(&since)).await?;
+            work.push(RecentRefreshWork {
+                plan,
+                state,
+                uid_validity,
+                uids: recent_uids_newest_first(parse_search_uids(&search)),
+                selected_uids: Vec::new(),
+            });
+        }
+        allocate_recent_refresh_uids(&mut work, max_messages as usize);
+
+        let mut refreshed = Vec::new();
+        for item in &work {
+            if item.selected_uids.is_empty() {
+                continue;
+            }
+            let expected_flags = self
+                .store
+                .capture_recent_catalogue_expected_flags(
+                    account.id,
+                    &item.plan.storage,
+                    &item.selected_uids,
+                )
+                .await?;
+            client
+                .command(&format!("SELECT {}", quote_imap(&item.plan.remote)))
+                .await?;
+            let mut messages = Vec::with_capacity(item.selected_uids.len());
+            for uid in &item.selected_uids {
+                let mut response = client
+                    .command_with_literal_limited(
+                        &format!("UID FETCH {uid} ({})", catalogue_fetch_fields(account)),
+                        MAX_DISPLAY_PART_BYTES,
+                    )
+                    .await?;
+                if item.plan.skip_gmail_system_labels && !gmail_all_mail_is_archive(&response.lines)
+                {
+                    continue;
+                }
+                let snippet = recent_catalogue_snippet(&mut client, *uid, &response).await?;
+                let Some(headers) = response.take_header_literal_for(*uid) else {
+                    continue;
+                };
+                messages.push(parse_catalog_message(
+                    account,
+                    &item.plan.storage,
+                    *uid,
+                    &response.lines,
+                    &headers,
+                    snippet,
+                )?);
+            }
+            // Inserts carry provider FLAGS. Existing rows accept them only
+            // when their local flags still match the pre-FETCH snapshot, so
+            // remote-client changes propagate without undoing a concurrent
+            // local read/star action.
+            // We intentionally do not call `reconcile_mailbox_uids`: a SINCE
+            // result cannot distinguish an absent recent row from an older
+            // local row, so full reconciliation here could delete history.
+            self.store
+                .upsert_recent_catalog_messages(&messages, &expected_flags)
+                .await?;
+            self.store
+                .save_mailbox_catalog_state(
+                    account.id,
+                    &item.plan.storage,
+                    &item.plan.remote,
+                    item.uid_validity,
+                    item.state.remote_total.max(0) as usize,
+                    item.state.historical_complete,
+                )
+                .await?;
+            refreshed.extend(messages);
+        }
+        let _ = client.command("LOGOUT").await;
+        Ok(refreshed)
+    }
+
+    /// Fetches display-safe message content without retrieving the complete
+    /// RFC822 source or ordinary attachment bodies.  `AttachmentData::bytes`
+    /// is intentionally empty; callers that need bytes must use
+    /// [`Self::fetch_attachment`] or [`Self::fetch_full_message`].
     pub async fn fetch_message(
         &self,
         account: &Account,
@@ -923,18 +1056,53 @@ impl MailService {
             .await?;
         let current_uid_validity = parse_uid_validity(&selected)
             .context("IMAP server omitted UIDVALIDITY after SELECT")?;
-        if i64::from(current_uid_validity) != state.uid_validity {
-            bail!("mailbox identity changed; sync the account before opening this message");
-        }
-        let fields = if account.provider_id == "gmail" {
-            "FLAGS INTERNALDATE X-GM-LABELS RFC822"
-        } else {
-            "FLAGS INTERNALDATE RFC822"
-        };
-        let response = client
-            .command_with_literal(&format!("UID FETCH {uid} ({fields})"))
+        verify_mailbox_uid_validity(current_uid_validity, state.uid_validity, "opening")?;
+        let fields = selective_metadata_fetch_fields(account);
+        let mut response = client
+            .command_with_literal_limited(
+                &format!("UID FETCH {uid} ({fields})"),
+                MAX_MIME_HEADER_BYTES,
+            )
             .await?;
-        let raw = response.literal.context("message is no longer available")?;
+        let structure = parse_bodystructure_response(&response)?;
+        let headers = response
+            .take_header_literal_for(uid)
+            .context("message is no longer available")?;
+        let message = fetch_selective_message(
+            &mut client,
+            account,
+            mailbox,
+            uid,
+            &response.lines,
+            &headers,
+            &structure,
+        )
+        .await?;
+        let _ = client.command("LOGOUT").await;
+        Ok(message)
+    }
+
+    /// Fetches the complete RFC822 message for explicit operations such as
+    /// forwarding or saving every attachment.  This remains read-neutral but
+    /// is intentionally not used by reader display/prefetch.
+    pub async fn fetch_full_message(
+        &self,
+        account: &Account,
+        mailbox: &str,
+        uid: u32,
+    ) -> Result<MailSummary> {
+        let (mut client, _state) = self
+            .select_catalogued_mailbox(account, mailbox, "opening")
+            .await?;
+        let mut response = client
+            .command_with_literal_limited(
+                &hydration_fetch_command(account, uid),
+                MAX_IMAP_RESPONSE_LITERAL_BYTES,
+            )
+            .await?;
+        let raw = response
+            .take_body_literal_for(uid, "")
+            .context("message is no longer available")?;
         let message = parse_message(
             account,
             mailbox,
@@ -946,6 +1114,79 @@ impl MailService {
         .await?;
         let _ = client.command("LOGOUT").await;
         Ok(message)
+    }
+
+    /// Fetches exactly one downloadable attachment identified by the metadata
+    /// returned from [`Self::fetch_message`].
+    pub async fn fetch_attachment(
+        &self,
+        account: &Account,
+        mailbox: &str,
+        uid: u32,
+        attachment_id: &str,
+    ) -> Result<AttachmentData> {
+        let (mut client, _state) = self
+            .select_catalogued_mailbox(account, mailbox, "saving")
+            .await?;
+        let mut metadata = client
+            .command_with_literal_limited(
+                &format!(
+                    "UID FETCH {uid} ({})",
+                    selective_metadata_fetch_fields(account)
+                ),
+                MAX_MIME_HEADER_BYTES,
+            )
+            .await?;
+        let structure = parse_bodystructure_response(&metadata)?;
+        let headers = metadata
+            .take_header_literal_for(uid)
+            .context("message is no longer available")?;
+        let plan = selective_plan(&structure)?;
+        let id = stable_message_id(account.id, mailbox, uid);
+        let attachment = plan
+            .attachments
+            .into_iter()
+            .find(|part| part.attachment_id(&id) == attachment_id)
+            .context("attachment is not available for download")?;
+        let header =
+            fetch_section_mime_headers(&mut client, uid, &attachment.part.path, Some(&headers))
+                .await?;
+        let mut response = client
+            .command_with_literal_limited(
+                &section_fetch_command(uid, &attachment.part.path),
+                MAX_TARGETED_ATTACHMENT_ENCODED_BYTES,
+            )
+            .await?;
+        let bytes = response
+            .take_body_literal_for(uid, &response_body_section(&attachment.part.path))
+            .context("attachment is no longer available")?;
+        let data = attachment_data_from_part(&attachment, &id, &header, Some(bytes), false)?;
+        validate_targeted_attachment_bytes(&data.bytes)?;
+        let _ = client.command("LOGOUT").await;
+        Ok(data)
+    }
+
+    async fn select_catalogued_mailbox(
+        &self,
+        account: &Account,
+        mailbox: &str,
+        action: &str,
+    ) -> Result<(ImapClient, crate::storage::MailboxCatalogState)> {
+        let state = self
+            .store
+            .mailbox_catalog_state(account.id, mailbox)
+            .await?
+            .context("mailbox catalogue is not initialized")?;
+        let secret = self.credentials.secret(account).await?;
+        let mut client = ImapClient::connect(account).await?;
+        client.authenticate(account, &secret).await?;
+        let selected = client
+            .command(&format!("SELECT {}", quote_imap(&state.remote_name)))
+            .await?;
+        let current_uid_validity = parse_uid_validity(&selected)
+            .context("IMAP server omitted UIDVALIDITY after SELECT")?;
+        verify_mailbox_uid_validity(current_uid_validity, state.uid_validity, action)?;
+        Ok((client, state))
     }
 
     /// Fetches the original RFC 822 bytes for an explicit export without
@@ -974,13 +1215,13 @@ impl MailService {
             .await?;
         let current_uid_validity = parse_uid_validity(&selected)
             .context("IMAP server omitted UIDVALIDITY after SELECT")?;
-        if i64::from(current_uid_validity) != state.uid_validity {
-            bail!("mailbox identity changed; sync the account before exporting this message");
-        }
-        let response = client
+        verify_mailbox_uid_validity(current_uid_validity, state.uid_validity, "exporting")?;
+        let mut response = client
             .command_with_literal(&raw_message_fetch_command(uid))
             .await?;
-        let raw = response.literal.context("message is no longer available")?;
+        let raw = response
+            .take_body_literal_for(uid, "")
+            .context("message is no longer available")?;
         let _ = client.command("LOGOUT").await;
         Ok(raw)
     }
@@ -1049,10 +1290,13 @@ impl MailService {
                     } else {
                         "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
                     };
-                    let response = client
-                        .command_with_literal(&format!("UID FETCH {uid} ({fields})"))
+                    let mut response = client
+                        .command_with_literal_limited(
+                            &format!("UID FETCH {uid} ({fields})"),
+                            MAX_MIME_HEADER_BYTES,
+                        )
                         .await?;
-                    if let Some(headers) = response.literal {
+                    if let Some(headers) = response.take_header_literal_for(uid) {
                         if plan.skip_gmail_system_labels
                             && !gmail_all_mail_is_archive(&response.lines)
                         {
@@ -1062,7 +1306,7 @@ impl MailService {
                             .command_with_literal(&format!("UID FETCH {uid} (BODY.PEEK[]<0.8192>)"))
                             .await
                             .ok()
-                            .and_then(|response| response.literal)
+                            .and_then(|mut response| response.take_body_literal_for(uid, "TEXT"))
                             .map(|raw| snippet_from_partial(&raw))
                             .unwrap_or_default();
                         let Ok(message) = parse_catalog_message(
@@ -1603,7 +1847,56 @@ struct ImapClient {
 }
 struct ImapResponse {
     lines: Vec<String>,
-    literal: Option<Vec<u8>>,
+    /// Every server literal in transcript order. The associated FETCH item
+    /// keeps a literal BODYSTRUCTURE parameter from being mistaken for the
+    /// header/body requested by a caller.
+    literals: Vec<ImapLiteral>,
+}
+
+struct ImapLiteral {
+    /// UID from the untagged FETCH that introduced this literal.  IMAP may
+    /// interleave unsolicited FETCH replies while a command is outstanding.
+    uid: Option<u32>,
+    data_item: ImapLiteralItem,
+    bytes: Vec<u8>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum ImapLiteralItem {
+    BodyStructure,
+    Body(String),
+    Other,
+}
+
+impl ImapResponse {
+    fn take_header_literal_for(&mut self, uid: u32) -> Option<Vec<u8>> {
+        self.take_literal_for(uid, |item| {
+            matches!(item, ImapLiteralItem::Body(value) if body_item_section(value).is_some_and(|section| section.to_ascii_uppercase().starts_with("HEADER")))
+        })
+    }
+
+    fn take_body_literal_for(&mut self, uid: u32, section: &str) -> Option<Vec<u8>> {
+        self.take_literal_for(uid, |item| {
+            matches!(item, ImapLiteralItem::Body(value) if body_item_section(value).is_some_and(|actual| actual.eq_ignore_ascii_case(section)))
+        })
+    }
+
+    fn take_literal_for(
+        &mut self,
+        uid: u32,
+        matches: impl Fn(&ImapLiteralItem) -> bool,
+    ) -> Option<Vec<u8>> {
+        self.literals
+            .iter()
+            .position(|literal| literal.uid == Some(uid) && matches(&literal.data_item))
+            .map(|index| self.literals.remove(index).bytes)
+    }
+}
+
+fn body_item_section(value: &str) -> Option<&str> {
+    let start = value.find('[')? + 1;
+    let end = value[start..].find(']')? + start;
+    Some(&value[start..end])
 }
 
 enum IdleOutcome {
@@ -1627,6 +1920,14 @@ struct MailboxSyncWork {
     previous_highest: Option<u32>,
     uids: Vec<u32>,
     offset: usize,
+}
+
+struct RecentRefreshWork {
+    plan: MailboxPlan,
+    state: crate::storage::MailboxCatalogState,
+    uid_validity: u32,
+    uids: Vec<u32>,
+    selected_uids: Vec<u32>,
 }
 
 impl MailboxPlan {
@@ -1808,6 +2109,1071 @@ fn hydration_fetch_command(account: &Account, uid: u32) -> String {
 
 fn raw_message_fetch_command(uid: u32) -> String {
     format!("UID FETCH {uid} (BODY.PEEK[])")
+}
+
+fn refresh_main_mailbox_plans(plans: Vec<MailboxPlan>) -> Vec<MailboxPlan> {
+    plans
+        .into_iter()
+        .filter(|plan| matches!(plan.local, "INBOX" | "Sent" | "Archive"))
+        .collect()
+}
+
+fn imap_since_date(cutoff: chrono::DateTime<Utc>) -> String {
+    cutoff.format("%d-%b-%Y").to_string()
+}
+
+fn recent_uid_search_command(since: &str) -> String {
+    format!("UID SEARCH SINCE {since}")
+}
+
+fn recent_uids_newest_first(mut uids: Vec<u32>) -> Vec<u32> {
+    uids.sort_unstable_by(|left, right| right.cmp(left));
+    uids.dedup();
+    uids
+}
+
+fn allocate_recent_refresh_uids(work: &mut [RecentRefreshWork], max_messages: usize) {
+    for item in work.iter_mut() {
+        item.selected_uids.clear();
+    }
+    let mut remaining = max_messages;
+    while remaining > 0 {
+        let mut allocated = false;
+        for item in work.iter_mut() {
+            if remaining == 0 {
+                break;
+            }
+            if let Some(uid) = item.uids.get(item.selected_uids.len()).copied() {
+                item.selected_uids.push(uid);
+                remaining -= 1;
+                allocated = true;
+            }
+        }
+        if !allocated {
+            break;
+        }
+    }
+}
+
+fn catalogue_fetch_fields(account: &Account) -> &'static str {
+    if account.provider_id == "gmail" {
+        "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE X-GM-LABELS BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE CONTENT-TRANSFER-ENCODING LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
+    } else {
+        "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE CONTENT-TRANSFER-ENCODING LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
+    }
+}
+
+fn section_partial_fetch_command(uid: u32, path: &[usize], length: usize) -> String {
+    let section = if path.is_empty() {
+        "TEXT".into()
+    } else {
+        section_name(path)
+    };
+    format!("UID FETCH {uid} (BODY.PEEK[{section}]<0.{length}>)")
+}
+
+async fn recent_catalogue_snippet(
+    client: &mut ImapClient,
+    uid: u32,
+    metadata_response: &ImapResponse,
+) -> Result<String> {
+    let structure = match parse_bodystructure_response(metadata_response)
+        .and_then(|structure| selective_plan(&structure))
+    {
+        Ok(plan) => plan,
+        Err(_) => return Ok(String::new()),
+    };
+    let Some(part) = structure.text_parts.first() else {
+        return Ok(String::new());
+    };
+    let mut response = client
+        .command_with_literal_limited(
+            &section_partial_fetch_command(uid, &part.part.path, 8192),
+            8192,
+        )
+        .await?;
+    let section = if part.part.path.is_empty() {
+        "TEXT".to_owned()
+    } else {
+        section_name(&part.part.path)
+    };
+    let Some(raw) = response.take_body_literal_for(uid, &section) else {
+        return Ok(String::new());
+    };
+    Ok(snippet_from_partial(&mime_part_headers(&part.part, &raw)))
+}
+
+fn mime_part_headers(part: &MimePart, body: &[u8]) -> Vec<u8> {
+    let mut headers = format!("Content-Type: {}", part.mime_type);
+    for (name, value) in &part.params {
+        headers.push_str(&format!("; {name}=\"{value}\""));
+    }
+    if !part.transfer_encoding.is_empty() {
+        headers.push_str(&format!(
+            "\r\nContent-Transfer-Encoding: {}",
+            part.transfer_encoding
+        ));
+    }
+    headers.push_str("\r\n\r\n");
+    let mut result = headers.into_bytes();
+    result.extend_from_slice(body);
+    result
+}
+
+fn selective_metadata_fetch_fields(account: &Account) -> &'static str {
+    if account.provider_id == "gmail" {
+        "FLAGS INTERNALDATE X-GM-LABELS BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE CONTENT-TRANSFER-ENCODING LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
+    } else {
+        "FLAGS INTERNALDATE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE CONTENT-TRANSFER-ENCODING LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
+    }
+}
+
+fn section_name(path: &[usize]) -> String {
+    path.iter()
+        .map(usize::to_string)
+        .collect::<Vec<_>>()
+        .join(".")
+}
+
+fn section_fetch_command(uid: u32, path: &[usize]) -> String {
+    let section = response_body_section(path);
+    format!("UID FETCH {uid} (BODY.PEEK[{section}])")
+}
+
+fn response_body_section(path: &[usize]) -> String {
+    if path.is_empty() {
+        "TEXT".into()
+    } else {
+        section_name(path)
+    }
+}
+
+fn section_mime_fetch_command(uid: u32, path: &[usize]) -> String {
+    let section = if path.is_empty() {
+        "MIME".into()
+    } else {
+        format!("{}.MIME", section_name(path))
+    };
+    format!("UID FETCH {uid} (BODY.PEEK[{section}])")
+}
+
+fn nested_section_mime_fetch_command(uid: u32, path: &[usize]) -> Option<String> {
+    (!path.is_empty()).then(|| section_mime_fetch_command(uid, path))
+}
+
+#[derive(Debug, Clone)]
+enum ImapBodyValue {
+    Atom(String),
+    String(String),
+    List(Vec<ImapBodyValue>),
+}
+
+impl ImapBodyValue {
+    fn atom(&self) -> Option<&str> {
+        match self {
+            Self::Atom(value) if !value.eq_ignore_ascii_case("NIL") => Some(value),
+            Self::String(value) => Some(value),
+            _ => None,
+        }
+    }
+    fn list(&self) -> Option<&[ImapBodyValue]> {
+        match self {
+            Self::List(values) => Some(values),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MimePart {
+    path: Vec<usize>,
+    mime_type: String,
+    params: BTreeMap<String, String>,
+    content_id: Option<String>,
+    disposition: Option<String>,
+    disposition_params: BTreeMap<String, String>,
+    transfer_encoding: String,
+    encoded_size: usize,
+    children: Vec<MimePart>,
+}
+
+impl MimePart {
+    fn is_leaf(&self) -> bool {
+        self.children.is_empty()
+    }
+    fn filename(&self) -> Option<&str> {
+        self.disposition_params
+            .get("filename")
+            .or_else(|| self.params.get("name"))
+            .map(String::as_str)
+            .filter(|value| !value.trim().is_empty())
+    }
+    fn is_explicit_attachment(&self) -> bool {
+        self.disposition
+            .as_deref()
+            .is_some_and(|value| value.eq_ignore_ascii_case("attachment"))
+    }
+    fn is_text_body(&self) -> bool {
+        self.mime_type.eq_ignore_ascii_case("text/plain")
+            || self.mime_type.eq_ignore_ascii_case("text/html")
+    }
+    fn is_attachment_candidate(&self) -> bool {
+        self.is_explicit_attachment()
+            || self.filename().is_some()
+            || (self.is_leaf() && !self.is_text_body())
+    }
+    fn is_attached_container(&self) -> bool {
+        !self.is_leaf() && self.is_attachment_candidate()
+    }
+}
+
+#[derive(Debug, Clone)]
+struct PlannedAttachment {
+    part: MimePart,
+    index: usize,
+}
+
+#[derive(Debug, Clone)]
+struct PlannedTextPart {
+    part: MimePart,
+    /// A multipart/alternative representation may have several candidates of
+    /// one kind.  They are fetched in preference order and only the first
+    /// decodable member of this group becomes the visible representation.
+    fallback_group: Option<usize>,
+}
+
+impl PlannedAttachment {
+    fn attachment_id(&self, message_id: &str) -> String {
+        mime_attachment_id(message_id, &self.part.path)
+    }
+}
+
+#[derive(Debug, Clone)]
+struct SelectivePlan {
+    text_parts: Vec<PlannedTextPart>,
+    attachments: Vec<PlannedAttachment>,
+}
+
+#[cfg(test)]
+fn parse_bodystructure(lines: &[String]) -> Result<MimePart> {
+    parse_bodystructure_with_literals(lines, &[])
+}
+
+fn parse_bodystructure_response(response: &ImapResponse) -> Result<MimePart> {
+    parse_bodystructure_with_literals(&response.lines, &response.literals)
+}
+
+fn parse_bodystructure_with_literals(
+    lines: &[String],
+    literals: &[ImapLiteral],
+) -> Result<MimePart> {
+    let source = imap_transcript_with_literals(lines, literals)?;
+    if source.len() > MAX_MIME_HEADER_BYTES {
+        bail!("mime_headers_too_large");
+    }
+    let offset = find_imap_atom_outside_quotes(&source, "BODYSTRUCTURE")
+        .context("IMAP server omitted BODYSTRUCTURE")?
+        + "BODYSTRUCTURE".len();
+    let (value, _) = parse_imap_body_value(source[offset..].trim_start())
+        .context("IMAP BODYSTRUCTURE is malformed")?;
+    bodystructure_part(&value, Vec::new())
+}
+
+fn find_imap_atom_outside_quotes(source: &str, atom: &str) -> Option<usize> {
+    let bytes = source.as_bytes();
+    let atom = atom.as_bytes();
+    let mut quoted = false;
+    let mut escaped = false;
+    let mut index = 0usize;
+    while index + atom.len() <= bytes.len() {
+        let byte = bytes[index];
+        if quoted {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                quoted = false;
+            }
+            index += 1;
+            continue;
+        }
+        if byte == b'"' {
+            quoted = true;
+            index += 1;
+            continue;
+        }
+        let before_is_atom = index > 0 && bytes[index - 1].is_ascii_alphanumeric();
+        let after = index + atom.len();
+        let after_is_atom = after < bytes.len() && bytes[after].is_ascii_alphanumeric();
+        if !before_is_atom
+            && !after_is_atom
+            && bytes[index..]
+                .get(..atom.len())
+                .is_some_and(|value| value.eq_ignore_ascii_case(atom))
+        {
+            return Some(index);
+        }
+        index += 1;
+    }
+    None
+}
+
+fn imap_transcript_with_literals(lines: &[String], literals: &[ImapLiteral]) -> Result<String> {
+    let source = lines.join(" ");
+    let mut result = String::with_capacity(source.len());
+    let mut cursor = 0;
+    let mut literal_index = 0;
+    while let Some(offset) = source[cursor..].find('{') {
+        let start = cursor + offset;
+        let Some(end_offset) = source[start..].find('}') else {
+            break;
+        };
+        let end = start + end_offset;
+        let marker = &source[start + 1..end];
+        if marker.trim_end_matches('+').parse::<usize>().is_err() {
+            result.push_str(&source[cursor..end + 1]);
+            cursor = end + 1;
+            continue;
+        }
+        let literal = literals
+            .get(literal_index)
+            .context("IMAP response omitted a declared literal")?;
+        result.push_str(&source[cursor..start]);
+        result.push('"');
+        result.push_str(
+            &String::from_utf8_lossy(&literal.bytes)
+                .replace('\\', "\\\\")
+                .replace('"', "\\\""),
+        );
+        result.push('"');
+        cursor = end + 1;
+        literal_index += 1;
+    }
+    result.push_str(&source[cursor..]);
+    if literal_index != literals.len() {
+        bail!("IMAP response contains an unassociated literal");
+    }
+    Ok(result)
+}
+
+fn parse_imap_body_value(input: &str) -> Option<(ImapBodyValue, &str)> {
+    let mut values_seen = 0usize;
+    parse_imap_body_value_inner(input, 0, &mut values_seen)
+}
+
+fn parse_imap_body_value_inner<'a>(
+    input: &'a str,
+    depth: usize,
+    values_seen: &mut usize,
+) -> Option<(ImapBodyValue, &'a str)> {
+    if depth > MAX_MULTIPART_NESTING + 16 || *values_seen >= MAX_MIME_PARTS.saturating_mul(32) {
+        return None;
+    }
+    *values_seen += 1;
+    let input = input.trim_start();
+    let mut chars = input.chars();
+    match chars.next()? {
+        '(' => {
+            let mut rest = chars.as_str();
+            let mut values = Vec::new();
+            loop {
+                rest = rest.trim_start();
+                if let Some(after) = rest.strip_prefix(')') {
+                    return Some((ImapBodyValue::List(values), after));
+                }
+                let (value, after) = parse_imap_body_value_inner(rest, depth + 1, values_seen)?;
+                values.push(value);
+                rest = after;
+            }
+        }
+        '"' => {
+            let mut value = String::new();
+            let mut rest = chars.as_str();
+            while let Some(character) = rest.chars().next() {
+                rest = &rest[character.len_utf8()..];
+                match character {
+                    '"' => return Some((ImapBodyValue::String(value), rest)),
+                    '\\' => {
+                        let escaped = rest.chars().next()?;
+                        value.push(escaped);
+                        rest = &rest[escaped.len_utf8()..];
+                    }
+                    _ => value.push(character),
+                }
+            }
+            None
+        }
+        character => {
+            let end = input
+                .find(|value: char| value.is_ascii_whitespace() || matches!(value, '(' | ')'))
+                .unwrap_or(input.len());
+            let _ = character;
+            (end > 0).then(|| (ImapBodyValue::Atom(input[..end].to_owned()), &input[end..]))
+        }
+    }
+}
+
+fn bodystructure_params(value: Option<&[ImapBodyValue]>) -> BTreeMap<String, String> {
+    let mut params = BTreeMap::new();
+    let Some(values) = value else {
+        return params;
+    };
+    for pair in values.chunks_exact(2) {
+        if let (Some(name), Some(value)) = (pair[0].atom(), pair[1].atom()) {
+            params.insert(name.to_ascii_lowercase(), value.to_owned());
+        }
+    }
+    // BODYSTRUCTURE exposes RFC 2231 extended parameters verbatim on many
+    // providers.  Normalize the common single-value form so targeted
+    // attachment metadata agrees with the complete MIME parser.
+    for (extended, plain) in [("filename*", "filename"), ("name*", "name")] {
+        let Some(value) = params.get(extended) else {
+            continue;
+        };
+        let encoded = value
+            .split_once("''")
+            .map(|(_, encoded)| encoded)
+            .unwrap_or(value);
+        if valid_percent_escapes(encoded) {
+            if let Ok(decoded) = percent_decode_str(encoded).decode_utf8() {
+                if !decoded.trim().is_empty() {
+                    params.insert(plain.to_owned(), decoded.into_owned());
+                }
+            }
+        }
+    }
+    params
+}
+
+fn bodystructure_disposition(values: &[ImapBodyValue]) -> Option<&[ImapBodyValue]> {
+    values
+        .iter()
+        .filter_map(ImapBodyValue::list)
+        .find(|values| {
+            values
+                .first()
+                .and_then(ImapBodyValue::atom)
+                .is_some_and(|value| {
+                    matches!(value.to_ascii_lowercase().as_str(), "attachment" | "inline")
+                })
+        })
+}
+
+fn bodystructure_part(value: &ImapBodyValue, path: Vec<usize>) -> Result<MimePart> {
+    let mut part_count = 0usize;
+    bodystructure_part_inner(value, path, 0, &mut part_count)
+}
+
+fn bodystructure_part_inner(
+    value: &ImapBodyValue,
+    path: Vec<usize>,
+    depth: usize,
+    part_count: &mut usize,
+) -> Result<MimePart> {
+    if depth > MAX_MULTIPART_NESTING {
+        bail!("mime_multipart_nesting_too_deep");
+    }
+    *part_count = part_count
+        .checked_add(1)
+        .context("MIME part count overflow")?;
+    if *part_count > MAX_MIME_PARTS {
+        bail!("mime_too_many_parts");
+    }
+    let values = value.list().context("BODYSTRUCTURE part is not a list")?;
+    if values.first().is_some_and(|value| value.list().is_some()) {
+        let child_count = values
+            .iter()
+            .take_while(|value| value.list().is_some())
+            .count();
+        let subtype = values
+            .get(child_count)
+            .and_then(ImapBodyValue::atom)
+            .context("multipart BODYSTRUCTURE omitted subtype")?;
+        let mut children = Vec::with_capacity(child_count);
+        for (index, child) in values[..child_count].iter().enumerate() {
+            let mut child_path = path.clone();
+            child_path.push(index + 1);
+            children.push(bodystructure_part_inner(
+                child,
+                child_path,
+                depth + 1,
+                part_count,
+            )?);
+        }
+        let disposition_value =
+            bodystructure_disposition(values.get(child_count + 2..).unwrap_or_default());
+        let disposition = disposition_value
+            .and_then(|values| values.first())
+            .and_then(ImapBodyValue::atom)
+            .map(str::to_ascii_lowercase);
+        let disposition_params = disposition_value
+            .and_then(|values| values.get(1))
+            .and_then(ImapBodyValue::list)
+            .map(|values| bodystructure_params(Some(values)))
+            .unwrap_or_default();
+        return Ok(MimePart {
+            path,
+            mime_type: format!("multipart/{subtype}").to_ascii_lowercase(),
+            params: bodystructure_params(values.get(child_count + 1).and_then(ImapBodyValue::list)),
+            content_id: None,
+            disposition,
+            disposition_params,
+            transfer_encoding: String::new(),
+            encoded_size: 0,
+            children,
+        });
+    }
+    let kind = values
+        .first()
+        .and_then(ImapBodyValue::atom)
+        .context("BODYSTRUCTURE omitted media type")?;
+    let subtype = values
+        .get(1)
+        .and_then(ImapBodyValue::atom)
+        .context("BODYSTRUCTURE omitted media subtype")?;
+    let disposition_value = bodystructure_disposition(values.get(7..).unwrap_or_default());
+    let disposition = disposition_value
+        .and_then(|values| values.first())
+        .and_then(ImapBodyValue::atom)
+        .map(str::to_ascii_lowercase);
+    let disposition_params = disposition_value
+        .and_then(|values| values.get(1))
+        .and_then(ImapBodyValue::list)
+        .map(|values| bodystructure_params(Some(values)))
+        .unwrap_or_default();
+    Ok(MimePart {
+        path,
+        mime_type: format!("{kind}/{subtype}").to_ascii_lowercase(),
+        params: bodystructure_params(values.get(2).and_then(ImapBodyValue::list)),
+        content_id: values
+            .get(3)
+            .and_then(ImapBodyValue::atom)
+            .map(str::to_owned),
+        disposition,
+        disposition_params,
+        transfer_encoding: values
+            .get(5)
+            .and_then(ImapBodyValue::atom)
+            .unwrap_or_default()
+            .to_ascii_lowercase(),
+        encoded_size: values
+            .get(6)
+            .and_then(ImapBodyValue::atom)
+            .and_then(|value| value.parse().ok())
+            .unwrap_or(0),
+        children: Vec::new(),
+    })
+}
+
+fn selective_plan(root: &MimePart) -> Result<SelectivePlan> {
+    let mut text_parts = Vec::new();
+    let mut fallback_groups = 0usize;
+    select_text_parts(root, &mut text_parts, &mut fallback_groups);
+    let mut candidates = Vec::new();
+    collect_attachment_candidates(root, &mut candidates);
+    if candidates.len() > MAX_ATTACHMENT_COUNT {
+        bail!("message has too many attachments");
+    }
+    Ok(SelectivePlan {
+        text_parts,
+        attachments: candidates
+            .into_iter()
+            .enumerate()
+            .map(|(index, part)| PlannedAttachment { part, index })
+            .collect(),
+    })
+}
+
+fn select_text_parts(
+    part: &MimePart,
+    selected: &mut Vec<PlannedTextPart>,
+    fallback_groups: &mut usize,
+) {
+    if part.is_attached_container() {
+        return;
+    }
+    if part.is_leaf() {
+        if part.is_text_body() && !part.is_attachment_candidate() {
+            selected.push(PlannedTextPart {
+                part: part.clone(),
+                fallback_group: None,
+            });
+        }
+        return;
+    }
+    if part.mime_type.eq_ignore_ascii_case("multipart/alternative") {
+        let mut candidates = Vec::new();
+        for child in &part.children {
+            select_text_parts(child, &mut candidates, fallback_groups);
+        }
+        for mime_type in ["text/plain", "text/html"] {
+            let matching = candidates
+                .iter()
+                .rev()
+                .filter(|candidate| candidate.part.mime_type.eq_ignore_ascii_case(mime_type))
+                .cloned()
+                .collect::<Vec<_>>();
+            if matching.is_empty() {
+                continue;
+            }
+            *fallback_groups += 1;
+            selected.extend(matching.into_iter().map(|mut candidate| {
+                candidate.fallback_group = Some(*fallback_groups);
+                candidate
+            }));
+        }
+    } else if part.mime_type.eq_ignore_ascii_case("multipart/related") {
+        let declared_start = part
+            .params
+            .get("start")
+            .map(|value| value.trim().trim_matches(['<', '>']).to_ascii_lowercase());
+        let root = declared_start
+            .as_deref()
+            .and_then(|start| {
+                part.children.iter().find(|child| {
+                    child
+                        .content_id
+                        .as_deref()
+                        .map(|value| {
+                            value
+                                .trim()
+                                .trim_matches(['<', '>'])
+                                .eq_ignore_ascii_case(start)
+                        })
+                        .unwrap_or(false)
+                })
+            })
+            .or_else(|| part.children.first());
+        if let Some(root) = root {
+            select_text_parts(root, selected, fallback_groups);
+        }
+    } else {
+        for child in &part.children {
+            select_text_parts(child, selected, fallback_groups);
+        }
+    }
+}
+
+fn collect_attachment_candidates(part: &MimePart, candidates: &mut Vec<MimePart>) {
+    if part.is_attached_container() {
+        candidates.push(part.clone());
+        return;
+    }
+    if part.is_leaf() {
+        if part.is_attachment_candidate() {
+            candidates.push(part.clone());
+        }
+        return;
+    }
+    for child in &part.children {
+        collect_attachment_candidates(child, candidates);
+    }
+}
+
+async fn fetch_section_mime_headers(
+    client: &mut ImapClient,
+    uid: u32,
+    path: &[usize],
+    root_headers: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    if path.is_empty() {
+        return root_headers
+            .map(ToOwned::to_owned)
+            .context("IMAP root MIME headers were not fetched");
+    }
+    let command = nested_section_mime_fetch_command(uid, path)
+        .context("IMAP MIME header section is missing")?;
+    let mut response = client
+        .command_with_literal_limited(&command, 256 * 1024)
+        .await?;
+    response
+        .take_body_literal_for(uid, &format!("{}.MIME", section_name(path)))
+        .context("IMAP server did not return MIME part headers")
+}
+
+async fn fetch_selective_message(
+    client: &mut ImapClient,
+    account: &Account,
+    mailbox: &str,
+    uid: u32,
+    response_lines: &[String],
+    headers: &[u8],
+    structure: &MimePart,
+) -> Result<MailSummary> {
+    let plan = selective_plan(structure)?;
+    let mut total = 0usize;
+    let mut plain = Vec::new();
+    let mut html = None;
+    let mut text_decode_failures = 0usize;
+    let mut successful_fallback_groups = BTreeSet::new();
+    let mut referenced_inline = BTreeMap::new();
+    for part in &plan.text_parts {
+        if part
+            .fallback_group
+            .is_some_and(|group| successful_fallback_groups.contains(&group))
+        {
+            continue;
+        }
+        let header =
+            fetch_section_mime_headers(client, uid, &part.part.path, Some(headers)).await?;
+        let remaining =
+            display_literal_limit(total, part.part.encoded_size, "message display part")?;
+        let mut response = client
+            .command_with_literal_limited(
+                &section_fetch_command(uid, &part.part.path),
+                remaining.min(MAX_DISPLAY_PART_BYTES),
+            )
+            .await?;
+        let bytes = response
+            .take_body_literal_for(uid, &response_body_section(&part.part.path))
+            .context("IMAP server did not return the requested MIME part")?;
+        total = total
+            .checked_add(bytes.len())
+            .context("message display body size overflow")?;
+        let decoded = match decode_mime_part_body(&header, &bytes) {
+            Ok(decoded) => decoded,
+            Err(error) => {
+                text_decode_failures += 1;
+                tracing::warn!(
+                    %error,
+                    uid,
+                    section = %section_name(&part.part.path),
+                    "could not decode a selective MIME body candidate"
+                );
+                continue;
+            }
+        };
+        if let Some(group) = part.fallback_group {
+            successful_fallback_groups.insert(group);
+        }
+        if part.part.mime_type.eq_ignore_ascii_case("text/html") && html.is_none() {
+            html = Some(decoded);
+        } else if part.part.mime_type.eq_ignore_ascii_case("text/plain") {
+            plain.push(decoded);
+        }
+    }
+    let mut image_parts = BTreeMap::new();
+    let mut reference_counts = BTreeMap::new();
+    for attachment in &plan.attachments {
+        if !attachment.part.mime_type.starts_with("image/") {
+            for reference in unique_mime_part_references(&attachment.part) {
+                *reference_counts
+                    .entry(reference.to_ascii_lowercase())
+                    .or_insert(0usize) += 1;
+            }
+            continue;
+        }
+        let header =
+            fetch_section_mime_headers(client, uid, &attachment.part.path, Some(headers)).await?;
+        let part = mime_part_with_headers(&attachment.part, &header)?;
+        let references = unique_mime_part_references(&part);
+        for reference in &references {
+            *reference_counts
+                .entry(reference.to_ascii_lowercase())
+                .or_insert(0usize) += 1;
+        }
+        image_parts.insert(section_name(&part.path), (part, header, references));
+    }
+    let mut body_html = html;
+    if let Some(html) = &mut body_html {
+        for (path, (part, header, references)) in &image_parts {
+            let referenced = has_unambiguous_html_reference(html, references, &reference_counts);
+            referenced_inline.insert(path.clone(), referenced);
+            if !referenced {
+                continue;
+            }
+            let remaining = display_literal_limit(total, part.encoded_size, "inline image")?;
+            let mut response = client
+                .command_with_literal_limited(
+                    &section_fetch_command(uid, &part.path),
+                    remaining.min(MAX_DISPLAY_PART_BYTES),
+                )
+                .await?;
+            let bytes = response
+                .take_body_literal_for(uid, &response_body_section(&part.path))
+                .context("IMAP server did not return the referenced inline image")?;
+            total = total
+                .checked_add(bytes.len())
+                .context("message display body size overflow")?;
+            let image = decode_mime_part_raw(header, &bytes)?;
+            let data_url = format!(
+                "data:{};base64,{}",
+                safe_mime_type(&part.mime_type),
+                STANDARD.encode(image)
+            );
+            for reference in references {
+                *html = replace_resource_reference(html, reference, &data_url)?;
+            }
+        }
+    }
+    let mut body_text = plain
+        .into_iter()
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if body_text.trim().is_empty() {
+        if let Some(html) = &body_html {
+            body_text = mail_parser::decoders::html::html_to_text(html);
+        }
+    }
+    if !plan.text_parts.is_empty()
+        && text_decode_failures == plan.text_parts.len()
+        && body_text.trim().is_empty()
+        && body_html.is_none()
+    {
+        bail!(MIME_CONTENT_UNDECODABLE);
+    }
+    let id = stable_message_id(account.id, mailbox, uid);
+    let mut attachments = Vec::new();
+    for attachment in &plan.attachments {
+        let part = image_parts
+            .get(&section_name(&attachment.part.path))
+            .map(|(part, _, _)| part.clone())
+            .unwrap_or_else(|| attachment.part.clone());
+        let referenced = referenced_inline
+            .get(&section_name(&part.path))
+            .copied()
+            .unwrap_or(false);
+        let data = attachment_data_from_part(
+            &PlannedAttachment {
+                part,
+                index: attachment.index,
+            },
+            &id,
+            &[],
+            None,
+            referenced,
+        )?;
+        if data.attachment.presentation.is_downloadable() {
+            attachments.push(data);
+        }
+    }
+    let mut message = parse_catalog_message(
+        account,
+        mailbox,
+        uid,
+        response_lines,
+        headers,
+        clean_snippet(&body_text),
+    )?;
+    message.body_text = body_text;
+    message.body_html = body_html;
+    message.content_state = "complete".into();
+    message.has_attachments = !attachments.is_empty();
+    message.attachments = attachments;
+    Ok(message)
+}
+
+fn display_literal_limit(total: usize, advertised_size: usize, label: &str) -> Result<usize> {
+    let remaining = MAX_DISPLAY_TOTAL_BYTES
+        .checked_sub(total)
+        .context("message display body exceeds the 50 MiB safety limit")?;
+    if advertised_size > remaining || advertised_size > MAX_DISPLAY_PART_BYTES {
+        bail!(
+            "{label} exceeds the {} MiB safety limit",
+            MAX_DISPLAY_PART_BYTES / 1024 / 1024
+        );
+    }
+    Ok(remaining.min(MAX_DISPLAY_PART_BYTES))
+}
+
+fn validate_targeted_attachment_bytes(bytes: &[u8]) -> Result<()> {
+    if bytes.len() > MAX_ATTACHMENT_BYTES {
+        bail!(
+            "attachment exceeds the {} MiB safety limit",
+            MAX_ATTACHMENT_BYTES / 1024 / 1024
+        );
+    }
+    Ok(())
+}
+
+fn decode_mime_part_raw(headers: &[u8], bytes: &[u8]) -> Result<Vec<u8>> {
+    let mut source = Vec::with_capacity(headers.len() + bytes.len() + 4);
+    source.extend_from_slice(headers);
+    finish_mime_headers(&mut source);
+    source.extend_from_slice(bytes);
+    let parsed = parse_complete_message(&source)?;
+    let part = parsed
+        .part(0)
+        .context("MIME part parser omitted the root part")?;
+    decoded_part_bytes(parsed.raw_message(), part)
+        .context("MIME part uses an unsupported transfer encoding")
+}
+
+fn decode_mime_part_body(headers: &[u8], bytes: &[u8]) -> Result<String> {
+    let mut source = Vec::with_capacity(headers.len() + bytes.len() + 4);
+    source.extend_from_slice(headers);
+    finish_mime_headers(&mut source);
+    source.extend_from_slice(bytes);
+    let parsed = parse_complete_message(&source)?;
+    let part = parsed
+        .part(0)
+        .context("MIME part parser omitted the root part")?;
+    decode_text_candidate(&parsed, part)
+        .map(|text| {
+            if part.is_text_html() {
+                text
+            } else {
+                flowed_text(part, &text)
+            }
+        })
+        .map_err(|()| anyhow::anyhow!("MIME text part could not be decoded safely"))
+}
+
+fn mime_part_with_headers(part: &MimePart, headers: &[u8]) -> Result<MimePart> {
+    let mut source = headers.to_vec();
+    finish_mime_headers(&mut source);
+    let parsed = configured_message_parser()
+        .parse_headers(&source)
+        .context("MIME part headers are malformed")?;
+    let parsed = parsed
+        .part(0)
+        .context("MIME part parser omitted the root part")?;
+    let mut result = part.clone();
+    if let Some(content_type) = parsed.content_type() {
+        if let Some(subtype) = content_type.subtype() {
+            result.mime_type = format!("{}/{}", content_type.ctype(), subtype).to_ascii_lowercase();
+        }
+        if let Some(attributes) = content_type.attributes() {
+            result.params.extend(attributes.iter().map(|attribute| {
+                (
+                    attribute.name.to_ascii_lowercase(),
+                    attribute.value.to_string(),
+                )
+            }));
+        }
+    }
+    result.content_id = parsed
+        .content_id()
+        .map(ToOwned::to_owned)
+        .or(result.content_id);
+    if let Some(disposition) = parsed.content_disposition() {
+        result.disposition = Some(
+            if disposition.is_attachment() {
+                "attachment"
+            } else if disposition.is_inline() {
+                "inline"
+            } else {
+                ""
+            }
+            .to_owned(),
+        );
+        if let Some(attributes) = disposition.attributes() {
+            result
+                .disposition_params
+                .extend(attributes.iter().map(|attribute| {
+                    (
+                        attribute.name.to_ascii_lowercase(),
+                        attribute.value.to_string(),
+                    )
+                }));
+        }
+    }
+    if let Some(location) = parsed.content_location() {
+        result
+            .params
+            .insert("content-location".into(), location.to_owned());
+    }
+    Ok(result)
+}
+
+fn finish_mime_headers(source: &mut Vec<u8>) {
+    if source.ends_with(b"\r\n\r\n") || source.ends_with(b"\n\n") {
+        return;
+    }
+    if source.ends_with(b"\r\n") {
+        source.extend_from_slice(b"\r\n");
+    } else if source.ends_with(b"\n") {
+        source.extend_from_slice(b"\n");
+    } else {
+        source.extend_from_slice(b"\r\n\r\n");
+    }
+}
+
+fn mime_part_references(part: &MimePart) -> Vec<String> {
+    let mut references = Vec::new();
+    if let Some(content_id) = &part.content_id {
+        references.push(format!(
+            "cid:{}",
+            content_id.trim().trim_matches(['<', '>'])
+        ));
+    }
+    if let Some(location) = part.params.get("content-location") {
+        references.push(location.to_owned());
+    }
+    references
+}
+
+fn unique_mime_part_references(part: &MimePart) -> Vec<String> {
+    let mut seen = BTreeSet::new();
+    mime_part_references(part)
+        .into_iter()
+        .filter(|reference| seen.insert(reference.to_ascii_lowercase()))
+        .collect()
+}
+
+fn has_unambiguous_html_reference(
+    html: &str,
+    references: &[String],
+    reference_counts: &BTreeMap<String, usize>,
+) -> bool {
+    references.iter().any(|reference| {
+        html_contains_reference(html, reference)
+            && reference_counts
+                .get(&reference.to_ascii_lowercase())
+                .copied()
+                == Some(1)
+    })
+}
+
+fn attachment_data_from_part(
+    part: &PlannedAttachment,
+    message_id: &str,
+    headers: &[u8],
+    bytes: Option<Vec<u8>>,
+    referenced: bool,
+) -> Result<AttachmentData> {
+    let planned = part;
+    let part = if headers.is_empty() {
+        planned.part.clone()
+    } else {
+        mime_part_with_headers(&planned.part, headers)?
+    };
+    let filename = safe_attachment_filename(part.filename().unwrap_or("attachment"), planned.index);
+    let mime_type = safe_mime_type(&part.mime_type);
+    let is_inline = part
+        .disposition
+        .as_deref()
+        .is_some_and(|value| value.eq_ignore_ascii_case("inline"))
+        || part.content_id.is_some();
+    let presentation = match (part.is_explicit_attachment(), referenced) {
+        (true, true) => AttachmentPresentation::Both,
+        (true, false) => AttachmentPresentation::Downloadable,
+        (false, true) => AttachmentPresentation::Embedded,
+        (false, false) => AttachmentPresentation::Downloadable,
+    };
+    let bytes = match bytes {
+        Some(bytes) => decode_mime_part_raw(headers, &bytes)?,
+        None => Vec::new(),
+    };
+    Ok(AttachmentData {
+        attachment: Attachment {
+            id: planned.attachment_id(message_id),
+            message_id: message_id.to_owned(),
+            filename: filename.clone(),
+            mime_type: mime_type.clone(),
+            size_bytes: if bytes.is_empty() {
+                part.encoded_size as i64
+            } else {
+                bytes.len() as i64
+            },
+            is_inline,
+            presentation,
+            is_potentially_unsafe: is_potentially_unsafe(&filename, &mime_type),
+        },
+        bytes,
+    })
 }
 
 fn set_read_command(uid: u32, read: bool) -> String {
@@ -2039,15 +3405,28 @@ impl ImapClient {
     }
 
     async fn command_with_literal(&mut self, command: &str) -> Result<ImapResponse> {
+        self.command_with_literal_limited(command, MAX_IMAP_RESPONSE_LITERAL_BYTES)
+            .await
+    }
+
+    async fn command_with_literal_limited(
+        &mut self,
+        command: &str,
+        max_literal_bytes: usize,
+    ) -> Result<ImapResponse> {
         timeout(
             IMAP_COMMAND_TIMEOUT,
-            self.command_with_literal_inner(command),
+            self.command_with_literal_inner(command, max_literal_bytes),
         )
         .await
         .context("IMAP command timed out")?
     }
 
-    async fn command_with_literal_inner(&mut self, command: &str) -> Result<ImapResponse> {
+    async fn command_with_literal_inner(
+        &mut self,
+        command: &str,
+        max_literal_bytes: usize,
+    ) -> Result<ImapResponse> {
         self.tag += 1;
         let tag = format!("D{:04}", self.tag);
         self.reader
@@ -2056,23 +3435,50 @@ impl ImapClient {
             .await?;
         self.reader.get_mut().flush().await?;
         let mut lines = Vec::new();
-        let mut literal = None;
+        let mut literals = Vec::new();
+        let mut literal_bytes = 0usize;
+        let mut transcript_bytes = 0usize;
+        // A FETCH response may continue after a literal on a line that no
+        // longer repeats UID. Retain the owner until a new untagged FETCH
+        // starts; a new one replaces it, so unsolicited interleaving cannot
+        // donate its literal to the requested message.
+        let mut current_fetch_uid = None;
+        let mut pending_fetch_literals = Vec::new();
         loop {
-            let mut line = String::new();
-            if self.reader.read_line(&mut line).await? == 0 {
-                bail!("IMAP connection closed during command");
+            let line = self
+                .read_command_line_limited(MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES)
+                .await?;
+            transcript_bytes = reserve_imap_transcript_budget(transcript_bytes, line.len())?;
+            if is_untagged_fetch_start(&line) {
+                current_fetch_uid = None;
+                pending_fetch_literals.clear();
             }
+            if let Some(uid) = fetch_uid_from_line(&line) {
+                current_fetch_uid = Some(uid);
+                backfill_fetch_literal_uids(&mut literals, &mut pending_fetch_literals, uid);
+            }
+            lines.push(line.clone());
             if let Some(length) = literal_length(&line) {
                 if length > MAX_RAW_MESSAGE_BYTES {
                     bail!("mime_raw_message_too_large");
                 }
+                reserve_imap_literal_budget(
+                    literals.len(),
+                    literal_bytes,
+                    length,
+                    max_literal_bytes,
+                )?;
                 let mut bytes = vec![0; length];
                 self.reader.read_exact(&mut bytes).await?;
-                literal = Some(bytes);
-                let mut tail = String::new();
-                self.reader.read_line(&mut tail).await?;
-                if !tail.trim().is_empty() {
-                    lines.push(tail);
+                literal_bytes += length;
+                let pending = current_fetch_uid.is_none();
+                literals.push(ImapLiteral {
+                    uid: current_fetch_uid,
+                    data_item: literal_data_item(&line),
+                    bytes,
+                });
+                if pending {
+                    pending_fetch_literals.push(literals.len() - 1);
                 }
             }
             if line.starts_with(&tag) {
@@ -2082,16 +3488,170 @@ impl ImapClient {
                 lines.push(line);
                 break;
             }
-            lines.push(line);
         }
-        Ok(ImapResponse { lines, literal })
+        Ok(ImapResponse { lines, literals })
     }
+
+    async fn read_command_line_limited(&mut self, max_bytes: usize) -> Result<String> {
+        let mut bytes = Vec::new();
+        loop {
+            let byte = self
+                .reader
+                .read_u8()
+                .await
+                .context("IMAP connection closed during command")?;
+            if bytes.len() >= max_bytes {
+                bail!("IMAP response line exceeds MIME safety limit");
+            }
+            bytes.push(byte);
+            if byte == b'\n' {
+                return String::from_utf8(bytes).context("IMAP response line is not valid UTF-8");
+            }
+        }
+    }
+}
+
+fn fetch_uid_from_line(line: &str) -> Option<u32> {
+    let bytes = line.as_bytes();
+    let mut quoted = false;
+    let mut escaped = false;
+    let mut index = 0usize;
+    while index + 4 <= bytes.len() {
+        let byte = bytes[index];
+        if quoted {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                quoted = false;
+            }
+            index += 1;
+            continue;
+        }
+        if byte == b'"' {
+            quoted = true;
+            index += 1;
+            continue;
+        }
+        if bytes[index..]
+            .get(..4)
+            .is_some_and(|token| token.eq_ignore_ascii_case(b"UID "))
+        {
+            let start = index + 4;
+            let end = bytes[start..]
+                .iter()
+                .position(|byte| !byte.is_ascii_digit())
+                .map(|offset| start + offset)
+                .unwrap_or(bytes.len());
+            return (end > start)
+                .then(|| line[start..end].parse().ok())
+                .flatten();
+        }
+        index += 1;
+    }
+    None
+}
+
+fn is_untagged_fetch_start(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    trimmed.starts_with('*') && trimmed.to_ascii_uppercase().contains(" FETCH ")
+}
+
+fn backfill_fetch_literal_uids(literals: &mut [ImapLiteral], pending: &mut Vec<usize>, uid: u32) {
+    for index in pending.drain(..) {
+        literals[index].uid = Some(uid);
+    }
+}
+
+fn reserve_imap_literal_budget(
+    current_count: usize,
+    current_bytes: usize,
+    next_bytes: usize,
+    max_total_bytes: usize,
+) -> Result<()> {
+    if current_count >= MAX_IMAP_RESPONSE_LITERALS {
+        bail!("IMAP response exceeds the {MAX_IMAP_RESPONSE_LITERALS} literal safety limit");
+    }
+    let total = current_bytes
+        .checked_add(next_bytes)
+        .context("IMAP literal byte count overflow")?;
+    if next_bytes > max_total_bytes || total > max_total_bytes {
+        bail!(
+            "IMAP response literals exceed the {} MiB safety limit",
+            max_total_bytes / 1024 / 1024
+        );
+    }
+    Ok(())
+}
+
+fn reserve_imap_transcript_budget(current_bytes: usize, next_bytes: usize) -> Result<usize> {
+    let total = current_bytes
+        .checked_add(next_bytes)
+        .context("IMAP response transcript size overflow")?;
+    if total > MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES {
+        bail!("IMAP response transcript exceeds MIME safety limit");
+    }
+    Ok(total)
+}
+
+fn literal_data_item(line: &str) -> ImapLiteralItem {
+    let bytes = line.as_bytes();
+    let mut quoted = false;
+    let mut escaped = false;
+    let mut latest = None;
+    let mut index = 0usize;
+    while index < bytes.len() {
+        let byte = bytes[index];
+        if quoted {
+            if escaped {
+                escaped = false;
+            } else if byte == b'\\' {
+                escaped = true;
+            } else if byte == b'"' {
+                quoted = false;
+            }
+            index += 1;
+            continue;
+        }
+        if byte == b'"' {
+            quoted = true;
+            index += 1;
+            continue;
+        }
+        let remaining = &bytes[index..];
+        if remaining
+            .get(.."BODYSTRUCTURE".len())
+            .is_some_and(|value| value.eq_ignore_ascii_case(b"BODYSTRUCTURE"))
+        {
+            latest = Some(ImapLiteralItem::BodyStructure);
+            index += "BODYSTRUCTURE".len();
+            continue;
+        }
+        if remaining
+            .get(.."BODY[".len())
+            .is_some_and(|value| value.eq_ignore_ascii_case(b"BODY["))
+        {
+            let end = remaining
+                .iter()
+                .position(|byte| *byte == b']')
+                .map(|offset| index + offset + 1)
+                .unwrap_or(bytes.len());
+            latest = Some(ImapLiteralItem::Body(
+                String::from_utf8_lossy(&bytes[index..end]).into_owned(),
+            ));
+            index = end;
+            continue;
+        }
+        index += 1;
+    }
+    latest.unwrap_or(ImapLiteralItem::Other)
 }
 
 fn literal_length(line: &str) -> Option<usize> {
     let start = line.rfind('{')? + 1;
     let end = line[start..].find('}')? + start;
-    line[start..end].parse().ok()
+    line[start..end].trim_end_matches('+').parse().ok()
 }
 
 fn quote_imap(value: &str) -> String {
@@ -2117,6 +3677,13 @@ fn parse_uid_validity(lines: &[String]) -> Option<u32> {
         let end = line[start..].find(']')? + start;
         line[start..end].trim().parse().ok()
     })
+}
+
+fn verify_mailbox_uid_validity(current: u32, catalogued: i64, action: &str) -> Result<()> {
+    if i64::from(current) != catalogued {
+        bail!("mailbox identity changed; sync the account before {action} this message");
+    }
+    Ok(())
 }
 
 fn parse_uid_flags(lines: &[String]) -> Vec<(u32, bool, bool)> {
@@ -3084,8 +4651,7 @@ fn resolve_inline_images_from_raw(
     mail: &ParsedMessage<'_>,
     raw: &[u8],
 ) -> Result<String> {
-    let lower_html = html.to_ascii_lowercase();
-    let inline_images = collect_inline_images(mail, raw, &lower_html);
+    let inline_images = collect_inline_images(mail, raw, &html);
     for (reference, data_url) in inline_images {
         html = replace_resource_reference(&html, &reference, &data_url)?;
     }
@@ -3095,7 +4661,7 @@ fn resolve_inline_images_from_raw(
 fn collect_inline_images(
     mail: &ParsedMessage<'_>,
     raw: &[u8],
-    lower_html: &str,
+    html: &str,
 ) -> Vec<(String, String)> {
     attachment_part_ids(mail)
         .into_iter()
@@ -3115,9 +4681,7 @@ fn collect_inline_images(
             ]
             .into_iter()
             .flatten()
-            .filter(|reference| {
-                !reference.is_empty() && lower_html.contains(&reference.to_ascii_lowercase())
-            })
+            .filter(|reference| !reference.is_empty() && html_contains_reference(html, reference))
             .collect::<Vec<_>>();
             if references.is_empty() {
                 return None;
@@ -3136,13 +4700,75 @@ fn collect_inline_images(
 }
 
 fn replace_resource_reference(input: &str, reference: &str, replacement: &str) -> Result<String> {
-    let mut output = input.to_owned();
-    for (needle, replacement) in [
-        (format!("\"{reference}\""), format!("\"{replacement}\"")),
-        (format!("'{reference}'"), format!("'{replacement}'")),
-        (format!("url({reference})"), format!("url({replacement})")),
-    ] {
-        output = replace_ascii_case_insensitive_bounded(&output, &needle, &replacement)?;
+    rewrite_html_resource_references(input, reference, Some(replacement))
+}
+
+fn html_contains_reference(html: &str, reference: &str) -> bool {
+    rewrite_html_resource_references(html, reference, None)
+        .map(|output| output != html)
+        .unwrap_or(false)
+}
+
+fn rewrite_html_resource_references(
+    input: &str,
+    reference: &str,
+    replacement: Option<&str>,
+) -> Result<String> {
+    let mut output = String::with_capacity(input.len());
+    let mut cursor = 0;
+    while let Some(offset) = input[cursor..].find('<') {
+        let start = cursor + offset;
+        output.push_str(&input[cursor..start]);
+        let Some(end_offset) = input[start..].find('>') else {
+            output.push_str(&input[start..]);
+            return Ok(output);
+        };
+        let end = start + end_offset + 1;
+        let tag = &input[start..end];
+        output.push_str(&rewrite_resource_references_in_tag(
+            tag,
+            reference,
+            replacement,
+        )?);
+        cursor = end;
+    }
+    output.push_str(&input[cursor..]);
+    if output.len() > MAX_RAW_MESSAGE_BYTES {
+        bail!("mime_resolved_html_too_large");
+    }
+    Ok(output)
+}
+
+fn rewrite_resource_references_in_tag(
+    tag: &str,
+    reference: &str,
+    replacement: Option<&str>,
+) -> Result<String> {
+    let lower = tag.to_ascii_lowercase();
+    let mut output = tag.to_owned();
+    for attribute in ["src", "href", "background", "poster", "data"] {
+        for quote in ['\"', '\''] {
+            let needle = format!("{attribute}={quote}{reference}{quote}");
+            if lower.contains(&needle.to_ascii_lowercase()) {
+                let replacement = replacement
+                    .map(|value| format!("{attribute}={quote}{value}{quote}"))
+                    .unwrap_or_default();
+                output = replace_ascii_case_insensitive_bounded(&output, &needle, &replacement)?;
+                if replacement.is_empty() {
+                    return Ok(String::new());
+                }
+            }
+        }
+    }
+    let url = format!("url({reference})");
+    if lower.contains(&url.to_ascii_lowercase()) {
+        let replacement = replacement
+            .map(|value| format!("url({value})"))
+            .unwrap_or_default();
+        output = replace_ascii_case_insensitive_bounded(&output, &url, &replacement)?;
+        if replacement.is_empty() {
+            return Ok(String::new());
+        }
     }
     Ok(output)
 }
@@ -3370,18 +4996,29 @@ fn has_attachment(mail: &ParsedMessage<'_>) -> bool {
 }
 
 fn attachment_part_ids(mail: &ParsedMessage<'_>) -> Vec<u32> {
+    attachment_part_paths(mail)
+        .into_iter()
+        .map(|(part_id, _)| part_id)
+        .collect()
+}
+
+fn attachment_part_paths(mail: &ParsedMessage<'_>) -> Vec<(u32, Vec<usize>)> {
     let mut attachments = Vec::new();
-    let mut pending = vec![0_u32];
-    while let Some(part_id) = pending.pop() {
+    let mut pending = vec![(0_u32, Vec::new())];
+    while let Some((part_id, path)) = pending.pop() {
         let Some(part) = mail.part(part_id) else {
             continue;
         };
         if is_attachment_part(mail, part) {
-            attachments.push(part_id);
+            attachments.push((part_id, path));
             continue;
         }
         if let PartType::Multipart(children) = &part.body {
-            pending.extend(children.iter().rev().copied());
+            pending.extend(children.iter().enumerate().rev().map(|(index, child)| {
+                let mut child_path = path.clone();
+                child_path.push(index + 1);
+                (*child, child_path)
+            }));
         }
     }
     attachments
@@ -3433,13 +5070,13 @@ fn extract_attachments_from_raw(
     message_id: &str,
     selected_html: Option<&str>,
 ) -> Result<Vec<AttachmentData>> {
-    let candidate_ids = attachment_part_ids(mail);
-    if candidate_ids.len() > MAX_ATTACHMENT_COUNT {
+    let candidate_parts = attachment_part_paths(mail);
+    if candidate_parts.len() > MAX_ATTACHMENT_COUNT {
         bail!("message has more than {MAX_ATTACHMENT_COUNT} attachments");
     }
     let mut attachments = Vec::new();
     let mut decoded_bytes = 0_usize;
-    for part_id in candidate_ids {
+    for (part_id, part_path) in candidate_parts {
         let Some(part) = mail.part(part_id) else {
             continue;
         };
@@ -3479,7 +5116,7 @@ fn extract_attachments_from_raw(
             .is_some_and(|value| value.is_inline())
             || part.content_id().is_some();
         let attachment = Attachment {
-            id: format!("{message_id}:{}", attachments.len()),
+            id: mime_attachment_id(message_id, &part_path),
             message_id: message_id.to_owned(),
             is_potentially_unsafe: is_potentially_unsafe(&filename, &mime_type),
             filename,
@@ -3491,6 +5128,15 @@ fn extract_attachments_from_raw(
         attachments.push(AttachmentData { attachment, bytes });
     }
     Ok(attachments)
+}
+
+fn mime_attachment_id(message_id: &str, path: &[usize]) -> String {
+    let section = if path.is_empty() {
+        "root".to_owned()
+    } else {
+        section_name(path)
+    };
+    format!("{message_id}:mime-v1:{section}")
 }
 
 fn add_decoded_attachment_bytes(total: &mut usize, part_bytes: usize) -> Result<()> {
@@ -3555,11 +5201,6 @@ fn attachment_references(part: &MessagePart<'_>) -> Vec<String> {
         }
     }
     references
-}
-
-fn html_contains_reference(html: &str, reference: &str) -> bool {
-    html.to_ascii_lowercase()
-        .contains(&reference.to_ascii_lowercase())
 }
 
 pub fn safe_attachment_filename(value: &str, index: usize) -> String {
@@ -4036,6 +5677,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn complete_parser_attachment_ids_match_selective_mime_section_ids() {
+        let account = test_account();
+        let raw = concat!(
+            "Date: Tue, 21 Jul 2026 10:00:00 +0000\r\n",
+            "From: sender@example.test\r\nTo: recipient@example.test\r\n",
+            "Subject: Section identity\r\nMIME-Version: 1.0\r\n",
+            "Content-Type: multipart/mixed; boundary=m\r\n\r\n",
+            "--m\r\nContent-Type: text/plain\r\n\r\nBody\r\n",
+            "--m\r\nContent-Type: application/pdf; name=receipt.pdf\r\n",
+            "Content-Disposition: attachment; filename=receipt.pdf\r\n",
+            "Content-Transfer-Encoding: base64\r\n\r\ncGRm\r\n--m--\r\n"
+        );
+        let message = parse_message(&account, "INBOX", 9, &[], raw.as_bytes(), None)
+            .await
+            .unwrap();
+        assert_eq!(message.attachments.len(), 1);
+        assert_eq!(
+            message.attachments[0].attachment.id,
+            format!("{}:mime-v1:2", message.id)
+        );
+    }
+
+    #[tokio::test]
     async fn duplicate_singleton_headers_use_the_first_value_in_every_parse_path() {
         let account = test_account();
         let raw = concat!(
@@ -4136,6 +5800,20 @@ mod tests {
         let html = message.body_html.unwrap();
         assert!(html.contains("a cat remains readable"));
         assert!(html.contains("src=\"data:image/png;base64,"));
+    }
+
+    #[test]
+    fn inline_resource_detection_and_rewriting_ignore_visible_cid_text() {
+        let html = "<p>\"cid:logo\" remains visible</p><img src=\"cid:logo\">";
+        assert!(html_contains_reference(html, "cid:logo"));
+        assert!(!html_contains_reference(
+            "<p>\"cid:logo\" remains visible</p>",
+            "cid:logo"
+        ));
+        let resolved =
+            replace_resource_reference(html, "cid:logo", "data:image/png;base64,AA").unwrap();
+        assert!(resolved.contains("<p>\"cid:logo\" remains visible</p>"));
+        assert!(resolved.contains("src=\"data:image/png;base64,AA\""));
     }
 
     #[tokio::test]
@@ -4535,7 +6213,7 @@ mod tests {
     }
 
     #[test]
-    fn automatic_hydration_fetches_are_read_neutral_for_gmail_and_generic_imap() {
+    fn full_foreground_fetches_are_read_neutral_for_gmail_and_generic_imap() {
         let gmail = AccountDraft {
             email: "person@gmail.com".into(),
             display_name: "Person".into(),
@@ -4581,6 +6259,666 @@ mod tests {
             assert!(command.contains("BODY.PEEK[]"));
             assert!(!command.contains("RFC822"));
         }
+    }
+
+    #[test]
+    fn selective_fetch_commands_are_sectioned_read_neutral_and_never_request_pdf_bodies() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (((\"TEXT\" \"HTML\" (\"CHARSET\" \"utf-8\") NIL NIL \"QUOTED-PRINTABLE\" 450 10) ",
+            "(\"IMAGE\" \"PNG\" (\"NAME\" \"image001.png\") \"<image001.png@redacted>\" NIL \"BASE64\" 8 NIL (\"INLINE\" (\"FILENAME\" \"image001.png\"))) \"RELATED\" (\"BOUNDARY\" \"related-redacted\")) ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"claim-documents.pdf\") NIL NIL \"BASE64\" 4 NIL (\"ATTACHMENT\" (\"FILENAME\" \"claim-documents.pdf\"))) \"MIXED\" (\"BOUNDARY\" \"mixed-redacted\")))"
+        ).into()]).unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
+        assert_eq!(
+            plan.text_parts
+                .iter()
+                .map(|part| section_name(&part.part.path))
+                .collect::<Vec<_>>(),
+            vec!["1.1"]
+        );
+        assert_eq!(
+            plan.attachments
+                .iter()
+                .map(|part| section_name(&part.part.path))
+                .collect::<Vec<_>>(),
+            vec!["1.2", "2"]
+        );
+        let commands = plan
+            .text_parts
+            .iter()
+            .flat_map(|part| {
+                [
+                    section_mime_fetch_command(2965, &part.part.path),
+                    section_fetch_command(2965, &part.part.path),
+                ]
+            })
+            .collect::<Vec<_>>();
+        assert!(commands
+            .iter()
+            .all(|command| command.contains("BODY.PEEK[1.1")));
+        assert!(commands
+            .iter()
+            .all(|command| !command.contains("BODY.PEEK[]")
+                && !command.contains("RFC822")
+                && !command.contains("BODY[")));
+        assert!(commands.iter().all(|command| !command.contains("[2]")));
+    }
+
+    #[test]
+    fn top_level_text_reuses_root_headers_and_never_fetches_a_mime_section() {
+        assert_eq!(
+            section_fetch_command(42, &[]),
+            "UID FETCH 42 (BODY.PEEK[TEXT])"
+        );
+        assert_eq!(nested_section_mime_fetch_command(42, &[]), None);
+        assert_eq!(
+            nested_section_mime_fetch_command(42, &[1]),
+            Some("UID FETCH 42 (BODY.PEEK[1.MIME])".into())
+        );
+    }
+
+    #[test]
+    fn recent_refresh_limits_main_folder_selection_and_formats_imap_since_dates() {
+        let mut gmail = test_account();
+        gmail.provider_id = "gmail".into();
+        gmail.archive_mailbox = "[Gmail]/All Mail".into();
+        let plans = refresh_main_mailbox_plans(mailbox_plans(&gmail));
+        assert_eq!(
+            plans.iter().map(|plan| plan.local).collect::<Vec<_>>(),
+            vec!["INBOX", "Sent", "Archive"]
+        );
+        assert_eq!(plans[1].remote, "[Gmail]/Sent Mail");
+        assert_eq!(plans[2].remote, "[Gmail]/All Mail");
+        let cutoff = chrono::DateTime::parse_from_rfc3339("2026-07-15T23:59:59+00:00")
+            .unwrap()
+            .with_timezone(&Utc);
+        let since = imap_since_date(cutoff);
+        assert_eq!(since, "15-Jul-2026");
+        assert_eq!(
+            recent_uid_search_command(&since),
+            "UID SEARCH SINCE 15-Jul-2026"
+        );
+    }
+
+    #[test]
+    fn recent_refresh_is_account_bounded_and_newest_first_with_fair_folder_allocation() {
+        let state = crate::storage::MailboxCatalogState {
+            account_id: "account".into(),
+            mailbox: "INBOX".into(),
+            remote_name: "INBOX".into(),
+            uid_validity: 1,
+            remote_total: 4,
+            historical_complete: false,
+        };
+        let mut work = vec![
+            RecentRefreshWork {
+                plan: MailboxPlan::new("INBOX", "INBOX"),
+                state: state.clone(),
+                uid_validity: 1,
+                uids: recent_uids_newest_first(vec![4, 9, 7]),
+                selected_uids: Vec::new(),
+            },
+            RecentRefreshWork {
+                plan: MailboxPlan::new("Sent", "Sent"),
+                state: state.clone(),
+                uid_validity: 1,
+                uids: recent_uids_newest_first(vec![2, 8]),
+                selected_uids: Vec::new(),
+            },
+            RecentRefreshWork {
+                plan: MailboxPlan::new("Archive", "Archive"),
+                state,
+                uid_validity: 1,
+                uids: recent_uids_newest_first(vec![6]),
+                selected_uids: Vec::new(),
+            },
+        ];
+        allocate_recent_refresh_uids(&mut work, 4);
+
+        assert_eq!(
+            work.iter()
+                .map(|item| item.selected_uids.len())
+                .sum::<usize>(),
+            4
+        );
+        assert_eq!(work[0].selected_uids, vec![9, 7]);
+        assert_eq!(work[1].selected_uids, vec![8]);
+        assert_eq!(work[2].selected_uids, vec![6]);
+    }
+
+    #[test]
+    fn recent_refresh_fetches_only_catalogue_headers_and_sectioned_snippets() {
+        let account = test_account();
+        let fields = catalogue_fetch_fields(&account);
+        let snippet = section_partial_fetch_command(42, &[1, 1], 8192);
+
+        assert!(fields.contains("BODYSTRUCTURE"));
+        assert!(fields.contains("BODY.PEEK[HEADER.FIELDS"));
+        assert!(fields.contains("RFC822.SIZE"));
+        assert!(!fields.contains("BODY.PEEK[]"));
+        assert!(!fields.contains(" RFC822)"));
+        assert_eq!(snippet, "UID FETCH 42 (BODY.PEEK[1.1]<0.8192>)");
+        assert!(!snippet.contains("BODY.PEEK[]"));
+    }
+
+    #[test]
+    fn selective_bodystructure_parser_keeps_provider_signature_html_and_pdf_metadata_separate() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (((\"TEXT\" \"HTML\" (\"CHARSET\" \"utf-8\") NIL NIL \"QUOTED-PRINTABLE\" 450 10) ",
+            "(\"IMAGE\" \"PNG\" (\"NAME\" \"image001.png\") \"<image001.png@redacted>\" NIL \"BASE64\" 8 NIL (\"INLINE\" (\"FILENAME\" \"image001.png\"))) \"RELATED\") ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"claim-documents.pdf\") NIL NIL \"BASE64\" 4 NIL (\"ATTACHMENT\" (\"FILENAME\" \"claim-documents.pdf\"))) \"MIXED\"))"
+        ).into()]).unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        let id = "message-2965";
+        let image = attachment_data_from_part(&plan.attachments[0], id, b"Content-Type: image/png\r\nContent-ID: <image001.png@redacted>\r\nContent-Disposition: inline; filename=image001.png\r\n", None, true).unwrap();
+        let pdf = attachment_data_from_part(&plan.attachments[1], id, &[], None, false).unwrap();
+
+        assert!(image.bytes.is_empty());
+        assert_eq!(
+            image.attachment.presentation,
+            AttachmentPresentation::Embedded
+        );
+        assert!(pdf.bytes.is_empty());
+        assert_eq!(pdf.attachment.filename, "claim-documents.pdf");
+        assert_eq!(pdf.attachment.id, "message-2965:mime-v1:2");
+        assert_eq!(
+            pdf.attachment.presentation,
+            AttachmentPresentation::Downloadable
+        );
+    }
+
+    #[test]
+    fn selective_attachment_only_messages_keep_metadata_and_targeted_pdf_bytes() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (\"APPLICATION\" \"PDF\" (\"NAME\" \"claim-documents.pdf\") NIL NIL \"BASE64\" 4 NIL ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"claim-documents.pdf\"))))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        let data = attachment_data_from_part(
+            &plan.attachments[0],
+            "message-2965",
+            b"Content-Type: application/pdf\r\nContent-Transfer-Encoding: base64\r\nContent-Disposition: attachment; filename=claim-documents.pdf\r\n",
+            Some(b"cGRm".to_vec()),
+            false,
+        )
+        .unwrap();
+
+        assert!(plan.text_parts.is_empty());
+        assert_eq!(plan.attachments.len(), 1);
+        assert_eq!(data.attachment.id, "message-2965:mime-v1:root");
+        assert_eq!(data.attachment.filename, "claim-documents.pdf");
+        assert_eq!(data.bytes, b"pdf");
+    }
+
+    #[test]
+    fn selective_image_only_messages_do_not_require_a_text_part() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (\"IMAGE\" \"PNG\" (\"NAME\" \"logo.png\") \"<logo@example>\" NIL \"BASE64\" 8 NIL ",
+            "(\"INLINE\" (\"FILENAME\" \"logo.png\"))))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        let data =
+            attachment_data_from_part(&plan.attachments[0], "message-1", &[], None, false).unwrap();
+
+        assert!(plan.text_parts.is_empty());
+        assert_eq!(data.attachment.filename, "logo.png");
+        assert_eq!(
+            data.attachment.presentation,
+            AttachmentPresentation::Downloadable
+        );
+    }
+
+    #[test]
+    fn selective_empty_text_filename_remains_a_body_candidate() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (\"TEXT\" \"HTML\" (\"NAME\" \"\") \"<body@example>\" NIL ",
+            "\"7BIT\" 12 1 NIL (\"INLINE\" (\"FILENAME\" \"\"))))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
+        assert_eq!(plan.text_parts.len(), 1);
+        assert!(plan.attachments.is_empty());
+        assert_eq!(plan.text_parts[0].part.mime_type, "text/html");
+    }
+
+    #[test]
+    fn attached_multipart_branch_is_one_downloadable_candidate_not_outer_body_content() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (((\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 12 1) \"RELATED\" NIL ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"forwarded.eml\"))) \"MIXED\"))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
+        assert!(plan.text_parts.is_empty());
+        assert_eq!(plan.attachments.len(), 1);
+        assert_eq!(plan.attachments[0].part.path, vec![1]);
+        assert_eq!(plan.attachments[0].part.filename(), Some("forwarded.eml"));
+    }
+
+    #[test]
+    fn attached_message_rfc822_keeps_its_outer_disposition_instead_of_descending_into_it() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (\"MESSAGE\" \"RFC822\" (\"NAME\" \"forwarded.eml\") NIL NIL \"7BIT\" 123 ",
+            "(NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL) (\"TEXT\" \"PLAIN\" NIL NIL NIL \"7BIT\" 5 1) 1 NIL ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"forwarded.eml\"))))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
+        assert!(plan.text_parts.is_empty());
+        assert_eq!(plan.attachments.len(), 1);
+        assert!(plan.attachments[0].part.is_explicit_attachment());
+        assert_eq!(plan.attachments[0].part.filename(), Some("forwarded.eml"));
+    }
+
+    #[test]
+    fn duplicate_inline_references_are_ambiguous_and_remain_downloadable() {
+        let html = "<img src=\"cid:duplicate@example\">";
+        let references = vec!["cid:duplicate@example".to_owned()];
+        let counts = BTreeMap::from([("cid:duplicate@example".to_owned(), 2usize)]);
+
+        assert!(!has_unambiguous_html_reference(html, &references, &counts));
+    }
+
+    #[test]
+    fn selective_part_decoding_preserves_visible_html_cid_data_and_remote_urls() {
+        // The checked-in provider-shaped fixture is the real regression shape:
+        // multipart/mixed -> related, quoted-printable HTML, CID logo, PDF.
+        let fixture = include_str!("../tests/fixtures/provider-signature-inline.eml");
+        let parsed = parse_complete_message(fixture.as_bytes()).unwrap();
+        let html = format!(
+            "{}<img src=\"https://images.example.test/logo.png\">",
+            select_bodies(&parsed).unwrap().html.unwrap()
+        );
+        let resolved = resolve_inline_images_from_raw(html, &parsed, fixture.as_bytes()).unwrap();
+
+        assert!(resolved.contains("Redacted message content"));
+        assert!(resolved.contains("data:image/png;base64,iVBORw0KGgo="));
+        assert!(resolved.contains("https://images.example.test/logo.png"));
+    }
+
+    #[test]
+    fn selective_text_decoding_uses_hardened_charset_transfer_and_flowed_rules() {
+        assert_eq!(
+            decode_mime_part_body(
+                b"Content-Type: text/plain; charset=iso-8859-1\r\nContent-Transfer-Encoding: quoted-printable\r\n",
+                b"caf=E9",
+            )
+            .unwrap(),
+            "café"
+        );
+        assert_eq!(
+            decode_mime_part_body(
+                b"Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: base64\r\n",
+                b"PHA+aGVsbG88L3A+",
+            )
+            .unwrap(),
+            "<p>hello</p>"
+        );
+        assert_eq!(
+            decode_mime_part_body(
+                b"Content-Type: text/plain; charset=utf-8; format=flowed; delsp=yes\r\nContent-Transfer-Encoding: 7bit\r\n",
+                b"flowed \r\nline",
+            )
+            .unwrap(),
+            "flowedline"
+        );
+        assert!(decode_mime_part_body(
+            b"Content-Type: text/html; charset=utf-8\r\nContent-Transfer-Encoding: x-broken\r\n",
+            b"<p>ignored</p>",
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn selective_alternative_keeps_plain_fallback_when_html_is_undecodable() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" NIL NIL NIL \"7BIT\" 5 1) ",
+            "(\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 8 1) ",
+            "(\"TEXT\" \"HTML\" NIL NIL NIL \"X-BROKEN\" 9 1) \"ALTERNATIVE\"))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
+        assert_eq!(
+            plan.text_parts
+                .iter()
+                .map(|part| (part.part.mime_type.as_str(), part.part.path.as_slice()))
+                .collect::<Vec<_>>(),
+            vec![
+                ("text/plain", [1].as_slice()),
+                // The last alternative is attempted first, but a broken
+                // transfer encoding falls back to the previous HTML body.
+                ("text/html", [3].as_slice()),
+                ("text/html", [2].as_slice())
+            ]
+        );
+        assert_eq!(
+            plan.text_parts[1].fallback_group,
+            plan.text_parts[2].fallback_group
+        );
+    }
+
+    #[test]
+    fn selective_related_honors_the_declared_start_root() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"TEXT\" \"HTML\" NIL \"<wrong>\" NIL \"7BIT\" 5 1) ",
+            "(\"TEXT\" \"PLAIN\" NIL \"<declared-root>\" NIL \"7BIT\" 4 1) ",
+            "\"RELATED\" (\"START\" \"<declared-root>\")))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
+        assert_eq!(plan.text_parts.len(), 1);
+        assert_eq!(plan.text_parts[0].part.mime_type, "text/plain");
+        assert_eq!(plan.text_parts[0].part.path, vec![2]);
+    }
+
+    #[test]
+    fn selective_related_without_a_matching_start_uses_its_first_child() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" NIL \"<first>\" NIL \"7BIT\" 5 1) ",
+            "(\"TEXT\" \"HTML\" NIL \"<second>\" NIL \"7BIT\" 5 1) ",
+            "\"RELATED\" (\"START\" \"<missing>\")))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        assert_eq!(plan.text_parts.len(), 1);
+        assert_eq!(plan.text_parts[0].part.path, vec![1]);
+        assert_eq!(plan.text_parts[0].part.mime_type, "text/plain");
+    }
+
+    #[test]
+    fn targeted_attachment_allows_transport_overhead_but_enforces_decoded_limit() {
+        assert!(validate_targeted_attachment_bytes(&vec![0; MAX_ATTACHMENT_BYTES]).is_ok());
+        assert!(validate_targeted_attachment_bytes(&vec![0; MAX_ATTACHMENT_BYTES + 1]).is_err());
+    }
+
+    #[test]
+    fn selective_bodystructure_decodes_extended_rfc2231_filenames() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (\"APPLICATION\" \"PDF\" (\"NAME*\" ",
+            "\"utf-8''caf%C3%A9.pdf\") NIL NIL \"BASE64\" 4 NIL ",
+            "(\"ATTACHMENT\" (\"FILENAME*\" \"utf-8''caf%C3%A9.pdf\"))))"
+        )
+        .into()])
+        .unwrap();
+        assert_eq!(structure.filename(), Some("café.pdf"));
+    }
+
+    #[test]
+    fn selective_bodystructure_rejects_malformed_and_oversized_parts_before_literal_allocation() {
+        assert!(parse_bodystructure(&["* 1 FETCH (BODYSTRUCTURE (\"TEXT\"".into()]).is_err());
+        assert!(display_literal_limit(0, MAX_DISPLAY_PART_BYTES + 1, "text").is_err());
+        assert!(display_literal_limit(MAX_DISPLAY_TOTAL_BYTES - 10, 11, "text").is_err());
+        assert_eq!(
+            display_literal_limit(0, 1024, "text").unwrap(),
+            MAX_DISPLAY_PART_BYTES
+        );
+    }
+
+    #[test]
+    fn selective_bodystructure_enforces_depth_part_and_attachment_budgets() {
+        let text_leaf = || {
+            ImapBodyValue::List(vec![
+                ImapBodyValue::Atom("TEXT".into()),
+                ImapBodyValue::Atom("PLAIN".into()),
+                ImapBodyValue::Atom("NIL".into()),
+                ImapBodyValue::Atom("NIL".into()),
+                ImapBodyValue::Atom("NIL".into()),
+                ImapBodyValue::Atom("7BIT".into()),
+                ImapBodyValue::Atom("1".into()),
+            ])
+        };
+        let multipart = |children: Vec<ImapBodyValue>| {
+            let mut values = children;
+            values.push(ImapBodyValue::Atom("MIXED".into()));
+            values.push(ImapBodyValue::Atom("NIL".into()));
+            ImapBodyValue::List(values)
+        };
+
+        let mut deeply_nested = text_leaf();
+        for _ in 0..=MAX_MULTIPART_NESTING {
+            deeply_nested = multipart(vec![deeply_nested]);
+        }
+        assert!(bodystructure_part(&deeply_nested, Vec::new())
+            .unwrap_err()
+            .to_string()
+            .contains("mime_multipart_nesting_too_deep"));
+
+        let too_many_parts = multipart((0..MAX_MIME_PARTS).map(|_| text_leaf()).collect());
+        assert!(bodystructure_part(&too_many_parts, Vec::new())
+            .unwrap_err()
+            .to_string()
+            .contains("mime_too_many_parts"));
+
+        let attachment_leaf = || {
+            ImapBodyValue::List(vec![
+                ImapBodyValue::Atom("APPLICATION".into()),
+                ImapBodyValue::Atom("OCTET-STREAM".into()),
+                ImapBodyValue::Atom("NIL".into()),
+                ImapBodyValue::Atom("NIL".into()),
+                ImapBodyValue::Atom("NIL".into()),
+                ImapBodyValue::Atom("BASE64".into()),
+                ImapBodyValue::Atom("1".into()),
+            ])
+        };
+        let too_many_attachments = bodystructure_part(
+            &multipart(
+                (0..=MAX_ATTACHMENT_COUNT)
+                    .map(|_| attachment_leaf())
+                    .collect(),
+            ),
+            Vec::new(),
+        )
+        .unwrap();
+        assert!(selective_plan(&too_many_attachments)
+            .unwrap_err()
+            .to_string()
+            .contains("too many attachments"));
+    }
+
+    #[test]
+    fn bodystructure_transcript_retains_literal_parameters_before_later_header_and_body_literals() {
+        let response = ImapResponse {
+            lines: vec![
+                "* 1 FETCH (BODYSTRUCTURE (\"APPLICATION\" \"PDF\" (\"NAME\" {19}\r\n".into(),
+                ") NIL NIL \"BASE64\" 4 NIL (\"ATTACHMENT\" (\"FILENAME\" {19}\r\n".into(),
+                "))) BODY[HEADER.FIELDS (SUBJECT)] {17}\r\n".into(),
+                " BODY[1] {4}\r\n".into(),
+                ")\r\n".into(),
+                "D0001 OK Fetch complete\r\n".into(),
+            ],
+            literals: vec![
+                ImapLiteral {
+                    uid: Some(1),
+                    data_item: ImapLiteralItem::BodyStructure,
+                    bytes: b"claim-documents.pdf".to_vec(),
+                },
+                ImapLiteral {
+                    uid: Some(1),
+                    data_item: ImapLiteralItem::BodyStructure,
+                    bytes: b"claim-documents.pdf".to_vec(),
+                },
+                ImapLiteral {
+                    uid: Some(1),
+                    data_item: ImapLiteralItem::Body("BODY[HEADER.FIELDS (SUBJECT)]".into()),
+                    bytes: b"Subject: Test\r\n\r\n".to_vec(),
+                },
+                ImapLiteral {
+                    uid: Some(1),
+                    data_item: ImapLiteralItem::Body("BODY[1]".into()),
+                    bytes: b"body".to_vec(),
+                },
+            ],
+        };
+        let structure = parse_bodystructure_response(&response).unwrap();
+
+        assert_eq!(structure.filename(), Some("claim-documents.pdf"));
+        assert_eq!(response.literals.len(), 4);
+        let mut response = response;
+        assert_eq!(
+            response.take_header_literal_for(1).as_deref(),
+            Some(b"Subject: Test\r\n\r\n".as_slice())
+        );
+        assert_eq!(
+            response.take_body_literal_for(1, "1").as_deref(),
+            Some(b"body".as_slice())
+        );
+    }
+
+    #[test]
+    fn header_literal_selection_survives_reverse_order_before_bodystructure_literals() {
+        let mut response = ImapResponse {
+            lines: vec![
+                "* 1 FETCH (BODY[HEADER.FIELDS (SUBJECT)] {17}\r\n".into(),
+                " BODYSTRUCTURE (\"APPLICATION\" \"PDF\" (\"NAME\" {19}\r\n".into(),
+                ") NIL NIL \"BASE64\" 4 NIL (\"ATTACHMENT\" (\"FILENAME\" \"claim-documents.pdf\")))\r\n".into(),
+                "D0001 OK Fetch complete\r\n".into(),
+            ],
+            literals: vec![
+                ImapLiteral {
+                    uid: Some(1),
+                    data_item: ImapLiteralItem::Body("BODY[HEADER.FIELDS (SUBJECT)]".into()),
+                    bytes: b"Subject: Test\r\n\r\n".to_vec(),
+                },
+                ImapLiteral {
+                    uid: Some(1),
+                    data_item: ImapLiteralItem::BodyStructure,
+                    bytes: b"claim-documents.pdf".to_vec(),
+                },
+            ],
+        };
+
+        let structure = parse_bodystructure_response(&response).unwrap();
+        assert_eq!(structure.filename(), Some("claim-documents.pdf"));
+        assert_eq!(
+            response.take_header_literal_for(1).as_deref(),
+            Some(b"Subject: Test\r\n\r\n".as_slice())
+        );
+    }
+
+    #[test]
+    fn bodystructure_locator_ignores_header_literal_text() {
+        let response = ImapResponse {
+            lines: vec![
+                "* 1 FETCH (BODY[HEADER.FIELDS (SUBJECT)] {28}\r\n".into(),
+                " BODYSTRUCTURE (\"TEXT\" \"PLAIN\" NIL NIL NIL \"7BIT\" 4 1))\r\n".into(),
+            ],
+            literals: vec![ImapLiteral {
+                uid: Some(42),
+                data_item: ImapLiteralItem::Body("BODY[HEADER.FIELDS (SUBJECT)]".into()),
+                bytes: b"Subject: BODYSTRUCTURE\r\n\r\n".to_vec(),
+            }],
+        };
+        let structure = parse_bodystructure_response(&response).unwrap();
+        assert_eq!(structure.mime_type, "text/plain");
+    }
+
+    #[test]
+    fn literal_labels_ignore_body_tokens_inside_quoted_parameters() {
+        assert_eq!(
+            literal_data_item(
+                "* 1 FETCH (BODYSTRUCTURE (\"TEXT\" \"PLAIN\" (\"NAME\" \"BODY[HEADER]\") NIL NIL \"7BIT\" {4}\r\n"
+            ),
+            ImapLiteralItem::BodyStructure
+        );
+        assert_eq!(
+            literal_data_item("* 1 FETCH (BODYSTRUCTURE NIL BODY[HEADER.FIELDS (SUBJECT)] {4}\r\n"),
+            ImapLiteralItem::Body("BODY[HEADER.FIELDS (SUBJECT)]".into())
+        );
+    }
+
+    #[test]
+    fn literal_selection_requires_the_requested_fetch_uid_and_body_section() {
+        let mut response = ImapResponse {
+            lines: vec![],
+            literals: vec![
+                ImapLiteral {
+                    uid: Some(7),
+                    data_item: ImapLiteralItem::Body("BODY[1]".into()),
+                    bytes: b"unsolicited-other-message".to_vec(),
+                },
+                ImapLiteral {
+                    uid: Some(42),
+                    data_item: ImapLiteralItem::Body("BODY[2]".into()),
+                    bytes: b"unsolicited-other-section".to_vec(),
+                },
+                ImapLiteral {
+                    uid: Some(42),
+                    data_item: ImapLiteralItem::Body("BODY[1]".into()),
+                    bytes: b"requested".to_vec(),
+                },
+            ],
+        };
+        assert_eq!(
+            response.take_body_literal_for(42, "1").as_deref(),
+            Some(b"requested".as_slice())
+        );
+        assert_eq!(response.literals.len(), 2);
+        assert_eq!(
+            fetch_uid_from_line("* 3 FETCH (UID 42 BODY[1] {9}\r\n"),
+            Some(42)
+        );
+    }
+
+    #[test]
+    fn uid_after_a_body_literal_backfills_only_that_fetch_response() {
+        let mut literals = vec![ImapLiteral {
+            uid: None,
+            data_item: ImapLiteralItem::Body("BODY[TEXT]".into()),
+            bytes: b"requested-root-body".to_vec(),
+        }];
+        let mut pending = vec![0];
+        backfill_fetch_literal_uids(&mut literals, &mut pending, 42);
+        assert_eq!(literals[0].uid, Some(42));
+        let mut response = ImapResponse {
+            lines: vec![],
+            literals,
+        };
+        assert_eq!(
+            response.take_body_literal_for(42, "TEXT").as_deref(),
+            Some(b"requested-root-body".as_slice())
+        );
+        assert!(is_untagged_fetch_start("* 7 FETCH (BODY[TEXT] {19}\r\n"));
+        assert!(is_untagged_fetch_start("* 8 FETCH (UID 7 BODY[1] {4}\r\n"));
+    }
+
+    #[test]
+    fn aggregate_literal_budget_rejects_many_small_literals_before_allocation() {
+        assert!(reserve_imap_literal_budget(3, 24, 9, 32).is_err());
+        assert!(reserve_imap_literal_budget(MAX_IMAP_RESPONSE_LITERALS, 0, 1, 32).is_err());
+        assert!(reserve_imap_literal_budget(3, 24, 8, 32).is_ok());
+    }
+
+    #[test]
+    fn response_transcript_budget_rejects_bodystructure_growth_before_joining_lines() {
+        assert_eq!(
+            reserve_imap_transcript_budget(MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES - 1, 1).unwrap(),
+            MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES
+        );
+        assert!(reserve_imap_transcript_budget(MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES, 1).is_err());
+    }
+
+    #[test]
+    fn selective_fetch_rejects_recycled_uids_when_catalogue_uidvalidity_differs() {
+        let error = verify_mailbox_uid_validity(8, 7, "opening").unwrap_err();
+        assert!(error.to_string().contains("mailbox identity changed"));
+        assert!(error.to_string().contains("sync the account"));
+        assert!(verify_mailbox_uid_validity(7, 7, "opening").is_ok());
     }
 
     #[test]

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -31,19 +31,64 @@ const VAULT_NONCE_LEN: usize = 12;
 /// Foreground-opened, non-starred mail is useful offline, but it must never
 /// grow into a second unbounded mail store. Starred mail has its own durable,
 /// authoritative cache and is intentionally not counted here.
-const MESSAGE_CONTENT_CACHE_MAX_ENTRIES: i64 = 64;
-const MESSAGE_CONTENT_CACHE_MAX_BYTES: i64 = 8 * 1024 * 1024;
-/// Attachment presentation changes when the selected HTML branch changes.
-/// Cached metadata written before this version could only tell us whether a
-/// MIME part was transport-inline, which is not enough to decide whether it
-/// should be shown to the user.
-const ATTACHMENT_PRESENTATION_CACHE_VERSION: &str = "1";
-const ATTACHMENT_PRESENTATION_VERSION: i64 = 1;
+const MESSAGE_CONTENT_CACHE_MAX_BYTES: i64 = 512 * 1024 * 1024;
+const MESSAGE_CONTENT_CACHE_RECENT_WINDOW_DAYS: i64 = 30;
+/// Attachment presentation and opaque IDs change when the selected HTML/MIME
+/// branch changes. Version 2 invalidates IDs written by the full-message
+/// parser, whose downloadable-only numbering can otherwise select a different
+/// part when interpreted by the sectioned MIME planner.
+const ATTACHMENT_PRESENTATION_CACHE_VERSION: &str = "2";
+const ATTACHMENT_PRESENTATION_VERSION: i64 = 2;
 
 #[derive(Clone)]
 pub struct Store {
     pool: SqlitePool,
     vault_key: Arc<[u8; VAULT_KEY_LEN]>,
+}
+
+/// Cancellation-safe ownership of one provider body fetch. Dropping the
+/// owning future schedules claim release so later readers do not wait for a
+/// process restart.
+pub struct MessageContentFetchClaim {
+    store: Store,
+    message_id: String,
+    released: bool,
+}
+
+/// Outcome of attempting to own one provider body fetch.
+///
+/// A reader needs to distinguish another live owner from a message that has
+/// already been moved or removed. Treating both as "not acquired" makes a
+/// stale UI row wait for the full fetch timeout.
+pub enum MessageContentFetchAcquire {
+    Claimed(MessageContentFetchClaim),
+    Busy,
+    Missing,
+}
+
+impl MessageContentFetchClaim {
+    pub async fn release(mut self) -> Result<()> {
+        self.store
+            .release_message_content_fetch(&self.message_id)
+            .await?;
+        self.released = true;
+        Ok(())
+    }
+}
+
+impl Drop for MessageContentFetchClaim {
+    fn drop(&mut self) {
+        if self.released {
+            return;
+        }
+        let store = self.store.clone();
+        let message_id = self.message_id.clone();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                let _ = store.release_message_content_fetch(&message_id).await;
+            });
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -96,6 +141,17 @@ pub struct MailSummary {
     #[serde(skip)]
     #[sqlx(skip)]
     pub attachments: Vec<AttachmentData>,
+}
+
+/// Local flags observed before a remote catalogue fetch. They form the
+/// compare-and-swap precondition when the delayed fetch is published.
+#[derive(Debug, Clone, PartialEq, Eq, FromRow)]
+pub struct ExpectedMessageFlags {
+    pub account_id: String,
+    pub mailbox: String,
+    pub uid: i64,
+    pub is_read: bool,
+    pub is_flagged: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -379,6 +435,7 @@ impl Store {
             "CREATE TABLE IF NOT EXISTS starred_attachment_metadata (id TEXT PRIMARY KEY, message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, filename TEXT NOT NULL, mime_type TEXT NOT NULL, size_bytes INTEGER NOT NULL, is_inline INTEGER NOT NULL DEFAULT 0, presentation TEXT NOT NULL DEFAULT 'unknown', is_potentially_unsafe INTEGER NOT NULL DEFAULT 0)",
             "CREATE TABLE IF NOT EXISTS message_content_cache (message_id TEXT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, content_state TEXT NOT NULL CHECK(content_state = 'complete'), body_text TEXT NOT NULL, body_html TEXT, unsubscribe_kind TEXT, attachments_json TEXT NOT NULL, byte_size INTEGER NOT NULL CHECK(byte_size >= 0), last_accessed INTEGER NOT NULL)",
             "CREATE INDEX IF NOT EXISTS message_content_cache_lru ON message_content_cache(last_accessed, message_id)",
+            "CREATE TABLE IF NOT EXISTS message_content_fetches (message_id TEXT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, claimed_at TEXT NOT NULL)",
             "CREATE TABLE IF NOT EXISTS app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
             "CREATE TABLE IF NOT EXISTS mailbox_catalog_state (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, remote_name TEXT NOT NULL, uid_validity INTEGER NOT NULL, remote_total INTEGER NOT NULL DEFAULT 0, historical_complete INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox))",
             "CREATE TABLE IF NOT EXISTS mail_rebuild_jobs (account_id TEXT PRIMARY KEY, phase TEXT NOT NULL, completed INTEGER NOT NULL DEFAULT 0, total INTEGER, updated_at TEXT NOT NULL)",
@@ -389,6 +446,12 @@ impl Store {
                 .await
                 .with_context(|| format!("storage migration statement failed: {statement}"))?;
         }
+        // Fetch claims coordinate only concurrent work in this process. A
+        // previous process cannot still be downloading, so never let its
+        // transient rows block a fresh store after restart.
+        sqlx::query("DELETE FROM message_content_fetches")
+            .execute(&self.pool)
+            .await?;
         // Provider work can outlive a UI action (for example, a hydration
         // task that fetched an IMAP message just before the account was
         // removed). These are deliberately database-level guards rather
@@ -1095,6 +1158,72 @@ impl Store {
         Ok(())
     }
 
+    /// Captures local flags before a remote catalogue fetch. The returned
+    /// values are later used as compare-and-swap preconditions at publication.
+    pub async fn capture_recent_catalogue_expected_flags(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        uids: &[u32],
+    ) -> Result<Vec<ExpectedMessageFlags>> {
+        if uids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let placeholders = vec!["?"; uids.len()].join(",");
+        let sql = format!(
+            "SELECT account_id, mailbox, uid, is_read, is_flagged FROM messages WHERE account_id = ? AND mailbox = ? AND uid IN ({placeholders})"
+        );
+        let mut statement = sqlx::query_as::<_, ExpectedMessageFlags>(&sql)
+            .bind(account_id.to_string())
+            .bind(mailbox);
+        for uid in uids {
+            statement = statement.bind(i64::from(*uid));
+        }
+        Ok(statement.fetch_all(&self.pool).await?)
+    }
+
+    /// Publishes a delayed recent-catalogue refresh. Provider flags apply to
+    /// new rows, but conflict rows accept them only when their current local
+    /// flags still match the snapshot captured before the remote fetch.
+    pub async fn upsert_recent_catalog_messages(
+        &self,
+        messages: &[MailSummary],
+        expected_flags: &[ExpectedMessageFlags],
+    ) -> Result<()> {
+        let expected_by_locator: HashMap<(&str, &str, i64), (bool, bool)> = expected_flags
+            .iter()
+            .map(|expected| {
+                (
+                    (
+                        expected.account_id.as_str(),
+                        expected.mailbox.as_str(),
+                        expected.uid,
+                    ),
+                    (expected.is_read, expected.is_flagged),
+                )
+            })
+            .collect();
+        let mut tx = self.pool.begin().await?;
+        for message in messages {
+            persist_message_with_flag_policy(
+                &mut tx,
+                message,
+                FlagUpdatePolicy::CompareAndSwap(
+                    expected_by_locator
+                        .get(&(
+                            message.account_id.as_str(),
+                            message.mailbox.as_str(),
+                            message.uid,
+                        ))
+                        .copied(),
+                ),
+            )
+            .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
     /// Stores one incremental mailbox batch and returns messages eligible for
     /// new-mail notification. The first successful batch establishes a silent
     /// baseline so connecting an account never alerts for historical mail.
@@ -1621,8 +1750,22 @@ impl Store {
         let Some((body_text, body_html, unsubscribe_kind, attachments_json)) = cached else {
             return Ok(None);
         };
-        let attachments: Vec<Attachment> = serde_json::from_str(&attachments_json)
-            .context("cached attachment metadata is invalid")?;
+        let attachments: Vec<Attachment> = match serde_json::from_str(&attachments_json) {
+            Ok(attachments) => attachments,
+            Err(error) => {
+                tracing::warn!(
+                    %error,
+                    %message_id,
+                    "discarding corrupt cached attachment metadata"
+                );
+                sqlx::query("DELETE FROM message_content_cache WHERE message_id = ?")
+                    .bind(message_id)
+                    .execute(&mut *tx)
+                    .await?;
+                tx.commit().await?;
+                return Ok(None);
+            }
+        };
         if attachments
             .iter()
             .any(|attachment| !attachment.presentation.is_current())
@@ -1663,6 +1806,22 @@ impl Store {
         is_flagged: bool,
         content: CachedMessageContent,
     ) -> Result<()> {
+        self.cache_message_content_with_budget(
+            message_id,
+            is_flagged,
+            content,
+            MESSAGE_CONTENT_CACHE_MAX_BYTES,
+        )
+        .await
+    }
+
+    async fn cache_message_content_with_budget(
+        &self,
+        message_id: &str,
+        is_flagged: bool,
+        content: CachedMessageContent,
+        max_bytes: i64,
+    ) -> Result<()> {
         let mut attachments = content.attachments;
         // The cache key is the current provider locator. Never retain parsed
         // metadata that refers to a different local message id.
@@ -1677,7 +1836,7 @@ impl Store {
             content.unsubscribe_kind.as_deref(),
             &attachments_json,
         )?;
-        if byte_size > MESSAGE_CONTENT_CACHE_MAX_BYTES {
+        if byte_size > max_bytes {
             sqlx::query("DELETE FROM message_content_cache WHERE message_id = ?")
                 .bind(message_id)
                 .execute(&self.pool)
@@ -1711,28 +1870,20 @@ impl Store {
             return Ok(());
         }
 
-        let entries: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM message_content_cache")
-            .fetch_one(&mut *tx)
-            .await?;
-        if entries > MESSAGE_CONTENT_CACHE_MAX_ENTRIES {
-            sqlx::query(
-                "DELETE FROM message_content_cache WHERE message_id IN (SELECT message_id FROM (SELECT message_id FROM message_content_cache ORDER BY last_accessed, message_id LIMIT ?))",
-            )
-            .bind(entries - MESSAGE_CONTENT_CACHE_MAX_ENTRIES)
-            .execute(&mut *tx)
-            .await?;
-        }
+        let recent_cutoff =
+            Utc::now() - chrono::Duration::days(MESSAGE_CONTENT_CACHE_RECENT_WINDOW_DAYS);
         loop {
             let used_bytes: i64 =
                 sqlx::query_scalar("SELECT COALESCE(SUM(byte_size), 0) FROM message_content_cache")
                     .fetch_one(&mut *tx)
                     .await?;
-            if used_bytes <= MESSAGE_CONTENT_CACHE_MAX_BYTES {
+            if used_bytes <= max_bytes {
                 break;
             }
             let removed = sqlx::query(
-                "DELETE FROM message_content_cache WHERE message_id = (SELECT message_id FROM message_content_cache ORDER BY last_accessed, message_id LIMIT 1)",
+                "DELETE FROM message_content_cache WHERE message_id = (SELECT message_id FROM (SELECT c.message_id FROM message_content_cache c JOIN messages m ON m.id = c.message_id ORDER BY CASE WHEN m.mailbox IN ('INBOX', 'Sent', 'Archive') AND m.received_at >= ? THEN 1 ELSE 0 END, c.last_accessed, c.message_id LIMIT 1))",
             )
+            .bind(recent_cutoff)
             .execute(&mut *tx)
             .await?
             .rows_affected();
@@ -1741,6 +1892,102 @@ impl Store {
             }
         }
         tx.commit().await?;
+        Ok(())
+    }
+
+    /// Returns recent primary-folder messages that still need their body in
+    /// the cache appropriate to their current flag state. Exact, non-empty
+    /// stored Message-IDs are deduplicated in SQL; malformed or variant IDs
+    /// deliberately remain distinct for the coordinator to deduplicate.
+    pub async fn recent_body_cache_candidates(
+        &self,
+        account_id: AccountId,
+        cutoff: DateTime<Utc>,
+        limit: u32,
+    ) -> Result<Vec<MailSummary>> {
+        self.recent_body_cache_candidates_page(account_id, cutoff, limit, 0)
+            .await
+    }
+
+    /// Returns a deterministic page of recent body-cache candidates. The
+    /// duplicate ranking runs before pagination so pages neither overlap nor
+    /// resurrect a lower-ranked copy of an already-selected Message-ID.
+    pub async fn recent_body_cache_candidates_page(
+        &self,
+        account_id: AccountId,
+        cutoff: DateTime<Utc>,
+        limit: u32,
+        offset: u32,
+    ) -> Result<Vec<MailSummary>> {
+        const SQL: &str = "WITH uncached AS (SELECT m.id, m.account_id, m.mailbox, m.uid, m.message_id, m.in_reply_to, m.reference_ids, m.thread_id, m.subject, m.from_name, m.from_address, m.to_addresses, m.cc_addresses, m.bcc_addresses, m.reply_to_addresses, m.received_at, m.snippet, m.body_text, m.body_html, m.content_state, m.unsubscribe_kind, m.unsubscribe_url, m.is_read, m.is_flagged, m.has_attachments, m.category, m.classification_confidence, m.classification_source, m.classification_signals, ROW_NUMBER() OVER (PARTITION BY CASE WHEN m.message_id IS NULL OR trim(m.message_id) = '' THEN m.id ELSE m.message_id END ORDER BY m.received_at DESC, m.id DESC) AS duplicate_rank FROM messages m LEFT JOIN message_content_cache c ON c.message_id = m.id LEFT JOIN starred_message_bodies b ON b.message_id = m.id AND b.attachment_presentation_version = ? WHERE m.account_id = ? AND m.mailbox IN ('INBOX', 'Sent', 'Archive') AND m.received_at >= ? AND ((m.is_flagged = 0 AND c.message_id IS NULL) OR (m.is_flagged = 1 AND b.message_id IS NULL))) SELECT id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals FROM uncached WHERE duplicate_rank = 1 ORDER BY received_at DESC, id DESC LIMIT ? OFFSET ?";
+        Ok(sqlx::query_as::<_, MailSummary>(SQL)
+            .bind(ATTACHMENT_PRESENTATION_VERSION)
+            .bind(account_id.to_string())
+            .bind(cutoff)
+            .bind(i64::from(limit))
+            .bind(i64::from(offset))
+            .fetch_all(&self.pool)
+            .await?)
+    }
+
+    /// Claims a local message for an in-flight body fetch. Claims are
+    /// intentionally transient and are cleared when the store starts.
+    pub async fn claim_message_content_fetch(&self, message_id: &str) -> Result<bool> {
+        Ok(sqlx::query(
+            "INSERT OR IGNORE INTO message_content_fetches(message_id, claimed_at) SELECT ?, ? WHERE EXISTS (SELECT 1 FROM messages WHERE id = ?)",
+        )
+        .bind(message_id)
+        .bind(Utc::now())
+        .bind(message_id)
+        .execute(&self.pool)
+        .await?
+        .rows_affected()
+            == 1)
+    }
+
+    pub async fn acquire_message_content_fetch(
+        &self,
+        message_id: &str,
+    ) -> Result<Option<MessageContentFetchClaim>> {
+        Ok(self
+            .claim_message_content_fetch(message_id)
+            .await?
+            .then(|| MessageContentFetchClaim {
+                store: self.clone(),
+                message_id: message_id.to_owned(),
+                released: false,
+            }))
+    }
+
+    /// Acquires a fetch claim while preserving why it was unavailable.
+    ///
+    /// Background work only needs a best-effort claim, but foreground opens
+    /// must fail a stale/deleted message immediately instead of polling it as
+    /// though another fetch still owned it.
+    pub async fn acquire_message_content_fetch_outcome(
+        &self,
+        message_id: &str,
+    ) -> Result<MessageContentFetchAcquire> {
+        if let Some(claim) = self.acquire_message_content_fetch(message_id).await? {
+            return Ok(MessageContentFetchAcquire::Claimed(claim));
+        }
+
+        let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM messages WHERE id = ?)")
+            .bind(message_id)
+            .fetch_one(&self.pool)
+            .await?;
+        Ok(if exists {
+            MessageContentFetchAcquire::Busy
+        } else {
+            MessageContentFetchAcquire::Missing
+        })
+    }
+
+    pub async fn release_message_content_fetch(&self, message_id: &str) -> Result<()> {
+        sqlx::query("DELETE FROM message_content_fetches WHERE message_id = ?")
+            .bind(message_id)
+            .execute(&self.pool)
+            .await?;
         Ok(())
     }
 
@@ -1777,7 +2024,7 @@ impl Store {
         account_id: AccountId,
         limit: u32,
     ) -> Result<Vec<MailSummary>> {
-        const SQL: &str = "SELECT m.id, m.account_id, m.mailbox, m.uid, m.message_id, m.in_reply_to, m.reference_ids, m.thread_id, m.subject, m.from_name, m.from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals FROM messages m LEFT JOIN starred_message_bodies b ON b.message_id = m.id WHERE m.account_id = ? AND m.is_flagged = 1 AND (b.message_id IS NULL OR b.attachment_presentation_version != ?) ORDER BY m.received_at DESC LIMIT ?";
+        const SQL: &str = "SELECT m.id, m.account_id, m.mailbox, m.uid, m.message_id, m.in_reply_to, m.reference_ids, m.thread_id, m.subject, m.from_name, m.from_address, m.to_addresses, m.cc_addresses, m.bcc_addresses, m.reply_to_addresses, m.received_at, m.snippet, m.body_text, m.body_html, m.content_state, m.unsubscribe_kind, m.unsubscribe_url, m.is_read, m.is_flagged, m.has_attachments, m.category, m.classification_confidence, m.classification_source, m.classification_signals FROM messages m LEFT JOIN starred_message_bodies b ON b.message_id = m.id WHERE m.account_id = ? AND m.is_flagged = 1 AND (b.message_id IS NULL OR b.attachment_presentation_version != ?) ORDER BY m.received_at DESC LIMIT ?";
         Ok(sqlx::query_as::<_, MailSummary>(SQL)
             .bind(account_id.to_string())
             .bind(ATTACHMENT_PRESENTATION_VERSION)
@@ -2010,6 +2257,33 @@ impl Store {
         // Attachment identifiers encode the message locator. Invalidate the
         // source cache instead of cascading it to the destination locator.
         sqlx::query("DELETE FROM message_content_cache WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)")
+            .bind(&account_key)
+            .bind(source_mailbox)
+            .bind(source_uid)
+            .execute(&mut *tx)
+            .await?;
+        // Starred attachment metadata uses the same opaque IDs as the
+        // foreground cache. Do not cascade those IDs to the new locator:
+        // a later targeted download would resolve the old message prefix
+        // against the destination's MIME structure. Removing the durable
+        // starred body also makes the destination eligible for an
+        // authoritative refetch.
+        sqlx::query("DELETE FROM starred_attachment_metadata WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)")
+            .bind(&account_key)
+            .bind(source_mailbox)
+            .bind(source_uid)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM starred_message_bodies WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)")
+            .bind(&account_key)
+            .bind(source_mailbox)
+            .bind(source_uid)
+            .execute(&mut *tx)
+            .await?;
+        // In-flight fetch ownership is tied to the old locator. Revoke it
+        // before the message ID update instead of allowing the FK cascade to
+        // move a claim that its owner can only release by the old ID.
+        sqlx::query("DELETE FROM message_content_fetches WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)")
             .bind(&account_key)
             .bind(source_mailbox)
             .bind(source_uid)
@@ -2741,9 +3015,23 @@ fn participants_overlap(left: &ThreadRow, right: &ThreadRow) -> bool {
     left.contains(&right_from) || right.to_addresses.to_ascii_lowercase().contains(left_from)
 }
 
+#[derive(Clone, Copy)]
+enum FlagUpdatePolicy {
+    ProviderAuthoritative,
+    CompareAndSwap(Option<(bool, bool)>),
+}
+
 async fn persist_message(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     message: &MailSummary,
+) -> Result<()> {
+    persist_message_with_flag_policy(tx, message, FlagUpdatePolicy::ProviderAuthoritative).await
+}
+
+async fn persist_message_with_flag_policy(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    message: &MailSummary,
+    flag_policy: FlagUpdatePolicy,
 ) -> Result<()> {
     let suppressed: bool = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = ? AND uid = ?)",
@@ -2756,7 +3044,12 @@ async fn persist_message(
     if suppressed {
         return Ok(());
     }
-    sqlx::query("INSERT INTO messages(id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, threading_scanned, recipient_headers_scanned, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, unsubscribe_scanned, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox, uid) DO UPDATE SET message_id=excluded.message_id, in_reply_to=excluded.in_reply_to, reference_ids=excluded.reference_ids, threading_scanned=1, recipient_headers_scanned=1, subject=excluded.subject, from_name=excluded.from_name, from_address=excluded.from_address, to_addresses=excluded.to_addresses, cc_addresses=excluded.cc_addresses, bcc_addresses=excluded.bcc_addresses, reply_to_addresses=excluded.reply_to_addresses, received_at=excluded.received_at, snippet=CASE WHEN excluded.content_state = 'complete' THEN excluded.snippet ELSE messages.snippet END, body_text=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_text ELSE messages.body_text END, body_html=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_html ELSE messages.body_html END, content_state=CASE WHEN messages.content_state = 'complete' THEN messages.content_state ELSE excluded.content_state END, unsubscribe_kind=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_kind ELSE messages.unsubscribe_kind END, unsubscribe_url=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_url ELSE messages.unsubscribe_url END, unsubscribe_scanned=CASE WHEN excluded.content_state = 'complete' THEN 1 ELSE messages.unsubscribe_scanned END, is_read=excluded.is_read, is_flagged=excluded.is_flagged, has_attachments=CASE WHEN excluded.content_state = 'complete' THEN excluded.has_attachments ELSE messages.has_attachments END, classification_signals=excluded.classification_signals")
+    let (provider_authoritative, expected_flags) = match flag_policy {
+        FlagUpdatePolicy::ProviderAuthoritative => (true, None),
+        FlagUpdatePolicy::CompareAndSwap(expected_flags) => (false, expected_flags),
+    };
+    let (expected_read, expected_flagged) = expected_flags.unwrap_or_default();
+    sqlx::query("INSERT INTO messages(id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, threading_scanned, recipient_headers_scanned, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, unsubscribe_scanned, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox, uid) DO UPDATE SET message_id=excluded.message_id, in_reply_to=excluded.in_reply_to, reference_ids=excluded.reference_ids, threading_scanned=1, recipient_headers_scanned=1, subject=excluded.subject, from_name=excluded.from_name, from_address=excluded.from_address, to_addresses=excluded.to_addresses, cc_addresses=excluded.cc_addresses, bcc_addresses=excluded.bcc_addresses, reply_to_addresses=excluded.reply_to_addresses, received_at=excluded.received_at, snippet=CASE WHEN excluded.content_state = 'complete' THEN excluded.snippet ELSE messages.snippet END, body_text=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_text ELSE messages.body_text END, body_html=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_html ELSE messages.body_html END, content_state=CASE WHEN messages.content_state = 'complete' THEN messages.content_state ELSE excluded.content_state END, unsubscribe_kind=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_kind ELSE messages.unsubscribe_kind END, unsubscribe_url=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_url ELSE messages.unsubscribe_url END, unsubscribe_scanned=CASE WHEN excluded.content_state = 'complete' THEN 1 ELSE messages.unsubscribe_scanned END, is_read=CASE WHEN ? OR (? AND messages.is_read = ? AND messages.is_flagged = ?) THEN excluded.is_read ELSE messages.is_read END, is_flagged=CASE WHEN ? OR (? AND messages.is_read = ? AND messages.is_flagged = ?) THEN excluded.is_flagged ELSE messages.is_flagged END, has_attachments=CASE WHEN excluded.content_state = 'complete' THEN excluded.has_attachments ELSE messages.has_attachments END, classification_signals=excluded.classification_signals")
         .bind(&message.id).bind(&message.account_id).bind(&message.mailbox).bind(message.uid)
         .bind(&message.message_id).bind(&message.in_reply_to).bind(&message.reference_ids).bind(&message.thread_id)
         .bind(&message.subject).bind(&message.from_name)
@@ -2772,8 +3065,28 @@ async fn persist_message(
         .bind(message.is_flagged).bind(message.has_attachments)
         .bind(&message.category).bind(message.classification_confidence)
         .bind(&message.classification_source).bind(&message.classification_signals)
+        .bind(provider_authoritative)
+        .bind(expected_flags.is_some())
+        .bind(expected_read)
+        .bind(expected_flagged)
+        .bind(provider_authoritative)
+        .bind(expected_flags.is_some())
+        .bind(expected_read)
+        .bind(expected_flagged)
         .execute(&mut **tx).await?;
-    if message.is_flagged && message.content_state == "complete" {
+    let effective_is_flagged = if matches!(flag_policy, FlagUpdatePolicy::CompareAndSwap(_)) {
+        sqlx::query_scalar(
+            "SELECT is_flagged FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?",
+        )
+        .bind(&message.account_id)
+        .bind(&message.mailbox)
+        .bind(message.uid)
+        .fetch_one(&mut **tx)
+        .await?
+    } else {
+        message.is_flagged
+    };
+    if effective_is_flagged && message.content_state == "complete" {
         sqlx::query("INSERT INTO starred_message_bodies(message_id, body_text, body_html, attachment_presentation_version, cached_at) VALUES (?, ?, ?, ?, ?) ON CONFLICT(message_id) DO UPDATE SET body_text=excluded.body_text, body_html=excluded.body_html, attachment_presentation_version=excluded.attachment_presentation_version, cached_at=excluded.cached_at")
             .bind(&message.id)
             .bind(&message.body_text)
@@ -2803,7 +3116,7 @@ async fn persist_message(
                 .execute(&mut **tx)
                 .await?;
         }
-    } else if !message.is_flagged {
+    } else if !effective_is_flagged {
         sqlx::query("DELETE FROM starred_message_bodies WHERE message_id = ?")
             .bind(&message.id)
             .execute(&mut **tx)
@@ -3085,6 +3398,22 @@ mod tests {
         }
     }
 
+    fn cache_candidate_message(
+        account_id: uuid::Uuid,
+        id: &str,
+        uid: i64,
+        mailbox: &str,
+        received_at: DateTime<Utc>,
+    ) -> MailSummary {
+        let mut message = message(id, "preview");
+        message.id = id.into();
+        message.account_id = account_id.to_string();
+        message.uid = uid;
+        message.mailbox = mailbox.into();
+        message.received_at = received_at;
+        message
+    }
+
     #[tokio::test]
     async fn recipient_headers_round_trip_and_refresh_without_inference() {
         let store = Store::in_memory().await.unwrap();
@@ -3221,13 +3550,16 @@ mod tests {
             1
         );
 
-        // Simulate a database written before attachment presentation metadata
-        // existed, then reopen it so migration follows the production path.
-        sqlx::query("DELETE FROM app_meta WHERE key = 'attachment_presentation_cache_version'")
-            .execute(&store.pool)
-            .await
-            .unwrap();
-        sqlx::query("UPDATE starred_message_bodies SET attachment_presentation_version = 0 WHERE message_id = ?")
+        // Simulate version 1, whose full-parser downloadable-only attachment
+        // indexes can point at a different MIME part under the sectioned
+        // planner, then reopen so migration follows the production path.
+        sqlx::query(
+            "UPDATE app_meta SET value = '1' WHERE key = 'attachment_presentation_cache_version'",
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        sqlx::query("UPDATE starred_message_bodies SET attachment_presentation_version = 1 WHERE message_id = ?")
             .bind(&id)
             .execute(&store.pool)
             .await
@@ -3382,7 +3714,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn body_cache_replaces_accounting_and_evicts_entry_and_byte_lru() {
+    async fn body_cache_replaces_accounting_and_uses_global_byte_lru() {
         let store = Store::in_memory().await.unwrap();
         let first = message("First", "preview");
         let first_id = first.id.clone();
@@ -3408,7 +3740,7 @@ mod tests {
                 .unwrap();
         assert_eq!(used, expected);
 
-        for index in 0..=MESSAGE_CONTENT_CACHE_MAX_ENTRIES {
+        for index in 0..=64 {
             let mut entry = message("Entry", "preview");
             entry.id = format!("entry-{index}");
             entry.account_id = "cache-entry-account".into();
@@ -3427,14 +3759,14 @@ mod tests {
             .cached_message_content(&first_id)
             .await
             .unwrap()
-            .is_none());
+            .is_some());
         assert!(store
             .cached_message_content(&second_id)
             .await
             .unwrap()
             .is_none());
         assert!(store
-            .cached_message_content(&format!("entry-{MESSAGE_CONTENT_CACHE_MAX_ENTRIES}"))
+            .cached_message_content("entry-64")
             .await
             .unwrap()
             .is_some());
@@ -3442,7 +3774,7 @@ mod tests {
             .fetch_one(&store.pool)
             .await
             .unwrap();
-        assert_eq!(entries, MESSAGE_CONTENT_CACHE_MAX_ENTRIES);
+        assert!(entries > 64);
 
         let byte_store = Store::in_memory().await.unwrap();
         let byte_first = message("Byte first", "preview");
@@ -3455,13 +3787,31 @@ mod tests {
             .upsert_messages(&[byte_first, byte_second])
             .await
             .unwrap();
-        let half = "x".repeat((MESSAGE_CONTENT_CACHE_MAX_BYTES / 2) as usize);
         byte_store
-            .cache_message_content(&byte_first_id, false, cached_content(&half))
+            .cache_message_content(&byte_first_id, false, cached_content("first"))
             .await
             .unwrap();
         byte_store
-            .cache_message_content(&byte_second_id, false, cached_content(&half))
+            .cache_message_content(&byte_second_id, false, cached_content("second"))
+            .await
+            .unwrap();
+        sqlx::query("UPDATE message_content_cache SET byte_size = ?")
+            .bind(MESSAGE_CONTENT_CACHE_MAX_BYTES / 2)
+            .execute(&byte_store.pool)
+            .await
+            .unwrap();
+        let mut byte_third = message("Byte third", "preview");
+        byte_third.account_id = byte_store
+            .message(&byte_second_id)
+            .await
+            .unwrap()
+            .unwrap()
+            .account_id;
+        byte_third.uid = 3;
+        let byte_third_id = byte_third.id.clone();
+        byte_store.upsert_messages(&[byte_third]).await.unwrap();
+        byte_store
+            .cache_message_content(&byte_third_id, false, cached_content("third"))
             .await
             .unwrap();
         assert!(byte_store
@@ -3474,6 +3824,505 @@ mod tests {
             .await
             .unwrap()
             .is_some());
+        assert!(byte_store
+            .cached_message_content(&byte_third_id)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn recent_body_cache_candidates_respect_cache_folder_cutoff_and_exact_message_id_dedupe()
+    {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let cutoff = Utc::now();
+        let mut duplicate_new = cache_candidate_message(
+            account_id,
+            "duplicate-new",
+            1,
+            "INBOX",
+            cutoff + chrono::Duration::seconds(10),
+        );
+        duplicate_new.message_id = Some("<duplicate@example.test>".into());
+        let mut duplicate_old = cache_candidate_message(
+            account_id,
+            "duplicate-old",
+            2,
+            "Sent",
+            cutoff + chrono::Duration::seconds(9),
+        );
+        duplicate_old.message_id = duplicate_new.message_id.clone();
+        let mut flagged_missing = cache_candidate_message(
+            account_id,
+            "flagged-missing",
+            3,
+            "INBOX",
+            cutoff + chrono::Duration::seconds(8),
+        );
+        flagged_missing.is_flagged = true;
+        flagged_missing.content_state = "headers_only".into();
+        let sent = cache_candidate_message(
+            account_id,
+            "sent-candidate",
+            4,
+            "Sent",
+            cutoff + chrono::Duration::seconds(7),
+        );
+        let archive = cache_candidate_message(
+            account_id,
+            "archive-candidate",
+            5,
+            "Archive",
+            cutoff + chrono::Duration::seconds(6),
+        );
+        let cached_regular = cache_candidate_message(
+            account_id,
+            "cached-regular",
+            6,
+            "INBOX",
+            cutoff + chrono::Duration::seconds(5),
+        );
+        let mut cached_starred = cache_candidate_message(
+            account_id,
+            "cached-starred",
+            7,
+            "INBOX",
+            cutoff + chrono::Duration::seconds(4),
+        );
+        cached_starred.is_flagged = true;
+        let boundary = cache_candidate_message(account_id, "cutoff-boundary", 8, "INBOX", cutoff);
+        let old = cache_candidate_message(
+            account_id,
+            "older-than-cutoff",
+            9,
+            "INBOX",
+            cutoff - chrono::Duration::nanoseconds(1),
+        );
+        let draft = cache_candidate_message(
+            account_id,
+            "draft-excluded",
+            10,
+            "Drafts",
+            cutoff + chrono::Duration::seconds(20),
+        );
+        store
+            .upsert_messages(&[
+                duplicate_new.clone(),
+                duplicate_old,
+                flagged_missing.clone(),
+                sent.clone(),
+                archive.clone(),
+                cached_regular.clone(),
+                cached_starred.clone(),
+                boundary.clone(),
+                old,
+                draft,
+            ])
+            .await
+            .unwrap();
+        store
+            .cache_message_content(&cached_regular.id, false, cached_content("regular"))
+            .await
+            .unwrap();
+        assert!(store
+            .cache_starred_message_content(&cached_starred.id, cached_content("starred"))
+            .await
+            .unwrap());
+
+        let candidates = store
+            .recent_body_cache_candidates(account_id, cutoff, 20)
+            .await
+            .unwrap();
+        assert_eq!(
+            candidates
+                .iter()
+                .map(|message| message.id.as_str())
+                .collect::<Vec<_>>(),
+            [
+                duplicate_new.id.as_str(),
+                flagged_missing.id.as_str(),
+                sent.id.as_str(),
+                archive.id.as_str(),
+                boundary.id.as_str(),
+            ]
+        );
+        for (offset, expected) in [
+            (
+                0,
+                vec![duplicate_new.id.as_str(), flagged_missing.id.as_str()],
+            ),
+            (2, vec![sent.id.as_str(), archive.id.as_str()]),
+            (4, vec![boundary.id.as_str()]),
+        ] {
+            let page = store
+                .recent_body_cache_candidates_page(account_id, cutoff, 2, offset)
+                .await
+                .unwrap();
+            assert_eq!(
+                page.iter()
+                    .map(|message| message.id.as_str())
+                    .collect::<Vec<_>>(),
+                expected
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn body_cache_evicts_non_recent_entries_before_recent_primary_lru() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let now = Utc::now();
+        let old_primary = cache_candidate_message(
+            account_id,
+            "old-primary",
+            1,
+            "INBOX",
+            now - chrono::Duration::days(MESSAGE_CONTENT_CACHE_RECENT_WINDOW_DAYS + 1),
+        );
+        let non_primary = cache_candidate_message(account_id, "draft", 2, "Drafts", now);
+        let recent_primary = cache_candidate_message(account_id, "recent-primary", 3, "Sent", now);
+        let incoming = cache_candidate_message(account_id, "incoming", 4, "Archive", now);
+        store
+            .upsert_messages(&[
+                old_primary.clone(),
+                non_primary.clone(),
+                recent_primary.clone(),
+                incoming.clone(),
+            ])
+            .await
+            .unwrap();
+        for message in [&old_primary, &non_primary, &recent_primary] {
+            store
+                .cache_message_content(&message.id, false, cached_content(&message.id))
+                .await
+                .unwrap();
+        }
+        for (id, byte_size, last_accessed) in [
+            (
+                old_primary.id.as_str(),
+                MESSAGE_CONTENT_CACHE_MAX_BYTES / 2 + 1,
+                2,
+            ),
+            (
+                non_primary.id.as_str(),
+                MESSAGE_CONTENT_CACHE_MAX_BYTES / 2 - 1,
+                3,
+            ),
+            (recent_primary.id.as_str(), 1, 1),
+        ] {
+            sqlx::query("UPDATE message_content_cache SET byte_size = ?, last_accessed = ? WHERE message_id = ?")
+                .bind(byte_size)
+                .bind(last_accessed)
+                .bind(id)
+                .execute(&store.pool)
+                .await
+                .unwrap();
+        }
+        store
+            .cache_message_content(&incoming.id, false, cached_content("incoming"))
+            .await
+            .unwrap();
+
+        assert!(store
+            .cached_message_content(&old_primary.id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .cached_message_content(&non_primary.id)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .cached_message_content(&recent_primary.id)
+            .await
+            .unwrap()
+            .is_some());
+        let used: i64 =
+            sqlx::query_scalar("SELECT COALESCE(SUM(byte_size), 0) FROM message_content_cache")
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+        assert!(used <= MESSAGE_CONTENT_CACHE_MAX_BYTES);
+    }
+
+    #[tokio::test]
+    async fn message_content_fetch_claims_distinguish_busy_and_missing_messages() {
+        let store = Store::in_memory().await.unwrap();
+        let message = message("Claim", "preview");
+        let id = message.id.clone();
+        store.upsert_messages(&[message]).await.unwrap();
+
+        let claim = match store
+            .acquire_message_content_fetch_outcome(&id)
+            .await
+            .unwrap()
+        {
+            MessageContentFetchAcquire::Claimed(claim) => claim,
+            MessageContentFetchAcquire::Busy | MessageContentFetchAcquire::Missing => {
+                panic!("first reader must own the claim")
+            }
+        };
+        assert!(matches!(
+            store
+                .acquire_message_content_fetch_outcome(&id)
+                .await
+                .unwrap(),
+            MessageContentFetchAcquire::Busy
+        ));
+        assert!(matches!(
+            store
+                .acquire_message_content_fetch_outcome("missing-message")
+                .await
+                .unwrap(),
+            MessageContentFetchAcquire::Missing
+        ));
+        claim.release().await.unwrap();
+        let reacquired = match store
+            .acquire_message_content_fetch_outcome(&id)
+            .await
+            .unwrap()
+        {
+            MessageContentFetchAcquire::Claimed(claim) => claim,
+            MessageContentFetchAcquire::Busy | MessageContentFetchAcquire::Missing => {
+                panic!("released claim must be available to the next reader")
+            }
+        };
+        reacquired.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn dropped_message_content_fetch_owner_releases_its_claim() {
+        let store = Store::in_memory().await.unwrap();
+        let message = message("Cancelled claim", "preview");
+        let id = message.id.clone();
+        store.upsert_messages(&[message]).await.unwrap();
+
+        let claim = match store
+            .acquire_message_content_fetch_outcome(&id)
+            .await
+            .unwrap()
+        {
+            MessageContentFetchAcquire::Claimed(claim) => claim,
+            MessageContentFetchAcquire::Busy | MessageContentFetchAcquire::Missing => {
+                panic!("first reader must own the claim")
+            }
+        };
+        assert!(matches!(
+            store
+                .acquire_message_content_fetch_outcome(&id)
+                .await
+                .unwrap(),
+            MessageContentFetchAcquire::Busy
+        ));
+        drop(claim);
+
+        let mut reacquired = false;
+        for _ in 0..20 {
+            tokio::task::yield_now().await;
+            if let MessageContentFetchAcquire::Claimed(claim) = store
+                .acquire_message_content_fetch_outcome(&id)
+                .await
+                .unwrap()
+            {
+                claim.release().await.unwrap();
+                reacquired = true;
+                break;
+            }
+        }
+        assert!(reacquired, "drop must release the transient fetch claim");
+    }
+
+    #[tokio::test]
+    async fn moving_a_message_revokes_the_old_locator_fetch_claim() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let mut source = message("Moving claim", "preview");
+        source.id = stable_message_id(account_id, "INBOX", 1);
+        source.account_id = account_id.to_string();
+        source.uid = 1;
+        let source_id = source.id.clone();
+        store.upsert_messages(&[source]).await.unwrap();
+        let source_claim = match store
+            .acquire_message_content_fetch_outcome(&source_id)
+            .await
+            .unwrap()
+        {
+            MessageContentFetchAcquire::Claimed(claim) => claim,
+            MessageContentFetchAcquire::Busy | MessageContentFetchAcquire::Missing => {
+                panic!("source reader must own the claim")
+            }
+        };
+
+        store
+            .move_message(account_id, "INBOX", 1, "Archive", Some(3))
+            .await
+            .unwrap();
+
+        let destination_id = stable_message_id(account_id, "Archive", 3);
+        let destination_claim = match store
+            .acquire_message_content_fetch_outcome(&destination_id)
+            .await
+            .unwrap()
+        {
+            MessageContentFetchAcquire::Claimed(claim) => claim,
+            MessageContentFetchAcquire::Busy | MessageContentFetchAcquire::Missing => {
+                panic!("move must not strand the old fetch claim on the destination")
+            }
+        };
+        source_claim.release().await.unwrap();
+        destination_claim.release().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn moving_a_starred_message_discards_stale_attachment_ids_and_refetches_after_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("dakia.db");
+        let store = Store::open(&path).await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let mut account = AccountDraft {
+            email: "moved-star@example.test".into(),
+            display_name: "Moved star".into(),
+            provider_id: Some("fastmail".into()),
+            username: None,
+            imap_host: None,
+            imap_port: None,
+            imap_security: None,
+            smtp_host: None,
+            smtp_port: None,
+            smtp_security: None,
+            archive_mailbox: None,
+            spam_mailbox: None,
+        }
+        .into_account(provider::by_id("fastmail").unwrap());
+        account.id = account_id;
+        store.save_account(&account).await.unwrap();
+
+        let source_id = stable_message_id(account_id, "INBOX", 1);
+        let mut source = cache_candidate_message(account_id, &source_id, 1, "INBOX", Utc::now());
+        source.is_flagged = true;
+        store.upsert_messages(&[source]).await.unwrap();
+        let stale_attachment_id = format!("{source_id}:mime-v1:1");
+        assert!(store
+            .cache_starred_message_content(
+                &source_id,
+                CachedMessageContent {
+                    body_text: "cached starred body".into(),
+                    body_html: None,
+                    unsubscribe_kind: None,
+                    attachments: vec![Attachment {
+                        id: stale_attachment_id.clone(),
+                        message_id: source_id.clone(),
+                        filename: "claim.pdf".into(),
+                        mime_type: "application/pdf".into(),
+                        size_bytes: 3,
+                        is_inline: false,
+                        presentation: AttachmentPresentation::Downloadable,
+                        is_potentially_unsafe: false,
+                    }],
+                },
+            )
+            .await
+            .unwrap());
+
+        store
+            .move_message(account_id, "INBOX", 1, "Archive", Some(3))
+            .await
+            .unwrap();
+        let destination_id = stable_message_id(account_id, "Archive", 3);
+        assert!(store.starred_body(&destination_id).await.unwrap().is_none());
+        assert!(store
+            .starred_attachment_metadata(&destination_id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            store
+                .uncached_starred_messages(account_id, 10)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|message| message.id)
+                .collect::<Vec<_>>(),
+            vec![destination_id.clone()]
+        );
+
+        drop(store);
+        let reopened = Store::open(&path).await.unwrap();
+        assert!(reopened
+            .starred_body(&destination_id)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(reopened
+            .starred_attachment_metadata(&destination_id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            reopened
+                .uncached_starred_messages(account_id, 10)
+                .await
+                .unwrap()
+                .into_iter()
+                .map(|message| message.id)
+                .collect::<Vec<_>>(),
+            vec![destination_id]
+        );
+    }
+
+    #[tokio::test]
+    async fn message_content_fetch_claims_cascade_and_clear_on_restart() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("dakia.db");
+        let store = Store::open(&path).await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let first = cache_candidate_message(account_id, "claimed-message", 1, "INBOX", Utc::now());
+        let second = cache_candidate_message(account_id, "account-claimed", 2, "INBOX", Utc::now());
+        store
+            .upsert_messages(&[first.clone(), second.clone()])
+            .await
+            .unwrap();
+        assert!(store.claim_message_content_fetch(&first.id).await.unwrap());
+        assert!(store.claim_message_content_fetch(&second.id).await.unwrap());
+        sqlx::query("DELETE FROM messages WHERE id = ?")
+            .bind(&first.id)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        let first_claims: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM message_content_fetches WHERE message_id = ?")
+                .bind(&first.id)
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+        assert_eq!(first_claims, 0);
+        store.delete_account(account_id).await.unwrap();
+        let claims: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM message_content_fetches")
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+        assert_eq!(claims, 0);
+        let fresh_account_id = uuid::Uuid::new_v4();
+        sqlx::query("INSERT INTO accounts(id, email, data, created_at) VALUES (?, ?, '{}', ?)")
+            .bind(fresh_account_id.to_string())
+            .bind("restart-claim@example.test")
+            .bind(Utc::now())
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        let fresh =
+            cache_candidate_message(fresh_account_id, "restart-claimed", 3, "INBOX", Utc::now());
+        store
+            .upsert_messages(std::slice::from_ref(&fresh))
+            .await
+            .unwrap();
+        assert!(store.claim_message_content_fetch(&fresh.id).await.unwrap());
+        drop(store);
+
+        let store = Store::open(&path).await.unwrap();
+        assert!(store.claim_message_content_fetch(&fresh.id).await.unwrap());
     }
 
     #[tokio::test]
@@ -3486,15 +4335,9 @@ mod tests {
             .cache_message_content(&id, false, cached_content("old"))
             .await
             .unwrap();
-        let exact = "x".repeat((MESSAGE_CONTENT_CACHE_MAX_BYTES - 2) as usize);
+        let oversized = "x".repeat(21);
         store
-            .cache_message_content(&id, false, cached_content(&exact))
-            .await
-            .unwrap();
-        assert!(store.cached_message_content(&id).await.unwrap().is_some());
-        let oversized = "x".repeat((MESSAGE_CONTENT_CACHE_MAX_BYTES + 1) as usize);
-        store
-            .cache_message_content(&id, false, cached_content(&oversized))
+            .cache_message_content_with_budget(&id, false, cached_content(&oversized), 20)
             .await
             .unwrap();
         assert!(store.cached_message_content(&id).await.unwrap().is_none());
@@ -3730,7 +4573,18 @@ mod tests {
         .execute(&store.pool)
         .await
         .unwrap();
-        assert!(store.cached_message_content(&id).await.is_err());
+        assert!(store.cached_message_content(&id).await.unwrap().is_none());
+        assert_eq!(
+            sqlx::query_scalar::<_, i64>(
+                "SELECT COUNT(*) FROM message_content_cache WHERE message_id = ?",
+            )
+            .bind(&id)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap(),
+            0,
+            "a retry must fetch from the provider instead of repeating the corrupt cache error"
+        );
     }
 
     #[tokio::test]
@@ -4578,6 +5432,120 @@ mod tests {
             .await
             .unwrap()
             .is_some());
+    }
+
+    #[tokio::test]
+    async fn recent_catalogue_refresh_preserves_completed_local_flags_on_conflict() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let mut existing = message("Initial subject", "preview");
+        existing.id = stable_message_id(account_id, "INBOX", 12);
+        existing.account_id = account_id.to_string();
+        existing.uid = 12;
+        store
+            .upsert_catalog_messages(&[existing.clone()])
+            .await
+            .unwrap();
+        let expected_flags = store
+            .capture_recent_catalogue_expected_flags(account_id, "INBOX", &[12])
+            .await
+            .unwrap();
+
+        // Model a completed user action landing after the periodic refresh
+        // read the provider's old (unread, unstarred) flags.
+        store
+            .update_mailbox_flags(account_id, "INBOX", &[(12, true, true)])
+            .await
+            .unwrap();
+        let mut delayed_existing = existing.clone();
+        delayed_existing.subject = "Provider metadata still updates".into();
+        delayed_existing.is_read = false;
+        delayed_existing.is_flagged = false;
+        let mut inserted = message("New provider row", "preview");
+        inserted.id = stable_message_id(account_id, "INBOX", 13);
+        inserted.account_id = account_id.to_string();
+        inserted.uid = 13;
+        inserted.is_read = true;
+        inserted.is_flagged = true;
+
+        store
+            .upsert_recent_catalog_messages(&[delayed_existing, inserted.clone()], &expected_flags)
+            .await
+            .unwrap();
+
+        let retained = store.message(&existing.id).await.unwrap().unwrap();
+        assert_eq!(retained.subject, "Provider metadata still updates");
+        assert!(retained.is_read);
+        assert!(retained.is_flagged);
+        let new_row = store.message(&inserted.id).await.unwrap().unwrap();
+        assert!(new_row.is_read);
+        assert!(new_row.is_flagged);
+    }
+
+    #[tokio::test]
+    async fn recent_catalogue_refresh_applies_provider_flags_when_snapshot_is_current() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let mut existing = message("Initial", "preview");
+        existing.id = stable_message_id(account_id, "INBOX", 14);
+        existing.account_id = account_id.to_string();
+        existing.uid = 14;
+        store
+            .upsert_catalog_messages(&[existing.clone()])
+            .await
+            .unwrap();
+        let expected_flags = store
+            .capture_recent_catalogue_expected_flags(account_id, "INBOX", &[14])
+            .await
+            .unwrap();
+        let mut provider_refresh = existing.clone();
+        provider_refresh.is_read = true;
+        provider_refresh.is_flagged = true;
+
+        store
+            .upsert_recent_catalog_messages(&[provider_refresh], &expected_flags)
+            .await
+            .unwrap();
+
+        let stored = store.message(&existing.id).await.unwrap().unwrap();
+        assert!(stored.is_read);
+        assert!(stored.is_flagged);
+    }
+
+    #[tokio::test]
+    async fn recent_catalogue_refresh_does_not_reverse_local_unread_unstar_actions() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let mut existing = message("Initially read and starred", "preview");
+        existing.id = stable_message_id(account_id, "INBOX", 15);
+        existing.account_id = account_id.to_string();
+        existing.uid = 15;
+        existing.is_read = true;
+        existing.is_flagged = true;
+        store
+            .upsert_catalog_messages(&[existing.clone()])
+            .await
+            .unwrap();
+        let expected_flags = store
+            .capture_recent_catalogue_expected_flags(account_id, "INBOX", &[15])
+            .await
+            .unwrap();
+        store
+            .update_mailbox_flags(account_id, "INBOX", &[(15, false, false)])
+            .await
+            .unwrap();
+        let mut delayed_provider_flags = existing.clone();
+        delayed_provider_flags.is_read = true;
+        delayed_provider_flags.is_flagged = true;
+
+        store
+            .upsert_recent_catalog_messages(&[delayed_provider_flags], &expected_flags)
+            .await
+            .unwrap();
+
+        let stored = store.message(&existing.id).await.unwrap().unwrap();
+        assert!(!stored.is_read);
+        assert!(!stored.is_flagged);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Add proactive caching for recently accessed message bodies.
- Coordinate body availability across Rust storage, realtime events, native windows, and the reader UI.
- Update reader and app tests for cached-body behavior.

## Testing

- Not run (not requested).