### PR TITLE
Harden email rendering for provider-specific MIME content

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -924,6 +924,68 @@ struct MessageContent {
     attachments: Vec<Attachment>,
 }
 
+/// The reader must distinguish content that cannot change on another fetch
+/// from a transient provider failure. Keep the IPC payload deliberately small:
+/// parser and provider diagnostics are useful locally, but are not safe UI
+/// text.
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+enum MessageContentErrorKind {
+    ResourceLimit,
+    Malformed,
+    Undecodable,
+    Unsupported,
+    Transient,
+}
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+struct MessageContentCommandError {
+    kind: MessageContentErrorKind,
+}
+
+impl MessageContentCommandError {
+    fn from_failure(failure: &str) -> Self {
+        let failure = failure.to_ascii_lowercase();
+        let resource_limit = [
+            "mime_raw_message_too_large",
+            "mime_headers_too_large",
+            "mime_too_many_parts",
+            "mime_multipart_nesting_too_deep",
+            "mime_resolved_html_too_large",
+            "mime safety limit",
+            "safety limit",
+            "message has too many attachments",
+            "message has more than",
+            "message display body exceeds",
+            "message display body size overflow",
+            "attachment bytes overflowed",
+            "mime part count overflow",
+        ]
+        .iter()
+        .any(|marker| failure.contains(marker));
+        let malformed = [
+            "bodystructure",
+            "mime part headers are malformed",
+            "mime part parser omitted",
+            "message parser could not find",
+        ]
+        .iter()
+        .any(|marker| failure.contains(marker));
+        let kind = if resource_limit {
+            MessageContentErrorKind::ResourceLimit
+        } else if failure.contains("mime_content_undecodable") {
+            MessageContentErrorKind::Undecodable
+        } else if failure.contains("unsupported transfer encoding") {
+            MessageContentErrorKind::Unsupported
+        } else if malformed {
+            MessageContentErrorKind::Malformed
+        } else {
+            MessageContentErrorKind::Transient
+        };
+        Self { kind }
+    }
+}
+
 #[derive(Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct DesktopNotification {
@@ -1080,8 +1142,10 @@ async fn message_attachments(
 async fn message_content(
     state: State<'_, Arc<AppState>>,
     message_id: String,
-) -> Result<MessageContent, String> {
-    load_message_content(state.inner(), &message_id).await
+) -> Result<MessageContent, MessageContentCommandError> {
+    load_message_content(state.inner(), &message_id)
+        .await
+        .map_err(|failure| MessageContentCommandError::from_failure(&failure))
 }
 
 async fn cached_message_content(
@@ -1320,6 +1384,40 @@ mod message_content_repair_tests {
         .expect("a deleted message must not wait for the claim timeout");
 
         assert!(matches!(result, Err(error) if error == "Message not found"));
+    }
+
+    #[test]
+    fn message_content_error_envelope_classifies_mime_failures_without_details() {
+        let cases = [
+            ("mime_raw_message_too_large", "resource_limit"),
+            ("mime_content_undecodable", "undecodable"),
+            (
+                "MIME part uses an unsupported transfer encoding",
+                "unsupported",
+            ),
+            ("BODYSTRUCTURE part is not a list", "malformed"),
+            (
+                "message display body exceeds the 50 MiB safety limit",
+                "resource_limit",
+            ),
+            (
+                "message display part exceeds the 25 MiB safety limit",
+                "resource_limit",
+            ),
+            (
+                "message parser could not find RFC 5322 headers",
+                "malformed",
+            ),
+            ("IMAP connection reset by peer", "transient"),
+        ];
+
+        for (failure, kind) in cases {
+            let serialized =
+                serde_json::to_value(MessageContentCommandError::from_failure(failure))
+                    .expect("message-content error must serialize for Tauri IPC");
+            assert_eq!(serialized, serde_json::json!({ "kind": kind }));
+            assert!(!serialized.to_string().contains(failure));
+        }
     }
 }
 

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -12,6 +12,7 @@ import type {
   MessageContent,
   MailThread,
   MailThreadPage,
+  MessageContentErrorKind,
   Provider,
   SyncProgress,
   SyncResult,
@@ -21,6 +22,44 @@ import type {
   TranslationModelFiles,
   TranslationModelStatus,
 } from "./types";
+
+const messageContentErrorKinds = new Set<MessageContentErrorKind>([
+  "resource_limit",
+  "malformed",
+  "undecodable",
+  "unsupported",
+  "transient",
+]);
+
+export class MessageContentError extends Error {
+  readonly retryable: boolean;
+
+  constructor(readonly kind: MessageContentErrorKind) {
+    super("Message content could not be loaded");
+    this.name = "MessageContentError";
+    this.retryable = kind === "transient";
+  }
+}
+
+/**
+ * Converts the native error envelope into the only error shape Reader needs.
+ * Unknown/rejected IPC payloads remain retryable and never become user text.
+ */
+export function messageContentErrorFromUnknown(
+  error: unknown,
+): MessageContentError {
+  if (error instanceof MessageContentError) return error;
+  if (
+    error &&
+    typeof error === "object" &&
+    "kind" in error &&
+    typeof error.kind === "string" &&
+    messageContentErrorKinds.has(error.kind as MessageContentErrorKind)
+  ) {
+    return new MessageContentError(error.kind as MessageContentErrorKind);
+  }
+  return new MessageContentError("transient");
+}
 
 const desktopApi = {
   providers: () => invoke<Provider[]>("provider_presets"),
@@ -134,8 +173,13 @@ const desktopApi = {
     });
   },
   mailRebuildStatus: () => invoke<MailRebuildProgress[]>("mail_rebuild_status"),
-  content: (messageId: string) =>
-    invoke<MessageContent>("message_content", { messageId }),
+  content: async (messageId: string) => {
+    try {
+      return await invoke<MessageContent>("message_content", { messageId });
+    } catch (error) {
+      throw messageContentErrorFromUnknown(error);
+    }
+  },
   attachments: (messageId: string) =>
     invoke<Attachment[]>("message_attachments", { messageId }),
   saveAttachment: (messageId: string, attachmentId: string) =>

--- a/apps/desktop/src/apiMessageContent.test.ts
+++ b/apps/desktop/src/apiMessageContent.test.ts
@@ -1,0 +1,58 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: apiMocks.invoke,
+  Channel: class {},
+}));
+
+describe("native message-content API bridge", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  });
+
+  it("preserves the native content category while hiding its diagnostic detail", async () => {
+    apiMocks.invoke.mockRejectedValue({
+      kind: "undecodable",
+      detail: "invalid bytes at offset 42",
+    });
+    const { api, MessageContentError } = await import("./api");
+
+    await expect(api.content("message-1")).rejects.toMatchObject({
+      name: "MessageContentError",
+      kind: "undecodable",
+      retryable: false,
+      message: "Message content could not be loaded",
+    });
+    expect(apiMocks.invoke).toHaveBeenCalledWith("message_content", {
+      messageId: "message-1",
+    });
+    await api.content("message-1").catch((error: unknown) => {
+      expect(error).toBeInstanceOf(MessageContentError);
+      expect(String(error)).not.toContain("offset 42");
+    });
+  });
+
+  it("treats an untyped provider failure as transient and retryable", async () => {
+    apiMocks.invoke.mockRejectedValue("IMAP connection reset by peer");
+    const { api } = await import("./api");
+
+    await expect(api.content("message-1")).rejects.toMatchObject({
+      kind: "transient",
+      retryable: true,
+      message: "Message content could not be loaded",
+    });
+  });
+});

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -8,7 +8,7 @@ import {
 import { MantineProvider } from "@mantine/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import "../i18n";
-import { api } from "../api";
+import { api, MessageContentError } from "../api";
 import freshdeskReplySection from "../test/fixtures/freshdesk-reply-section.html?raw";
 import type { MailSummary } from "../types";
 import { Reader } from "./Reader";
@@ -204,7 +204,7 @@ describe("Reader unsubscribe action", () => {
 
   it("retries content without foreground hydration after a load failure", async () => {
     vi.mocked(api.content)
-      .mockRejectedValueOnce(new Error("content unavailable"))
+      .mockRejectedValueOnce(new MessageContentError("transient"))
       .mockResolvedValueOnce({ body_text: "Recovered body", attachments: [] });
     render(
       <MantineProvider>
@@ -1039,13 +1039,10 @@ describe("Reader unsubscribe action", () => {
     ).toBeEnabled();
   });
 
-  it("shows the existing retry state when malformed message content cannot be loaded", async () => {
-    vi.mocked(api.content)
-      .mockRejectedValueOnce(new Error("Malformed message content"))
-      .mockResolvedValueOnce({
-        body_text: "Recovered message body",
-        attachments: [],
-      });
+  it("does not offer retry when a message exceeds the MIME resource limit", async () => {
+    vi.mocked(api.content).mockRejectedValueOnce(
+      new MessageContentError("resource_limit"),
+    );
     render(
       <MantineProvider>
         <Reader {...props} message={message} />
@@ -1054,16 +1051,34 @@ describe("Reader unsubscribe action", () => {
 
     expect(
       await screen.findByText(
-        "This message could not be fetched from the mail server.",
+        "This message is too large or complex for Dakia to open.",
       ),
     ).toBeVisible();
-    expect(screen.queryByText("Malformed message content")).toBeNull();
-
-    fireEvent.click(screen.getByRole("button", { name: "Try again" }));
-    expect(await screen.findByText("Recovered message body")).toBeVisible();
-    expect(api.content).toHaveBeenCalledTimes(2);
-    expect(api.content).toHaveBeenLastCalledWith(message.id);
+    expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+    expect(api.content).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    ["malformed", "This message is malformed and cannot be opened."],
+    ["undecodable", "The contents of this message cannot be decoded."],
+    ["unsupported", "This message uses an unsupported format."],
+  ] as const)(
+    "shows the non-retryable %s content outcome",
+    async (kind, expectedCopy) => {
+      vi.mocked(api.content).mockRejectedValueOnce(
+        new MessageContentError(kind),
+      );
+      render(
+        <MantineProvider>
+          <Reader {...props} message={message} />
+        </MantineProvider>,
+      );
+
+      expect(await screen.findByText(expectedCopy)).toBeVisible();
+      expect(screen.queryByRole("button", { name: "Try again" })).toBeNull();
+      expect(api.content).toHaveBeenCalledTimes(1);
+    },
+  );
 
   it("runs delete from the reader toolbar", () => {
     render(

--- a/apps/desktop/src/components/Reader.tsx
+++ b/apps/desktop/src/components/Reader.tsx
@@ -38,14 +38,19 @@ import {
   useState,
 } from "react";
 import { useTranslation } from "react-i18next";
-import { api } from "../api";
+import { api, messageContentErrorFromUnknown } from "../api";
 import { confirmNativeAction } from "../nativeFeedback";
 import {
   detectTranslationLanguage,
   translateOffline,
 } from "../offlineTranslation";
 import { translateConversation } from "../translationWorkflow";
-import type { Attachment, MailSummary, MessageContent } from "../types";
+import type {
+  Attachment,
+  MailSummary,
+  MessageContent,
+  MessageContentErrorKind,
+} from "../types";
 import { formatAddress, messageRecipients } from "../recipients";
 import { splitQuotedText } from "../quotedHistory";
 import { EmptyState } from "./EmptyState";
@@ -529,7 +534,7 @@ function ThreadMessage({
     useState(false);
   const [content, setContent] = useState<MessageContent>();
   const [loadingContent, setLoadingContent] = useState(false);
-  const [contentError, setContentError] = useState(false);
+  const [contentError, setContentError] = useState<MessageContentErrorKind>();
   const [contentAttempt, setContentAttempt] = useState(0);
   const [loadingAttachments, setLoadingAttachments] = useState(false);
   const [saving, setSaving] = useState<string>();
@@ -557,7 +562,7 @@ function ThreadMessage({
   useEffect(() => {
     if (!isExpanded) return;
     let current = true;
-    setContentError(false);
+    setContentError(undefined);
     setLoadingContent(true);
     setLoadingAttachments(true);
     void loadContent(message.id)
@@ -568,7 +573,11 @@ function ThreadMessage({
           setAttachmentsAuthoritative(true);
         }
       })
-      .catch(() => current && setContentError(true))
+      .catch(
+        (error: unknown) =>
+          current &&
+          setContentError(messageContentErrorFromUnknown(error).kind),
+      )
       .finally(() => {
         if (current) {
           setLoadingContent(false);
@@ -869,14 +878,16 @@ function ThreadMessage({
         </div>
       ) : contentError ? (
         <div className="message-body">
-          <p>{t("reader.loadContentError")}</p>
-          <Button
-            size="xs"
-            variant="light"
-            onClick={() => setContentAttempt((value) => value + 1)}
-          >
-            {t("actions.retry")}
-          </Button>
+          <p>{t(`reader.contentError.${contentError}`)}</p>
+          {contentError === "transient" ? (
+            <Button
+              size="xs"
+              variant="light"
+              onClick={() => setContentAttempt((value) => value + 1)}
+            >
+              {t("actions.retry")}
+            </Button>
+          ) : null}
         </div>
       ) : displayContent?.body_html ? (
         <HtmlMessage

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -136,8 +136,14 @@ export const en = {
       replyErrorTitle: "Could not reply to message",
       forwardErrorTitle: "Could not forward message",
       loadingContent: "Fetching message…",
-      loadContentError:
-        "This message could not be fetched from the mail server.",
+      contentError: {
+        resource_limit:
+          "This message is too large or complex for Dakia to open.",
+        malformed: "This message is malformed and cannot be opened.",
+        undecodable: "The contents of this message cannot be decoded.",
+        unsupported: "This message uses an unsupported format.",
+        transient: "This message could not be fetched from the mail server.",
+      },
       exportSuccess: "Message exported to {{path}}",
       exportError: "Could not export this message.",
     },

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -113,6 +113,8 @@ export type MessageContent = {
   unsubscribe_kind?: "one_click" | "web" | "mailto";
   attachments: Attachment[];
 };
+export type MessageContentErrorKind =
+  "resource_limit" | "malformed" | "undecodable" | "unsupported" | "transient";
 export type ComposeAttachment = {
   filename: string;
   mime_type: string;

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::{BTreeMap, BTreeSet},
     net::IpAddr,
+    ops::Range,
     sync::Arc,
 };
 use tokio::{
@@ -2336,10 +2337,20 @@ struct PlannedAttachment {
 #[derive(Debug, Clone)]
 struct PlannedTextPart {
     part: MimePart,
-    /// A multipart/alternative representation may have several candidates of
-    /// one kind.  They are fetched in preference order and only the first
-    /// decodable member of this group becomes the visible representation.
-    fallback_group: Option<usize>,
+    /// Each enclosing multipart/alternative contributes one branch marker.
+    /// A successful later branch suppresses only earlier sibling branches;
+    /// text leaves in the same selected branch remain visible together.
+    alternative_branches: Vec<AlternativeBranch>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct AlternativeBranch {
+    group: usize,
+    branch: usize,
+    /// Only the first candidate for a representation may select a composite
+    /// branch. A decoded footer sibling must not hide a substantive fallback
+    /// when the branch's primary body is undecodable.
+    decisive: bool,
 }
 
 impl PlannedAttachment {
@@ -2688,7 +2699,7 @@ fn selective_plan(root: &MimePart) -> Result<SelectivePlan> {
 fn select_text_parts(
     part: &MimePart,
     selected: &mut Vec<PlannedTextPart>,
-    fallback_groups: &mut usize,
+    alternative_groups: &mut usize,
 ) {
     if part.is_attached_container() {
         return;
@@ -2697,31 +2708,48 @@ fn select_text_parts(
         if part.is_text_body() && !part.is_attachment_candidate() {
             selected.push(PlannedTextPart {
                 part: part.clone(),
-                fallback_group: None,
+                alternative_branches: Vec::new(),
             });
         }
         return;
     }
     if part.mime_type.eq_ignore_ascii_case("multipart/alternative") {
-        let mut candidates = Vec::new();
-        for child in &part.children {
-            select_text_parts(child, &mut candidates, fallback_groups);
-        }
-        for mime_type in ["text/plain", "text/html"] {
-            let matching = candidates
-                .iter()
-                .rev()
-                .filter(|candidate| candidate.part.mime_type.eq_ignore_ascii_case(mime_type))
-                .cloned()
-                .collect::<Vec<_>>();
-            if matching.is_empty() {
-                continue;
+        *alternative_groups += 1;
+        let group = *alternative_groups;
+        // RFC multipart/alternative orders direct children from least to most
+        // faithful. Plan the preferred branch first, but do not flatten its
+        // nested mixed/related siblings into competing alternatives.
+        for (branch, child) in part.children.iter().enumerate().rev() {
+            let mut candidates = Vec::new();
+            select_text_parts(child, &mut candidates, alternative_groups);
+            let mut first_plain = true;
+            let mut first_html = true;
+            for candidate in &mut candidates {
+                let first_for_representation =
+                    if candidate.part.mime_type.eq_ignore_ascii_case("text/html") {
+                        std::mem::take(&mut first_html)
+                    } else {
+                        std::mem::take(&mut first_plain)
+                    };
+                // A nested alternative may legitimately fall back from its
+                // first leaf. Propagate each nested branch's primary body to
+                // the enclosing branch, while plain mixed siblings still use
+                // only their first body as the decisive candidate.
+                let decisive = if candidate.alternative_branches.is_empty() {
+                    first_for_representation
+                } else {
+                    candidate
+                        .alternative_branches
+                        .iter()
+                        .all(|branch| branch.decisive)
+                };
+                candidate.alternative_branches.push(AlternativeBranch {
+                    group,
+                    branch,
+                    decisive,
+                });
             }
-            *fallback_groups += 1;
-            selected.extend(matching.into_iter().map(|mut candidate| {
-                candidate.fallback_group = Some(*fallback_groups);
-                candidate
-            }));
+            selected.extend(candidates);
         }
     } else if part.mime_type.eq_ignore_ascii_case("multipart/related") {
         let declared_start = part
@@ -2746,13 +2774,51 @@ fn select_text_parts(
             })
             .or_else(|| part.children.first());
         if let Some(root) = root {
-            select_text_parts(root, selected, fallback_groups);
+            select_text_parts(root, selected, alternative_groups);
         }
     } else {
         for child in &part.children {
-            select_text_parts(child, selected, fallback_groups);
+            select_text_parts(child, selected, alternative_groups);
         }
     }
+}
+
+fn alternative_branch_is_eligible(
+    part: &PlannedTextPart,
+    successful_branches: &BTreeMap<(usize, bool), usize>,
+) -> bool {
+    let html = part.part.mime_type.eq_ignore_ascii_case("text/html");
+    part.alternative_branches.iter().all(|branch| {
+        successful_branches
+            .get(&(branch.group, html))
+            .is_none_or(|selected| *selected == branch.branch)
+    })
+}
+
+fn record_successful_alternative_branches(
+    part: &PlannedTextPart,
+    successful_branches: &mut BTreeMap<(usize, bool), usize>,
+) {
+    let html = part.part.mime_type.eq_ignore_ascii_case("text/html");
+    for branch in &part.alternative_branches {
+        if branch.decisive {
+            successful_branches
+                .entry((branch.group, html))
+                .or_insert(branch.branch);
+        }
+    }
+}
+
+fn alternative_branch_is_selected(
+    part: &PlannedTextPart,
+    successful_branches: &BTreeMap<(usize, bool), usize>,
+) -> bool {
+    let html = part.part.mime_type.eq_ignore_ascii_case("text/html");
+    part.alternative_branches.iter().all(|branch| {
+        successful_branches
+            .get(&(branch.group, html))
+            .is_none_or(|selected| *selected == branch.branch)
+    })
 }
 
 fn collect_attachment_candidates(part: &MimePart, candidates: &mut Vec<MimePart>) {
@@ -2803,16 +2869,12 @@ async fn fetch_selective_message(
 ) -> Result<MailSummary> {
     let plan = selective_plan(structure)?;
     let mut total = 0usize;
-    let mut plain = Vec::new();
-    let mut html = None;
+    let mut decoded_text_parts = Vec::new();
     let mut text_decode_failures = 0usize;
-    let mut successful_fallback_groups = BTreeSet::new();
+    let mut successful_alternative_branches = BTreeMap::new();
     let mut referenced_inline = BTreeMap::new();
     for part in &plan.text_parts {
-        if part
-            .fallback_group
-            .is_some_and(|group| successful_fallback_groups.contains(&group))
-        {
+        if !alternative_branch_is_eligible(part, &successful_alternative_branches) {
             continue;
         }
         let header =
@@ -2844,11 +2906,17 @@ async fn fetch_selective_message(
                 continue;
             }
         };
-        if let Some(group) = part.fallback_group {
-            successful_fallback_groups.insert(group);
+        record_successful_alternative_branches(part, &mut successful_alternative_branches);
+        decoded_text_parts.push((part.clone(), decoded));
+    }
+    let mut plain = Vec::new();
+    let mut html = Vec::new();
+    for (part, decoded) in decoded_text_parts {
+        if !alternative_branch_is_selected(&part, &successful_alternative_branches) {
+            continue;
         }
-        if part.part.mime_type.eq_ignore_ascii_case("text/html") && html.is_none() {
-            html = Some(decoded);
+        if part.part.mime_type.eq_ignore_ascii_case("text/html") {
+            html.push(decoded);
         } else if part.part.mime_type.eq_ignore_ascii_case("text/plain") {
             plain.push(decoded);
         }
@@ -2875,10 +2943,13 @@ async fn fetch_selective_message(
         }
         image_parts.insert(section_name(&part.path), (part, header, references));
     }
-    let mut body_html = html;
+    let mut body_html = join_visible_html_segments(html);
     if let Some(html) = &mut body_html {
+        let html_references = html_resource_references(html);
+        let mut replacements = BTreeMap::new();
         for (path, (part, header, references)) in &image_parts {
-            let referenced = has_unambiguous_html_reference(html, references, &reference_counts);
+            let referenced =
+                has_unambiguous_html_reference(&html_references, references, &reference_counts);
             referenced_inline.insert(path.clone(), referenced);
             if !referenced {
                 continue;
@@ -2903,9 +2974,12 @@ async fn fetch_selective_message(
                 STANDARD.encode(image)
             );
             for reference in references {
-                *html = replace_resource_reference(html, reference, &data_url)?;
+                replacements
+                    .entry(reference.to_ascii_lowercase())
+                    .or_insert_with(|| data_url.clone());
             }
         }
+        *html = rewrite_html_resource_references(html, &replacements)?;
     }
     let mut body_text = plain
         .into_iter()
@@ -3114,12 +3188,12 @@ fn unique_mime_part_references(part: &MimePart) -> Vec<String> {
 }
 
 fn has_unambiguous_html_reference(
-    html: &str,
+    html_references: &BTreeSet<String>,
     references: &[String],
     reference_counts: &BTreeMap<String, usize>,
 ) -> bool {
     references.iter().any(|reference| {
-        html_contains_reference(html, reference)
+        html_references.contains(&reference.to_ascii_lowercase())
             && reference_counts
                 .get(&reference.to_ascii_lowercase())
                 .copied()
@@ -4449,14 +4523,7 @@ impl BodySelection {
                 .filter(|value| !value.trim().is_empty())
                 .collect::<Vec<_>>()
                 .join("\n\n"),
-            html: {
-                let html = self
-                    .html
-                    .into_iter()
-                    .filter(|value| !value.trim().is_empty())
-                    .collect::<Vec<_>>();
-                (!html.is_empty()).then(|| html.join("\n"))
-            },
+            html: { join_visible_html_segments(self.html) },
         })
     }
 }
@@ -4507,21 +4574,33 @@ fn select_alternative(mail: &ParsedMessage<'_>, children: &[u32]) -> BodySelecti
     let mut chosen_html = None;
     for child in children {
         let candidate = select_body_part(mail, *child);
-        // RFC multipart/alternative orders representations by increasing
-        // faithfulness. Keep only the last supported representation of each
-        // kind; never concatenate competing alternatives.
+        // RFC multipart/alternative orders direct children by increasing
+        // faithfulness. Keep the latest direct branch for each representation,
+        // but retain every mixed/related text sibling inside that branch.
         if !candidate.plain.is_empty() {
-            chosen_plain = Some(candidate.plain.join("\n\n"));
+            chosen_plain = Some(candidate.plain);
         }
         if !candidate.html.is_empty() {
-            chosen_html = Some(candidate.html.join("\n"));
+            chosen_html = Some(candidate.html);
         }
         selected.valid_candidates += candidate.valid_candidates;
         selected.undecodable_candidates += candidate.undecodable_candidates;
     }
-    selected.plain.extend(chosen_plain);
-    selected.html.extend(chosen_html);
+    if let Some(plain) = chosen_plain {
+        selected.plain.extend(plain);
+    }
+    if let Some(html) = chosen_html {
+        selected.html.extend(html);
+    }
     selected
+}
+
+fn join_visible_html_segments(segments: Vec<String>) -> Option<String> {
+    let selected = segments
+        .into_iter()
+        .filter(|value| !value.trim().is_empty())
+        .collect::<Vec<_>>();
+    (!selected.is_empty()).then(|| selected.join("\n"))
 }
 
 fn select_related(
@@ -4647,15 +4726,18 @@ fn resolve_inline_images(html: String, mail: &ParsedMessage<'_>) -> Result<Strin
 }
 
 fn resolve_inline_images_from_raw(
-    mut html: String,
+    html: String,
     mail: &ParsedMessage<'_>,
     raw: &[u8],
 ) -> Result<String> {
     let inline_images = collect_inline_images(mail, raw, &html);
+    let mut replacements = BTreeMap::new();
     for (reference, data_url) in inline_images {
-        html = replace_resource_reference(&html, &reference, &data_url)?;
+        replacements
+            .entry(reference.to_ascii_lowercase())
+            .or_insert(data_url);
     }
-    Ok(html)
+    rewrite_html_resource_references(&html, &replacements)
 }
 
 fn collect_inline_images(
@@ -4663,6 +4745,7 @@ fn collect_inline_images(
     raw: &[u8],
     html: &str,
 ) -> Vec<(String, String)> {
+    let html_references = html_resource_references(html);
     attachment_part_ids(mail)
         .into_iter()
         .filter_map(|part_id| mail.part(part_id))
@@ -4681,7 +4764,9 @@ fn collect_inline_images(
             ]
             .into_iter()
             .flatten()
-            .filter(|reference| !reference.is_empty() && html_contains_reference(html, reference))
+            .filter(|reference| {
+                !reference.is_empty() && html_references.contains(&reference.to_ascii_lowercase())
+            })
             .collect::<Vec<_>>();
             if references.is_empty() {
                 return None;
@@ -4699,114 +4784,310 @@ fn collect_inline_images(
         .collect()
 }
 
+#[cfg(test)]
 fn replace_resource_reference(input: &str, reference: &str, replacement: &str) -> Result<String> {
-    rewrite_html_resource_references(input, reference, Some(replacement))
+    rewrite_html_resource_references(
+        input,
+        &BTreeMap::from([(reference.to_ascii_lowercase(), replacement.to_owned())]),
+    )
 }
 
 fn html_contains_reference(html: &str, reference: &str) -> bool {
-    rewrite_html_resource_references(html, reference, None)
-        .map(|output| output != html)
-        .unwrap_or(false)
+    html_resource_references(html).contains(&reference.to_ascii_lowercase())
+}
+
+fn html_resource_references(input: &str) -> BTreeSet<String> {
+    let mut references = BTreeSet::new();
+    let mut cursor = 0;
+    while let Some(offset) = input[cursor..].find('<') {
+        let start = cursor + offset;
+        if input[start..].starts_with("<!--") {
+            cursor = input[start + 4..]
+                .find("-->")
+                .map_or(input.len(), |offset| start + 4 + offset + 3);
+            continue;
+        }
+        let Some(end) = html_tag_end(input, start) else {
+            break;
+        };
+        collect_html_tag_resource_references(&input[start..end], &mut references);
+        cursor = raw_text_element_end(input, start, end).unwrap_or(end);
+    }
+    references
 }
 
 fn rewrite_html_resource_references(
     input: &str,
-    reference: &str,
-    replacement: Option<&str>,
+    replacements: &BTreeMap<String, String>,
 ) -> Result<String> {
+    if replacements.is_empty() {
+        return Ok(input.to_owned());
+    }
     let mut output = String::with_capacity(input.len());
     let mut cursor = 0;
     while let Some(offset) = input[cursor..].find('<') {
         let start = cursor + offset;
-        output.push_str(&input[cursor..start]);
-        let Some(end_offset) = input[start..].find('>') else {
-            output.push_str(&input[start..]);
+        push_resolved_html(&mut output, &input[cursor..start])?;
+        if input[start..].starts_with("<!--") {
+            let end = input[start + 4..]
+                .find("-->")
+                .map_or(input.len(), |offset| start + 4 + offset + 3);
+            push_resolved_html(&mut output, &input[start..end])?;
+            cursor = end;
+            continue;
+        }
+        let Some(end) = html_tag_end(input, start) else {
+            push_resolved_html(&mut output, &input[start..])?;
             return Ok(output);
         };
-        let end = start + end_offset + 1;
         let tag = &input[start..end];
-        output.push_str(&rewrite_resource_references_in_tag(
-            tag,
-            reference,
-            replacement,
-        )?);
-        cursor = end;
+        push_resolved_html(
+            &mut output,
+            &rewrite_resource_references_in_tag(tag, replacements)?,
+        )?;
+        if let Some(raw_text_end) = raw_text_element_end(input, start, end) {
+            push_resolved_html(&mut output, &input[end..raw_text_end])?;
+            cursor = raw_text_end;
+        } else {
+            cursor = end;
+        }
     }
-    output.push_str(&input[cursor..]);
-    if output.len() > MAX_RAW_MESSAGE_BYTES {
+    push_resolved_html(&mut output, &input[cursor..])?;
+    Ok(output)
+}
+
+fn push_resolved_html(output: &mut String, value: &str) -> Result<()> {
+    if output
+        .len()
+        .checked_add(value.len())
+        .is_none_or(|length| length > MAX_RAW_MESSAGE_BYTES)
+    {
         bail!("mime_resolved_html_too_large");
     }
-    Ok(output)
+    output.push_str(value);
+    Ok(())
+}
+
+fn html_tag_end(input: &str, start: usize) -> Option<usize> {
+    let bytes = input.as_bytes();
+    let mut quote = None;
+    for (index, byte) in bytes.iter().enumerate().skip(start + 1) {
+        match quote {
+            Some(current) if *byte == current => quote = None,
+            Some(_) => {}
+            None if matches!(byte, b'\'' | b'"') => quote = Some(*byte),
+            None if *byte == b'>' => return Some(index + 1),
+            None => {}
+        }
+    }
+    None
+}
+
+fn raw_text_element_end(input: &str, start: usize, opening_end: usize) -> Option<usize> {
+    let after_open = input.get(start + 1..opening_end)?;
+    let name_end = after_open
+        .find(|character: char| character.is_ascii_whitespace() || matches!(character, '/' | '>'))
+        .unwrap_or(after_open.len());
+    let name = &after_open[..name_end];
+    if ![
+        "script",
+        "style",
+        "textarea",
+        "title",
+        "xmp",
+        "iframe",
+        "noembed",
+        "noframes",
+        "plaintext",
+    ]
+    .iter()
+    .any(|candidate| name.eq_ignore_ascii_case(candidate))
+    {
+        return None;
+    }
+    if name.eq_ignore_ascii_case("plaintext") {
+        return Some(input.len());
+    }
+
+    let closing = format!("</{name}");
+    let remainder = input.get(opening_end..)?;
+    let offset = remainder
+        .as_bytes()
+        .windows(closing.len())
+        .enumerate()
+        .find(|(offset, window)| {
+            window.eq_ignore_ascii_case(closing.as_bytes())
+                && remainder
+                    .as_bytes()
+                    .get(offset + closing.len())
+                    .is_none_or(|byte| byte.is_ascii_whitespace() || matches!(byte, b'/' | b'>'))
+        })
+        .map(|(offset, _)| offset);
+    let Some(closing_start) = offset.map(|offset| opening_end + offset) else {
+        return Some(input.len());
+    };
+    Some(html_tag_end(input, closing_start).unwrap_or(input.len()))
 }
 
 fn rewrite_resource_references_in_tag(
     tag: &str,
-    reference: &str,
-    replacement: Option<&str>,
+    replacements: &BTreeMap<String, String>,
 ) -> Result<String> {
-    let lower = tag.to_ascii_lowercase();
-    let mut output = tag.to_owned();
-    for attribute in ["src", "href", "background", "poster", "data"] {
-        for quote in ['\"', '\''] {
-            let needle = format!("{attribute}={quote}{reference}{quote}");
-            if lower.contains(&needle.to_ascii_lowercase()) {
-                let replacement = replacement
-                    .map(|value| format!("{attribute}={quote}{value}{quote}"))
-                    .unwrap_or_default();
-                output = replace_ascii_case_insensitive_bounded(&output, &needle, &replacement)?;
-                if replacement.is_empty() {
-                    return Ok(String::new());
-                }
-            }
+    let mut ranges = Vec::new();
+    collect_html_tag_resource_ranges(tag, |range, value| {
+        if let Some(replacement) = replacements.get(&value.to_ascii_lowercase()) {
+            ranges.push((range, replacement.as_str()));
         }
+    });
+    if ranges.is_empty() {
+        return Ok(tag.to_owned());
     }
-    let url = format!("url({reference})");
-    if lower.contains(&url.to_ascii_lowercase()) {
-        let replacement = replacement
-            .map(|value| format!("url({value})"))
-            .unwrap_or_default();
-        output = replace_ascii_case_insensitive_bounded(&output, &url, &replacement)?;
-        if replacement.is_empty() {
-            return Ok(String::new());
-        }
-    }
-    Ok(output)
-}
-
-fn replace_ascii_case_insensitive_bounded(
-    input: &str,
-    needle: &str,
-    replacement: &str,
-) -> Result<String> {
-    if needle.is_empty() {
-        return Ok(input.to_owned());
-    }
-    let lower_input = input.to_ascii_lowercase();
-    let lower_needle = needle.to_ascii_lowercase();
-    let occurrences = lower_input.match_indices(&lower_needle).count();
-    let projected_len = input
-        .len()
-        .checked_add(
-            replacement
-                .len()
-                .saturating_sub(needle.len())
-                .checked_mul(occurrences)
-                .context("mime_resolved_html_too_large")?,
-        )
-        .context("mime_resolved_html_too_large")?;
+    let projected_len = ranges
+        .iter()
+        .try_fold(tag.len(), |length, (range, replacement)| {
+            length
+                .checked_add(replacement.len())
+                .and_then(|value| value.checked_sub(range.len()))
+                .context("mime_resolved_html_too_large")
+        })?;
     if projected_len > MAX_RAW_MESSAGE_BYTES {
         bail!("mime_resolved_html_too_large");
     }
     let mut output = String::with_capacity(projected_len);
     let mut cursor = 0;
-    while let Some(offset) = lower_input[cursor..].find(&lower_needle) {
-        let start = cursor + offset;
-        output.push_str(&input[cursor..start]);
+    for (range, replacement) in ranges {
+        output.push_str(&tag[cursor..range.start]);
         output.push_str(replacement);
-        cursor = start + needle.len();
+        cursor = range.end;
     }
-    output.push_str(&input[cursor..]);
+    output.push_str(&tag[cursor..]);
     Ok(output)
+}
+
+fn collect_html_tag_resource_references(tag: &str, references: &mut BTreeSet<String>) {
+    collect_html_tag_resource_ranges(tag, |_, value| {
+        references.insert(value.to_ascii_lowercase());
+    });
+}
+
+fn collect_html_tag_resource_ranges<'a>(
+    tag: &'a str,
+    mut found: impl FnMut(Range<usize>, &'a str),
+) {
+    let bytes = tag.as_bytes();
+    let mut index = 1usize;
+    while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+        index += 1;
+    }
+    if index >= bytes.len() || matches!(bytes[index], b'/' | b'!' | b'?') {
+        return;
+    }
+    while index < bytes.len() && !bytes[index].is_ascii_whitespace() && bytes[index] != b'>' {
+        index += 1;
+    }
+    while index < bytes.len() {
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() || matches!(bytes[index], b'/' | b'>') {
+            break;
+        }
+        let name_start = index;
+        while index < bytes.len()
+            && !bytes[index].is_ascii_whitespace()
+            && !matches!(bytes[index], b'=' | b'/' | b'>')
+        {
+            index += 1;
+        }
+        let attribute_name = tag[name_start..index].to_ascii_lowercase();
+        let relevant = matches!(
+            attribute_name.as_str(),
+            "src" | "href" | "background" | "poster" | "data"
+        );
+        let is_style = attribute_name == "style";
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() || bytes[index] != b'=' {
+            continue;
+        }
+        index += 1;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        if index >= bytes.len() {
+            break;
+        }
+        let (start, end) = if matches!(bytes[index], b'\'' | b'"') {
+            let quote = bytes[index];
+            index += 1;
+            let start = index;
+            while index < bytes.len() && bytes[index] != quote {
+                index += 1;
+            }
+            (start, index)
+        } else {
+            let start = index;
+            while index < bytes.len() && !bytes[index].is_ascii_whitespace() && bytes[index] != b'>'
+            {
+                index += 1;
+            }
+            (start, index)
+        };
+        if relevant && start < end {
+            found(start..end, &tag[start..end]);
+        }
+        if is_style && start < end {
+            collect_css_url_resource_ranges(&tag[start..end], |range, value| {
+                found(start + range.start..start + range.end, value);
+            });
+        }
+        if index < bytes.len() && matches!(bytes[index], b'\'' | b'"') {
+            index += 1;
+        }
+    }
+}
+
+fn collect_css_url_resource_ranges<'a>(tag: &'a str, mut found: impl FnMut(Range<usize>, &'a str)) {
+    let bytes = tag.as_bytes();
+    let mut index = 0usize;
+    while index + 4 <= bytes.len() {
+        if !bytes[index..index + 4].eq_ignore_ascii_case(b"url(") {
+            index += 1;
+            continue;
+        }
+        index += 4;
+        while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+            index += 1;
+        }
+        let quote = matches!(bytes.get(index), Some(b'\'' | b'\"')).then(|| bytes[index]);
+        if quote.is_some() {
+            index += 1;
+        }
+        let start = index;
+        while index < bytes.len()
+            && quote.map_or(bytes[index] != b')', |value| bytes[index] != value)
+        {
+            index += 1;
+        }
+        let end = index;
+        if let Some(quote) = quote {
+            if index >= bytes.len() || bytes[index] != quote {
+                break;
+            }
+            index += 1;
+            while index < bytes.len() && bytes[index].is_ascii_whitespace() {
+                index += 1;
+            }
+        }
+        if index >= bytes.len() || bytes[index] != b')' {
+            break;
+        }
+        if start < end {
+            found(start..end, &tag[start..end]);
+        }
+        index += 1;
+    }
 }
 
 fn supplied_attachment_name(mail: &ParsedMessage<'_>, part: &MessagePart<'_>) -> Option<String> {
@@ -5326,6 +5607,9 @@ mod tests {
 
     fn mime_corpus(name: &str) -> &'static [u8] {
         match name {
+            "alternative-mixed-asic-footer" => {
+                include_bytes!("../testdata/mime/alternative-mixed-asic-footer.eml")
+            }
             "attached-message-rfc822" => {
                 include_bytes!("../testdata/mime/attached-message-rfc822.eml")
             }
@@ -5384,10 +5668,39 @@ mod tests {
         );
         assert!(linked_in.attachments.is_empty());
 
-        let nested = parse_message(
+        let alternative_mixed = parse_message(
             &account,
             "INBOX",
             2,
+            &[],
+            mime_corpus("alternative-mixed-asic-footer"),
+            None,
+        )
+        .await
+        .unwrap();
+        let alternative_html = alternative_mixed.body_html.as_deref().unwrap();
+        assert!(alternative_html.contains("Redacted secure delivery."));
+        assert_eq!(
+            alternative_html
+                .matches("Manage delivery preferences")
+                .count(),
+            2
+        );
+        assert!(alternative_mixed.body_text.contains("Plain fallback"));
+        assert_eq!(alternative_mixed.attachments.len(), 1);
+        assert_eq!(
+            alternative_mixed.attachments[0].attachment.filename,
+            "redacted-delivery.asice"
+        );
+        assert_eq!(
+            alternative_mixed.attachments[0].attachment.mime_type,
+            "application/vnd.etsi.asic-e+zip"
+        );
+
+        let nested = parse_message(
+            &account,
+            "INBOX",
+            3,
             &[],
             mime_corpus("competing-nested-alternatives"),
             None,
@@ -5409,7 +5722,7 @@ mod tests {
         let attached = parse_message(
             &account,
             "INBOX",
-            3,
+            4,
             &[],
             mime_corpus("attached-message-rfc822"),
             None,
@@ -5437,7 +5750,7 @@ mod tests {
         let flowed = parse_message(
             &account,
             "INBOX",
-            4,
+            5,
             &[],
             mime_corpus("format-flowed-delsp"),
             None,
@@ -5452,7 +5765,7 @@ mod tests {
         let filenames = parse_message(
             &account,
             "INBOX",
-            5,
+            6,
             &[],
             mime_corpus("filename-parameters-and-encodings"),
             None,
@@ -5474,7 +5787,7 @@ mod tests {
         let invalid = parse_message(
             &account,
             "INBOX",
-            6,
+            7,
             &[],
             mime_corpus("invalid-transfer-encodings"),
             None,
@@ -5486,7 +5799,7 @@ mod tests {
         let charset = parse_message(
             &account,
             "INBOX",
-            7,
+            8,
             &[],
             mime_corpus("charset-matrix"),
             None,
@@ -5514,7 +5827,7 @@ mod tests {
         let disposition = parse_message(
             &account,
             "INBOX",
-            8,
+            9,
             &[],
             mime_corpus("disposition-type-name-matrix"),
             None,
@@ -5535,7 +5848,7 @@ mod tests {
         let cr_only = parse_message(
             &account,
             "INBOX",
-            9,
+            10,
             &[],
             mime_corpus("line-endings-cr-only"),
             None,
@@ -5547,7 +5860,7 @@ mod tests {
         let multipart_attachment = parse_message(
             &account,
             "INBOX",
-            10,
+            11,
             &[],
             mime_corpus("multipart-attachment-container"),
             None,
@@ -5584,6 +5897,7 @@ mod tests {
     async fn every_mime_corpus_fixture_uses_all_publication_parse_paths() {
         let account = test_account();
         let cases = [
+            ("alternative-mixed-asic-footer", true),
             ("attached-message-rfc822", true),
             ("charset-matrix", true),
             ("competing-nested-alternatives", true),
@@ -5814,6 +6128,76 @@ mod tests {
             replace_resource_reference(html, "cid:logo", "data:image/png;base64,AA").unwrap();
         assert!(resolved.contains("<p>\"cid:logo\" remains visible</p>"));
         assert!(resolved.contains("src=\"data:image/png;base64,AA\""));
+    }
+
+    #[test]
+    fn inline_resource_rewriting_accepts_spaced_unquoted_and_quote_aware_attributes() {
+        let html = concat!(
+            "<p>cid:logo remains visible text</p>",
+            "<img alt=\"comparison: 2 > 1; url(cid:style)\" SRC = cid:logo>",
+            "<a href = 'cid:other'>link</a><table style=\"background: url( 'cid:style' )\">"
+        );
+        assert!(html_contains_reference(html, "CID:LOGO"));
+        assert!(html_contains_reference(html, "cid:other"));
+        assert!(html_contains_reference(html, "cid:style"));
+        assert!(!html_contains_reference(html, "cid:visible"));
+        let resolved = rewrite_html_resource_references(
+            html,
+            &BTreeMap::from([
+                ("cid:logo".into(), "data:image/png;base64,AA".into()),
+                ("cid:other".into(), "data:image/png;base64,BB".into()),
+                ("cid:style".into(), "data:image/png;base64,CC".into()),
+            ]),
+        )
+        .unwrap();
+        assert!(resolved.contains("cid:logo remains visible text"));
+        assert!(resolved.contains("comparison: 2 > 1; url(cid:style)"));
+        assert!(resolved.contains("SRC = data:image/png;base64,AA"));
+        assert!(resolved.contains("href = 'data:image/png;base64,BB'"));
+        assert!(resolved.contains("url( 'data:image/png;base64,CC' )"));
+    }
+
+    #[test]
+    fn html_joining_never_discards_actionable_sibling_markup() {
+        let merged = join_visible_html_segments(vec![
+            "<p>Primary delivery</p><p>Manage preferences</p>".into(),
+            "<a href=\"https://example.test/manage\">Manage preferences</a><img src=\"cid:seal\">"
+                .into(),
+        ])
+        .unwrap();
+        assert_eq!(merged.matches("Manage preferences").count(), 2);
+        assert!(merged.contains("https://example.test/manage"));
+        assert!(merged.contains("cid:seal"));
+    }
+
+    #[test]
+    fn inline_resource_detection_and_rewriting_ignore_html_comments() {
+        let html = concat!(
+            "<!--[if mso]><img src=\"cid:comment-only\"><![endif]-->",
+            "<script>const template = '</scripture><img src=\"cid:script-only\">';</script>",
+            "<iframe><img src=\"cid:iframe-only\"></iframe>",
+            "<img src=\"cid:live\">"
+        );
+        let references = html_resource_references(html);
+        assert!(!references.contains("cid:comment-only"));
+        assert!(!references.contains("cid:script-only"));
+        assert!(!references.contains("cid:iframe-only"));
+        assert!(references.contains("cid:live"));
+
+        let resolved = rewrite_html_resource_references(
+            html,
+            &BTreeMap::from([
+                ("cid:comment-only".into(), "data:image/png;base64,AA".into()),
+                ("cid:script-only".into(), "data:image/png;base64,CC".into()),
+                ("cid:iframe-only".into(), "data:image/png;base64,DD".into()),
+                ("cid:live".into(), "data:image/png;base64,BB".into()),
+            ]),
+        )
+        .unwrap();
+        assert!(resolved.contains("src=\"cid:comment-only\""));
+        assert!(resolved.contains("src=\"cid:script-only\""));
+        assert!(resolved.contains("src=\"cid:iframe-only\""));
+        assert!(resolved.contains("src=\"data:image/png;base64,BB\""));
     }
 
     #[tokio::test]
@@ -6527,7 +6911,11 @@ mod tests {
         let references = vec!["cid:duplicate@example".to_owned()];
         let counts = BTreeMap::from([("cid:duplicate@example".to_owned(), 2usize)]);
 
-        assert!(!has_unambiguous_html_reference(html, &references, &counts));
+        assert!(!has_unambiguous_html_reference(
+            &html_resource_references(html),
+            &references,
+            &counts
+        ));
     }
 
     #[test]
@@ -6597,17 +6985,134 @@ mod tests {
                 .map(|part| (part.part.mime_type.as_str(), part.part.path.as_slice()))
                 .collect::<Vec<_>>(),
             vec![
-                ("text/plain", [1].as_slice()),
                 // The last alternative is attempted first, but a broken
                 // transfer encoding falls back to the previous HTML body.
                 ("text/html", [3].as_slice()),
-                ("text/html", [2].as_slice())
+                ("text/html", [2].as_slice()),
+                ("text/plain", [1].as_slice()),
             ]
         );
+        let mut successful = BTreeMap::new();
+        assert!(alternative_branch_is_eligible(
+            &plan.text_parts[0],
+            &successful
+        ));
+        // The newest HTML branch is broken, so it cannot claim the group.
+        assert!(alternative_branch_is_eligible(
+            &plan.text_parts[1],
+            &successful
+        ));
+        record_successful_alternative_branches(&plan.text_parts[1], &mut successful);
+        // HTML and plain representations are selected independently, so a
+        // valid HTML branch does not erase the useful plain fallback.
+        assert!(alternative_branch_is_eligible(
+            &plan.text_parts[2],
+            &successful
+        ));
+    }
+
+    #[test]
+    fn selective_alternative_keeps_all_mixed_html_siblings_in_its_selected_branch() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" NIL NIL NIL \"7BIT\" 5 1) ",
+            "((\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 30 1) ",
+            "(\"APPLICATION\" \"VND.ETSI.ASIC-E+ZIP\" (\"NAME\" \"redacted-delivery.asice\") NIL NIL \"BASE64\" 40 NIL ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"redacted-delivery.asice\"))) ",
+            "(\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 20 1) \"MIXED\") \"ALTERNATIVE\"))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
         assert_eq!(
-            plan.text_parts[1].fallback_group,
-            plan.text_parts[2].fallback_group
+            plan.text_parts
+                .iter()
+                .map(|part| part.part.path.as_slice())
+                .collect::<Vec<_>>(),
+            vec![[2, 1].as_slice(), [2, 3].as_slice(), [1].as_slice()]
         );
+        assert_eq!(plan.attachments.len(), 1);
+        assert_eq!(plan.attachments[0].part.path, vec![2, 2]);
+
+        let mut successful = BTreeMap::new();
+        assert!(alternative_branch_is_eligible(
+            &plan.text_parts[0],
+            &successful
+        ));
+        record_successful_alternative_branches(&plan.text_parts[0], &mut successful);
+        // 2.3 is a sibling in the successful mixed branch, not a fallback.
+        assert!(alternative_branch_is_eligible(
+            &plan.text_parts[1],
+            &successful
+        ));
+        record_successful_alternative_branches(&plan.text_parts[1], &mut successful);
+        assert!(alternative_branch_is_eligible(
+            &plan.text_parts[2],
+            &successful
+        ));
+    }
+
+    #[test]
+    fn selective_composite_footer_cannot_claim_branch_after_primary_html_failure() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 25 1) ",
+            "((\"TEXT\" \"HTML\" NIL NIL NIL \"X-BROKEN\" 30 1) ",
+            "(\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 20 1) \"MIXED\") \"ALTERNATIVE\"))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        let mut successful = BTreeMap::new();
+
+        // 2.1 fails and therefore does not select the preferred composite.
+        assert!(plan.text_parts[0].alternative_branches[0].decisive);
+        // A decoded footer is retained provisionally, but cannot select it.
+        assert!(!plan.text_parts[1].alternative_branches[0].decisive);
+        record_successful_alternative_branches(&plan.text_parts[1], &mut successful);
+        assert!(alternative_branch_is_eligible(
+            &plan.text_parts[2],
+            &successful
+        ));
+
+        record_successful_alternative_branches(&plan.text_parts[2], &mut successful);
+        assert!(!alternative_branch_is_selected(
+            &plan.text_parts[1],
+            &successful
+        ));
+        assert!(alternative_branch_is_selected(
+            &plan.text_parts[2],
+            &successful
+        ));
+    }
+
+    #[test]
+    fn selective_nested_alternative_fallback_can_select_its_enclosing_branch() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 25 1) ",
+            "((\"TEXT\" \"HTML\" NIL NIL NIL \"7BIT\" 30 1) ",
+            "(\"TEXT\" \"HTML\" NIL NIL NIL \"X-BROKEN\" 20 1) \"ALTERNATIVE\") ",
+            "\"ALTERNATIVE\"))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        let mut successful = BTreeMap::new();
+
+        assert_eq!(plan.text_parts[0].part.path, vec![2, 2]);
+        assert_eq!(plan.text_parts[1].part.path, vec![2, 1]);
+        assert!(plan.text_parts[1]
+            .alternative_branches
+            .iter()
+            .all(|branch| branch.decisive));
+        record_successful_alternative_branches(&plan.text_parts[1], &mut successful);
+        assert!(alternative_branch_is_selected(
+            &plan.text_parts[1],
+            &successful
+        ));
+        assert!(!alternative_branch_is_selected(
+            &plan.text_parts[2],
+            &successful
+        ));
     }
 
     #[test]
@@ -6631,7 +7136,7 @@ mod tests {
         let structure = parse_bodystructure(&[concat!(
             "* 1 FETCH (BODYSTRUCTURE ((\"TEXT\" \"PLAIN\" NIL \"<first>\" NIL \"7BIT\" 5 1) ",
             "(\"TEXT\" \"HTML\" NIL \"<second>\" NIL \"7BIT\" 5 1) ",
-            "\"RELATED\" (\"START\" \"<missing>\")))"
+            "\"RELATED\" (\"START\" \" <missing> \")))"
         )
         .into()])
         .unwrap();
@@ -6639,6 +7144,22 @@ mod tests {
         assert_eq!(plan.text_parts.len(), 1);
         assert_eq!(plan.text_parts[0].part.path, vec![1]);
         assert_eq!(plan.text_parts[0].part.mime_type, "text/plain");
+    }
+
+    #[test]
+    fn malformed_related_start_matches_full_parse_first_child_fallback() {
+        let raw = concat!(
+            "Content-Type: multipart/related; start=\" <missing@example.test> \"; boundary=rel\r\n\r\n",
+            "--rel\r\nContent-Type: text/html; charset=utf-8\r\n\r\n<p>First related root</p>\r\n",
+            "--rel\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nSecond related sibling\r\n--rel--\r\n"
+        );
+        let parsed = parse_complete_message(raw.as_bytes()).unwrap();
+        let selected = select_bodies(&parsed).unwrap();
+        assert!(selected
+            .html
+            .as_deref()
+            .is_some_and(|html| html.contains("First related root")));
+        assert!(selected.text.is_empty());
     }
 
     #[test]

--- a/crates/dakia-core/src/mime_budget.rs
+++ b/crates/dakia-core/src/mime_budget.rs
@@ -89,10 +89,11 @@ fn preflight_mime_part_count(raw: &[u8]) -> Result<(), MimeBudgetError> {
     let mut in_headers = true;
     let mut content_type = Vec::new();
     let mut collecting_content_type = false;
+    let mut content_type_over_budget = false;
     let mut opening_delimiters = 0;
     let mut over_budget = false;
     for_each_line(raw, |line| {
-        if too_many_boundaries || over_budget {
+        if too_many_boundaries || over_budget || content_type_over_budget {
             return;
         }
 
@@ -106,9 +107,16 @@ fn preflight_mime_part_count(raw: &[u8]) -> Result<(), MimeBudgetError> {
                 .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
                 && collecting_content_type
             {
-                if content_type.len() < 4_096 {
+                let continuation = trim_ascii_whitespace(line);
+                if content_type
+                    .len()
+                    .checked_add(1 + continuation.len())
+                    .is_some_and(|length| length <= MAX_MIME_HEADER_BYTES)
+                {
                     content_type.push(b' ');
-                    content_type.extend_from_slice(trim_ascii_whitespace(line));
+                    content_type.extend_from_slice(continuation);
+                } else {
+                    content_type_over_budget = true;
                 }
             } else {
                 record_mime_boundary(&mut content_type, &mut boundaries, &mut too_many_boundaries);
@@ -139,6 +147,9 @@ fn preflight_mime_part_count(raw: &[u8]) -> Result<(), MimeBudgetError> {
             boundaries.remove(closing);
         }
     });
+    if content_type_over_budget {
+        return Err(MimeBudgetError::MimeHeadersTooLarge);
+    }
     if too_many_boundaries {
         return Err(MimeBudgetError::TooManyMimeParts);
     }
@@ -154,13 +165,11 @@ fn record_mime_boundary(
     boundaries: &mut HashSet<Vec<u8>>,
     too_many_boundaries: &mut bool,
 ) {
-    if contains_ascii_case_insensitive(content_type, b"multipart/") {
-        if let Some(boundary) = mime_boundary_parameter(content_type) {
-            if !boundary.is_empty() && boundary.len() <= 200 {
-                boundaries.insert(boundary.to_vec());
-                if boundaries.len() >= MAX_MIME_PARTS {
-                    *too_many_boundaries = true;
-                }
+    if let Some(boundary) = mime_boundary_parameter(content_type) {
+        if !boundary.is_empty() && boundary.len() <= 200 {
+            boundaries.insert(boundary);
+            if boundaries.len() >= MAX_MIME_PARTS {
+                *too_many_boundaries = true;
             }
         }
     }
@@ -216,28 +225,100 @@ fn starts_ascii_case_insensitive(haystack: &[u8], needle: &[u8]) -> bool {
         .is_some_and(|prefix| prefix.eq_ignore_ascii_case(needle))
 }
 
-fn contains_ascii_case_insensitive(haystack: &[u8], needle: &[u8]) -> bool {
-    haystack
-        .windows(needle.len())
-        .any(|window| window.eq_ignore_ascii_case(needle))
+fn mime_boundary_parameter(line: &[u8]) -> Option<Vec<u8>> {
+    let parameters = multipart_parameter_section(line)?;
+    let mut remaining = parameters;
+
+    while let Some((parameter, rest)) = next_parameter(remaining) {
+        if let Some(boundary) = boundary_parameter_value(parameter) {
+            return Some(boundary);
+        }
+        remaining = rest;
+    }
+
+    None
 }
 
-fn mime_boundary_parameter(line: &[u8]) -> Option<&[u8]> {
-    let marker = b"boundary=";
-    let offset = line
-        .windows(marker.len())
-        .position(|window| window.eq_ignore_ascii_case(marker))?;
-    let value = trim_ascii_whitespace(&line[offset + marker.len()..]);
+/// Returns the parameter portion of a multipart Content-Type header. This
+/// avoids treating boundary-like text in another media type as a delimiter.
+fn multipart_parameter_section(line: &[u8]) -> Option<&[u8]> {
+    let colon = line.iter().position(|byte| *byte == b':')?;
+    let value = trim_ascii_whitespace(&line[colon + 1..]);
+    let (media_type, after_media_type) = ascii_token(value);
+    if !media_type.eq_ignore_ascii_case(b"multipart") {
+        return None;
+    }
+
+    let after_slash = trim_ascii_whitespace(after_media_type).strip_prefix(b"/")?;
+    let (subtype, parameters) = ascii_token(trim_ascii_whitespace(after_slash));
+    (!subtype.is_empty()).then_some(parameters)
+}
+
+/// Splits the next parameter at a semicolon that is not inside a quoted value.
+fn next_parameter(value: &[u8]) -> Option<(&[u8], &[u8])> {
+    let start = value.iter().position(|byte| *byte == b';')? + 1;
+    let value = &value[start..];
+    let mut quoted = false;
+    let mut escaped = false;
+
+    for (index, byte) in value.iter().enumerate() {
+        match *byte {
+            b'\\' if quoted => escaped = !escaped,
+            b'"' if !escaped => quoted = !quoted,
+            b';' if !quoted => return Some((&value[..index], &value[index..])),
+            _ => escaped = false,
+        }
+    }
+
+    Some((value, &[]))
+}
+
+fn boundary_parameter_value(parameter: &[u8]) -> Option<Vec<u8>> {
+    let parameter = trim_ascii_whitespace(parameter);
+    let (name, after_name) = ascii_token(parameter);
+    if !name.eq_ignore_ascii_case(b"boundary") {
+        return None;
+    }
+
+    let value = trim_ascii_whitespace(after_name).strip_prefix(b"=")?;
+    let value = trim_ascii_whitespace(value);
     if let Some(value) = value.strip_prefix(b"\"") {
-        let end = value.iter().position(|byte| *byte == b'"')?;
-        Some(&value[..end])
+        unquote_boundary(value)
     } else {
         let end = value
             .iter()
-            .position(|byte| byte.is_ascii_whitespace() || *byte == b';')
+            .position(|byte| byte.is_ascii_whitespace())
             .unwrap_or(value.len());
-        Some(&value[..end])
+        Some(value[..end].to_vec())
     }
+}
+
+fn ascii_token(value: &[u8]) -> (&[u8], &[u8]) {
+    let end = value
+        .iter()
+        .position(|byte| matches!(*byte, b' ' | b'\t' | b'/' | b';' | b'='))
+        .unwrap_or(value.len());
+    (&value[..end], &value[end..])
+}
+
+fn unquote_boundary(value: &[u8]) -> Option<Vec<u8>> {
+    let mut boundary = Vec::with_capacity(value.len());
+    let mut escaped = false;
+
+    for byte in value {
+        if escaped {
+            boundary.push(*byte);
+            escaped = false;
+        } else if *byte == b'\\' {
+            escaped = true;
+        } else if *byte == b'"' {
+            return Some(boundary);
+        } else {
+            boundary.push(*byte);
+        }
+    }
+
+    None
 }
 
 /// Checks a parser-derived aggregate of all MIME header bytes.
@@ -295,6 +376,7 @@ fn outer_header_len(raw: &[u8]) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mail_parser::MessageParser;
 
     #[test]
     fn accepts_messages_at_all_budgets() {
@@ -420,9 +502,93 @@ mod tests {
     }
 
     #[test]
+    fn mail_parser_accepts_boundary_with_whitespace_around_equals() {
+        let raw = b"Content-Type: multipart/mixed; boundary = storm\r\n\r\n\
+--storm\r\n\r\nbody\r\n\
+--storm--\r\n";
+
+        assert!(MessageParser::default().parse(raw).unwrap().parts.len() > 1);
+    }
+
+    #[test]
+    fn preflight_rejects_boundary_storms_with_tolerant_parameter_spacing() {
+        fn multipart(declaration: &[u8], boundary: &[u8], leaves: usize) -> Vec<u8> {
+            let mut raw = b"Content-Type: multipart/mixed; ".to_vec();
+            raw.extend_from_slice(declaration);
+            raw.extend_from_slice(b"\r\n\r\n");
+            for _ in 0..leaves {
+                raw.extend_from_slice(b"--");
+                raw.extend_from_slice(boundary);
+                raw.extend_from_slice(b"\r\n\r\nx\r\n");
+            }
+            raw.extend_from_slice(b"--");
+            raw.extend_from_slice(boundary);
+            raw.extend_from_slice(b"--\r\n");
+            raw
+        }
+
+        for (declaration, boundary) in [
+            (b"boundary = storm".as_slice(), b"storm".as_slice()),
+            (
+                b"BOUNDARY\t=\t\"quoted-token\"".as_slice(),
+                b"quoted-token".as_slice(),
+            ),
+            (b"boundary = ending--".as_slice(), b"ending--".as_slice()),
+        ] {
+            assert_eq!(
+                preflight_raw_message(&multipart(declaration, boundary, MAX_MIME_PARTS)),
+                Err(MimeBudgetError::TooManyMimeParts),
+                "failed to preflight {declaration:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn preflight_finds_a_boundary_after_a_long_folded_content_type_parameter() {
+        let mut raw = b"Content-Type: multipart/mixed;\r\n\tnote=\"".to_vec();
+        raw.extend(std::iter::repeat_n(b'x', 8_192));
+        raw.extend_from_slice(b"\";\r\n\tboundary = storm\r\n\r\n");
+        for _ in 0..MAX_MIME_PARTS {
+            raw.extend_from_slice(b"--storm\r\n\r\nx\r\n");
+        }
+        raw.extend_from_slice(b"--storm--\r\n");
+
+        assert_eq!(
+            preflight_raw_message(&raw),
+            Err(MimeBudgetError::TooManyMimeParts)
+        );
+    }
+
+    #[test]
+    fn preflight_rejects_an_oversized_inner_content_type_before_parsing() {
+        let mut raw =
+            b"Content-Type: multipart/mixed; boundary=outer\r\n\r\n--outer\r\nContent-Type: multipart/mixed;\r\n\tpadding=\""
+                .to_vec();
+        raw.extend(std::iter::repeat_n(b'x', MAX_MIME_HEADER_BYTES));
+        raw.extend_from_slice(b"\"; boundary=inner\r\n\r\n--inner--\r\n--outer--\r\n");
+
+        assert_eq!(
+            preflight_raw_message(&raw),
+            Err(MimeBudgetError::MimeHeadersTooLarge)
+        );
+    }
+
+    #[test]
     fn preflight_does_not_parse_quoted_mime_inside_plain_text() {
         let mut raw = b"Content-Type: text/plain; charset=utf-8\r\n\r\n".to_vec();
-        raw.extend_from_slice(b"Content-Type: multipart/mixed; boundary=storm\r\n");
+        raw.extend_from_slice(b"Content-Type: multipart/mixed; boundary = storm\r\n");
+        for _ in 0..MAX_MIME_PARTS {
+            raw.extend_from_slice(b"--storm\r\n");
+        }
+
+        assert!(preflight_raw_message(&raw).is_ok());
+    }
+
+    #[test]
+    fn preflight_does_not_treat_quoted_parameter_text_as_a_boundary() {
+        let mut raw =
+            b"Content-Type: multipart/mixed; note=\"boundary = storm\"; boundary=real\r\n\r\n"
+                .to_vec();
         for _ in 0..MAX_MIME_PARTS {
             raw.extend_from_slice(b"--storm\r\n");
         }

--- a/crates/dakia-core/testdata/mime/alternative-mixed-asic-footer.eml
+++ b/crates/dakia-core/testdata/mime/alternative-mixed-asic-footer.eml
@@ -1,0 +1,97 @@
+From: Redacted Sender <sender@redacted.example>
+Content-Type: multipart/alternative;
+	boundary="Apple-Mail=_REDACTED-OUTER"
+Mime-Version: 1.0 (Mac OS X Mail 16.0 \(3864.600.51.1.1\))
+Subject: Redacted secure delivery
+Message-Id: <redacted-message@redacted.example>
+Date: Thu, 30 Jul 2026 15:08:12 +0300
+To: Redacted Group <group@redacted.example>
+X-Mailer: Apple Mail (2.3864.600.51.1.1)
+
+
+--Apple-Mail=_REDACTED-OUTER
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/plain; charset="UTF-8"
+
+Plain fallback must not replace the HTML delivery.
+
+--=20
+Manage delivery preferences
+
+--Apple-Mail=_REDACTED-OUTER
+Content-Type: multipart/mixed;
+	boundary="Apple-Mail=_REDACTED-INNER"
+
+
+--Apple-Mail=_REDACTED-INNER
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset="UTF-8"
+
+<html aria-label=3D"message body"><head><meta http-equiv=3D"content-type" c=
+ontent=3D"text/html; charset=3Dutf-8"></head><body style=3D"overflow-wrap: =
+break-word; -webkit-nbsp-mode: space; line-break: after-white-space;">Redac=
+ted secure delivery.<div><br></div><div>
+
+
+<meta http-equiv=3D"Content-Type" content=3D"text/html; charset=3Dutf-8">
+
+<!-- Dark mode support (Apple Mail only) -->
+<style>
+@media (prefers-color-scheme: dark) {
+  .logo-light { display: none !important; }
+  .logo-dark { display: block !important; }
+}
+</style>
+
+  <div style=3D"font-family:'Inter', -apple-system, BlinkMacSystemFont, 'Se=
+goe UI', Arial, sans-serif;">
+    <div style=3D"font-size:14px; font-weight:700;">Redacted Sender</div>
+    <a href=3D"https://www.redacted.example" class=3D"logo-light" style=3D"di=
+splay:inline-block; text-decoration:none;">
+      <img src=3D"https://media.redacted.example/logo-light.png" alt=3D"Red=
+acted" width=3D"250" style=3D"display:block; border:0; width:250px;">
+    </a>
+  </div>
+
+</div>
+
+
+</div></body></html>
+
+<p></p>
+
+-- <br />
+Manage delivery preferences<br />
+View the discussion at <a href=3D"https://groups.redacted.example/message?u=
+tm_medium=3Demail&utm_source=3Dfooter">https://groups.redacted.example/mess=
+age</a>.<br />
+
+--Apple-Mail=_REDACTED-INNER
+Content-Disposition: attachment;
+	filename=redacted-delivery.asice
+Content-Type: application/vnd.etsi.asic-e+zip;
+	x-unix-mode=0644;
+	name="redacted-delivery.asice"
+Content-Transfer-Encoding: base64
+
+ZmljdGlvbmFsLUFTaUMtRS1hdHRhY2htZW50
+--Apple-Mail=_REDACTED-INNER
+Content-Transfer-Encoding: quoted-printable
+Content-Type: text/html; charset="UTF-8"
+
+<html aria-label=3D"message body"><head><meta http-equiv=3D"content-type" c=
+ontent=3D"text/html; charset=3Dus-ascii"></head><body style=3D"overflow-wra=
+p: break-word; -webkit-nbsp-mode: space; line-break: after-white-space;"><d=
+iv></div></body></html>
+
+<p></p>
+
+-- <br />
+Manage delivery preferences<br />
+View the discussion at <a href=3D"https://groups.redacted.example/message?u=
+tm_medium=3Demail&utm_source=3Dfooter">https://groups.redacted.example/mess=
+age</a>.<br />
+
+--Apple-Mail=_REDACTED-INNER--
+
+--Apple-Mail=_REDACTED-OUTER--


### PR DESCRIPTION
## Summary

- Improve MIME parsing and resource-budget handling for complex provider email structures.
- Preserve valid inline content and classify attachments more accurately.
- Update Reader rendering, message-content APIs, types, and localization.
- Add regression coverage for an alternative/mixed ASIC footer fixture.

## Testing

- Added and updated Rust MIME and frontend Reader/API tests covering the affected rendering paths.