### PR TITLE
Implement cost-effective testing strategy

### DIFF
--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -86,7 +86,7 @@ jobs:
           cargo test --workspace
           npm run typecheck
           npm run format:check
-          NODE_OPTIONS="--localstorage-file=/tmp/dakia-manual-vitest-localstorage" npm run test -- --maxWorkers=1
+          npm run test -- --maxWorkers=1
           npm run test:release-scripts
           npm run build:web
 

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -39,14 +39,11 @@ jobs:
         env:
           REASON: ${{ inputs.reason }}
         run: test -n "$(printf '%s' "$REASON" | tr -d '[:space:]')"
-      - name: Guard provider smoke credentials and opt-in
+      - name: Guard provider smoke explicit opt-in
         if: inputs.lane == 'provider-smoke'
         env:
           ENABLE_PROVIDER_SMOKE: ${{ inputs.enable_provider_smoke }}
-          PROVIDER_SMOKE_CONFIG: ${{ secrets.DAKIA_PROVIDER_SMOKE_CONFIG }}
-        run: |
-          test "$ENABLE_PROVIDER_SMOKE" = true
-          test -n "$PROVIDER_SMOKE_CONFIG"
+        run: test "$ENABLE_PROVIDER_SMOKE" = true
 
   full-source:
     name: Full Linux source suite
@@ -171,7 +168,7 @@ jobs:
           ./scripts/run-fixed-seed-property-regressions.sh 3
 
   provider-smoke:
-    name: Credentialed provider smoke contract
+    name: Credentialed provider smoke
     needs: validate-request
     if: inputs.lane == 'provider-smoke' && inputs.enable_provider_smoke
     runs-on: ubuntu-24.04
@@ -184,11 +181,15 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
           node-version: 20.19.0
-      - name: Validate the non-network provider smoke contract
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.82.0 --profile minimal
+          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+      - name: Compile the exact locked provider smoke binary
+        run: cargo build --locked -p dakia-cli --bin dakia-provider-smoke
+      - name: Run the read-neutral IMAP and SMTP auth/QUIT smoke
         env:
           PROVIDER_SMOKE_CONFIG: ${{ secrets.DAKIA_PROVIDER_SMOKE_CONFIG }}
-        run: node scripts/provider-smoke-contract.mjs
-      - name: Record scope accurately
         run: |
-          echo 'A secret-backed configuration contract was validated.'
-          echo 'No provider connection was attempted: a live MailService provider harness is not checked in yet.'
+          node scripts/provider-smoke-contract.mjs
+          target/debug/dakia-provider-smoke

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -64,15 +64,15 @@ jobs:
           key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
       - name: Install pinned Rust toolchain
         run: |
-          rustup toolchain install 1.82.0 --profile minimal --component rustfmt --component clippy
-          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+          rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
+          echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.82.0-${{ hashFiles('Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
       - name: Install Linux dependencies for workspace tests
         run: |
           sudo apt-get update
@@ -105,8 +105,8 @@ jobs:
           node-version: 20.19.0
       - name: Install pinned Rust coverage tooling
         run: |
-          rustup toolchain install 1.82.0 --profile minimal --component llvm-tools-preview
-          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+          rustup toolchain install 1.89.0 --profile minimal --component llvm-tools-preview
+          echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
           cargo install cargo-llvm-cov --version 0.6.13 --locked
       - name: Install Linux dependencies for workspace coverage
         run: |
@@ -158,8 +158,8 @@ jobs:
           node-version: 20.19.0
       - name: Install pinned Rust toolchain
         run: |
-          rustup toolchain install 1.82.0 --profile minimal
-          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+          rustup toolchain install 1.89.0 --profile minimal
+          echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
       - run: npm ci --ignore-scripts
       - name: Fetch classifier fixtures needed to compile the core test crate
         run: git lfs pull --include='apps/desktop/src-tauri/resources/email-classifier-v2/model.onnx,apps/desktop/src-tauri/resources/email-classifier-v2/tokenizer.json'
@@ -183,8 +183,8 @@ jobs:
           node-version: 20.19.0
       - name: Install pinned Rust toolchain
         run: |
-          rustup toolchain install 1.82.0 --profile minimal
-          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+          rustup toolchain install 1.89.0 --profile minimal
+          echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
       - name: Compile the exact locked provider smoke binary
         run: cargo build --locked -p dakia-cli --bin dakia-provider-smoke
       - name: Run the read-neutral IMAP and SMTP auth/QUIT smoke

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -1,0 +1,194 @@
+name: Manual validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      lane:
+        description: Validation lane to run
+        required: true
+        type: choice
+        options:
+          - full-source
+          - coverage
+          - fuzz
+          - provider-smoke
+      reason:
+        description: Why this manually dispatched validation is needed
+        required: true
+        type: string
+      enable_provider_smoke:
+        description: Explicitly permit a credentialed provider smoke attempt
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: manual-validation-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate manual request
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Require a meaningful reason
+        env:
+          REASON: ${{ inputs.reason }}
+        run: test -n "$(printf '%s' "$REASON" | tr -d '[:space:]')"
+      - name: Guard provider smoke credentials and opt-in
+        if: inputs.lane == 'provider-smoke'
+        env:
+          ENABLE_PROVIDER_SMOKE: ${{ inputs.enable_provider_smoke }}
+          PROVIDER_SMOKE_CONFIG: ${{ secrets.DAKIA_PROVIDER_SMOKE_CONFIG }}
+        run: |
+          test "$ENABLE_PROVIDER_SMOKE" = true
+          test -n "$PROVIDER_SMOKE_CONFIG"
+
+  full-source:
+    name: Full Linux source suite
+    needs: validate-request
+    if: inputs.lane == 'full-source'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: false
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.82.0 --profile minimal --component rustfmt clippy
+          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.82.0-${{ hashFiles('Cargo.lock') }}
+      - name: Install Linux dependencies for workspace tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: npm ci --ignore-scripts
+      - run: git lfs pull --include='apps/desktop/src-tauri/resources/email-classifier-v2/model.onnx,apps/desktop/src-tauri/resources/email-classifier-v2/tokenizer.json'
+      - run: |
+          npm run bundle:cli:dev
+          cargo fmt --all -- --check
+          cargo clippy --workspace --all-targets -- -D warnings
+          cargo test --workspace
+          npm run typecheck
+          npm run format:check
+          NODE_OPTIONS="--localstorage-file=/tmp/dakia-manual-vitest-localstorage" npm run test -- --maxWorkers=1
+          npm run test:release-scripts
+          npm run build:web
+
+  coverage:
+    name: Coverage baseline candidate
+    needs: validate-request
+    if: inputs.lane == 'coverage'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: false
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - name: Install pinned Rust coverage tooling
+        run: |
+          rustup toolchain install 1.82.0 --profile minimal --component llvm-tools-preview
+          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+          cargo install cargo-llvm-cov --version 0.6.13 --locked
+      - name: Install Linux dependencies for workspace coverage
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: npm ci --ignore-scripts
+      - name: Fetch classifier fixtures needed by the full Rust test suite
+        run: git lfs pull --include='apps/desktop/src-tauri/resources/email-classifier-v2/model.onnx,apps/desktop/src-tauri/resources/email-classifier-v2/tokenizer.json'
+      - name: Prepare the required Tauri CLI sidecar
+        run: npm run bundle:cli:dev
+      - name: Install the pinned Vitest coverage provider for this manual lane
+        run: npm install --no-save --ignore-scripts @vitest/coverage-v8@4.1.10
+      - name: Generate Rust and frontend LCOV reports
+        run: |
+          mkdir -p coverage
+          cargo llvm-cov --workspace --lcov --output-path coverage/rust.lcov
+          npm run test -- --coverage.enabled true --coverage.provider v8 --coverage.reporter lcov --coverage.reportsDirectory coverage/frontend --maxWorkers=1
+          test -f coverage/frontend/lcov.info
+      - name: Compare an existing ratchet or write a review candidate
+        run: |
+          baseline_args=()
+          if [ -f testdata/coverage/baseline.json ]; then
+            baseline_args=(--baseline testdata/coverage/baseline.json)
+          fi
+          node scripts/coverage-ratchet.mjs \
+            --rust-lcov coverage/rust.lcov \
+            --frontend-lcov coverage/frontend/lcov.info \
+            --output coverage/candidate.json \
+            "${baseline_args[@]}"
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: coverage-${{ github.run_id }}
+          path: coverage/
+          if-no-files-found: error
+          retention-days: 14
+
+  fuzz:
+    name: Bounded property and parser corpus
+    needs: validate-request
+    if: inputs.lane == 'fuzz'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: false
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.82.0 --profile minimal
+          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+      - run: npm ci --ignore-scripts
+      - name: Fetch classifier fixtures needed to compile the core test crate
+        run: git lfs pull --include='apps/desktop/src-tauri/resources/email-classifier-v2/model.onnx,apps/desktop/src-tauri/resources/email-classifier-v2/tokenizer.json'
+      - name: Run checked-in fixed-seed property and MIME corpus regressions
+        run: |
+          ./scripts/run-fixed-seed-property-regressions.sh 3
+
+  provider-smoke:
+    name: Credentialed provider smoke contract
+    needs: validate-request
+    if: inputs.lane == 'provider-smoke' && inputs.enable_provider_smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: provider-smoke
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: false
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - name: Validate the non-network provider smoke contract
+        env:
+          PROVIDER_SMOKE_CONFIG: ${{ secrets.DAKIA_PROVIDER_SMOKE_CONFIG }}
+        run: node scripts/provider-smoke-contract.mjs
+      - name: Record scope accurately
+        run: |
+          echo 'A secret-backed configuration contract was validated.'
+          echo 'No provider connection was attempted: a live MailService provider harness is not checked in yet.'

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -64,7 +64,7 @@ jobs:
           key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
       - name: Install pinned Rust toolchain
         run: |
-          rustup toolchain install 1.82.0 --profile minimal --component rustfmt clippy
+          rustup toolchain install 1.82.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -77,8 +77,8 @@ jobs:
       - name: Install pinned Rust toolchain
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         run: |
-          rustup toolchain install 1.82.0 --profile minimal --component rustfmt --component clippy
-          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+          rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
+          echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         with:
@@ -86,7 +86,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.82.0-${{ hashFiles('Cargo.lock') }}
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
       - id: rust_core
         name: Validate Rust core scope
         if: needs.classify.outputs.rust_core == 'true'

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -1,0 +1,139 @@
+name: Pull request validation
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+concurrency:
+  group: pull-request-validation-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  classify:
+    name: Classify changed paths
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      docs_only: ${{ steps.classify.outputs.docs_only }}
+      frontend: ${{ steps.classify.outputs.frontend }}
+      rust_core: ${{ steps.classify.outputs.rust_core }}
+      mail_boundary: ${{ steps.classify.outputs.mail_boundary }}
+      tauri_boundary: ${{ steps.classify.outputs.tauri_boundary }}
+      release_only: ${{ steps.classify.outputs.release_only }}
+      requires_lfs: ${{ steps.classify.outputs.requires_lfs }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 2
+          lfs: false
+      - name: Fetch PR base revision
+        run: git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
+      - id: classify
+        name: Derive scopes from merge-base diff
+        run: node scripts/change-classifier.mjs --base ${{ github.event.pull_request.base.sha }} --head HEAD --github-output
+      - name: Test classifier
+        run: node --test scripts/change-classifier.node-test.mjs
+
+  validate:
+    name: Validate applicable scopes
+    needs: classify
+    runs-on: ubuntu-24.04
+    timeout-minutes: 9
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 2
+          lfs: false
+      - name: Fetch PR base revision
+        run: git fetch --no-tags --depth=1 origin ${{ github.event.pull_request.base.sha }}
+      - id: docs_only
+        name: Validate documentation-only diff
+        if: needs.classify.outputs.docs_only == 'true'
+        run: git diff --check ${{ github.event.pull_request.base.sha }}...HEAD
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        if: needs.classify.outputs.frontend == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true' || needs.classify.outputs.release_only == 'true'
+        with:
+          node-version: 20.19.0
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: needs.classify.outputs.frontend == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.release_only == 'true'
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
+      - name: Install JavaScript dependencies without lifecycle preparation
+        if: needs.classify.outputs.frontend == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.release_only == 'true'
+        run: npm ci --ignore-scripts
+      - id: frontend
+        name: Validate frontend scope
+        if: needs.classify.outputs.frontend == 'true'
+        run: |
+          npm run format:check
+          npm run typecheck
+          NODE_OPTIONS="--localstorage-file=/tmp/dakia-vitest-localstorage" npm run test -- --maxWorkers=1
+          node --test scripts/tauri-contract-inventory.node-test.mjs
+          node scripts/tauri-contract-inventory.mjs
+      - name: Install pinned Rust toolchain
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        run: |
+          rustup toolchain install 1.82.0 --profile minimal --component rustfmt clippy
+          echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.82.0-${{ hashFiles('Cargo.lock') }}
+      - id: rust_core
+        name: Validate Rust core scope
+        if: needs.classify.outputs.rust_core == 'true'
+        run: |
+          cargo fmt --all -- --check
+          cargo clippy -p dakia-core --all-targets -- -D warnings
+          cargo test -p dakia-core -- \
+            --skip classification::tests::local_model_classifies_representative_email_types \
+            --skip classification::tests::does_not_treat_a_branded_monthly_update_as_personal_correspondence \
+            --skip classification::tests::does_not_treat_brand_marketing_as_personal_correspondence \
+            --skip classification::tests::bulk_insurance_price_promotion_is_not_a_transaction
+          cargo clippy -p dakia-cli --all-targets -- -D warnings
+          cargo test -p dakia-cli
+      - id: mail_boundary
+        name: Validate mail boundary suites
+        if: needs.classify.outputs.mail_boundary == 'true'
+        run: |
+          node --test scripts/validate-realistic-fixtures.node-test.mjs
+          node scripts/validate-realistic-fixtures.mjs
+          if [ "${{ needs.classify.outputs.frontend }}" != "true" ]; then
+            NODE_OPTIONS="--localstorage-file=/tmp/dakia-mail-boundary-vitest-localstorage" npx vitest run apps/desktop/src/apiMessageContent.test.ts apps/desktop/src/components/HtmlMessage.test.tsx apps/desktop/src/components/Reader.test.tsx --maxWorkers=1
+          fi
+      - name: Install Linux dependencies for Tauri command tests
+        if: needs.classify.outputs.tauri_boundary == 'true'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+      - id: tauri_boundary
+        name: Validate Linux-compilable Tauri boundary
+        if: needs.classify.outputs.tauri_boundary == 'true'
+        run: |
+          npm run bundle:cli:dev
+          cargo clippy -p dakia-desktop --all-targets -- -D warnings
+          cargo test -p dakia-desktop
+      - id: release_only
+        name: Validate release scripts without packaging
+        if: needs.classify.outputs.release_only == 'true'
+        run: npm run test:release-scripts
+      - name: Report selected scopes
+        if: always()
+        run: |
+          {
+            echo '### Pull request validation scopes'
+            echo '- docs-only: ${{ steps.docs_only.outcome }}'
+            echo '- frontend: ${{ steps.frontend.outcome }}'
+            echo '- rust-core: ${{ steps.rust_core.outcome }}'
+            echo '- mail-boundary: ${{ steps.mail_boundary.outcome }}'
+            echo '- tauri-boundary: ${{ steps.tauri_boundary.outcome }}'
+            echo '- release-only: ${{ steps.release_only.outcome }}'
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -41,7 +41,10 @@ jobs:
     name: Validate applicable scopes
     needs: classify
     runs-on: ubuntu-24.04
-    timeout-minutes: 9
+    # The first run for a new lockfile/toolchain must be able to populate the
+    # shared Cargo cache. Steady-state duration is measured separately against
+    # the strategy's warm-cache target.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -71,7 +71,7 @@ jobs:
         run: |
           npm run format:check
           npm run typecheck
-          NODE_OPTIONS="--localstorage-file=/tmp/dakia-vitest-localstorage" npm run test -- --maxWorkers=1
+          npm run test -- --maxWorkers=1
           node --test scripts/tauri-contract-inventory.node-test.mjs
           node scripts/tauri-contract-inventory.mjs
       - name: Install pinned Rust toolchain
@@ -107,7 +107,7 @@ jobs:
           node --test scripts/validate-realistic-fixtures.node-test.mjs
           node scripts/validate-realistic-fixtures.mjs
           if [ "${{ needs.classify.outputs.frontend }}" != "true" ]; then
-            NODE_OPTIONS="--localstorage-file=/tmp/dakia-mail-boundary-vitest-localstorage" npx vitest run apps/desktop/src/apiMessageContent.test.ts apps/desktop/src/components/HtmlMessage.test.tsx apps/desktop/src/components/Reader.test.tsx --maxWorkers=1
+            npx vitest run apps/desktop/src/apiMessageContent.test.ts apps/desktop/src/components/HtmlMessage.test.tsx apps/desktop/src/components/Reader.test.tsx --maxWorkers=1
           fi
       - name: Install Linux dependencies for Tauri command tests
         if: needs.classify.outputs.tauri_boundary == 'true'

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install pinned Rust toolchain
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         run: |
-          rustup toolchain install 1.82.0 --profile minimal --component rustfmt clippy
+          rustup toolchain install 1.82.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.82.0' >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "dakia-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-core"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-desktop"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -950,6 +950,7 @@ dependencies = [
  "secrecy",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing-subscriber",
  "url",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/DakiaMail/dakia-desktop"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ version = "0.3.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/DakiaMail/dakia-desktop"
-rust-version = "1.82"
+rust-version = "1.89"
 
 [workspace.dependencies]
 anyhow = "1.0"

--- a/README.md
+++ b/README.md
@@ -46,4 +46,7 @@ Build platform installers:
 npm run build
 ```
 
-See [docs/architecture.md](docs/architecture.md), [docs/providers.md](docs/providers.md), and [docs/releasing.md](docs/releasing.md).
+See [docs/architecture.md](docs/architecture.md),
+[docs/providers.md](docs/providers.md),
+[docs/testing-strategy.md](docs/testing-strategy.md), and
+[docs/releasing.md](docs/releasing.md).

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -62,13 +62,29 @@ const MAX_DOWNLOAD_COLLISION_SUFFIX_BYTES: usize = " (9999)".len();
 struct AppState {
     store: Store,
     data_dir: PathBuf,
-    classifier: Mutex<LocalEmailClassifier>,
+    classifier: Mutex<Box<dyn EmailClassifier>>,
     classification: Arc<ClassificationScheduler>,
     realtime: RealtimeSyncManager,
     remote_operation_slots: Arc<Semaphore>,
     mail_rebuilds: Mutex<HashMap<Uuid, MailRebuildProgress>>,
     account_operations: AccountOperationLocks,
     translation_downloads: Mutex<HashMap<String, Arc<AtomicBool>>>,
+}
+
+trait EmailClassifier: Send {
+    fn classify(
+        &mut self,
+        emails: &[String],
+    ) -> anyhow::Result<Vec<dakia_core::classification::ModelClassification>>;
+}
+
+impl EmailClassifier for LocalEmailClassifier {
+    fn classify(
+        &mut self,
+        emails: &[String],
+    ) -> anyhow::Result<Vec<dakia_core::classification::ModelClassification>> {
+        LocalEmailClassifier::classify(self, emails)
+    }
 }
 
 /// Serializes destructive and provider-backed work for one account without
@@ -1313,16 +1329,23 @@ mod message_content_repair_tests {
     use super::*;
     use dakia_core::AttachmentPresentation;
 
+    struct UnexpectedClassifier;
+
+    impl EmailClassifier for UnexpectedClassifier {
+        fn classify(
+            &mut self,
+            _emails: &[String],
+        ) -> anyhow::Result<Vec<dakia_core::classification::ModelClassification>> {
+            panic!("message-content loading must not invoke email classification")
+        }
+    }
+
     fn message_content_test_state(store: Store) -> Arc<AppState> {
-        let resources =
-            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("resources/email-classifier-v2");
         Arc::new(AppState {
             realtime: RealtimeSyncManager::new(store.clone()),
             store,
             data_dir: PathBuf::new(),
-            classifier: Mutex::new(
-                LocalEmailClassifier::from_dir(resources).expect("bundled test classifier"),
-            ),
+            classifier: Mutex::new(Box::new(UnexpectedClassifier)),
             classification: Arc::new(ClassificationScheduler::default()),
             mail_rebuilds: Mutex::new(HashMap::new()),
             account_operations: AccountOperationLocks::default(),
@@ -4025,7 +4048,7 @@ pub fn run() {
                     realtime: RealtimeSyncManager::new(store.clone()),
                     store,
                     data_dir,
-                    classifier: Mutex::new(classifier),
+                    classifier: Mutex::new(Box::new(classifier)),
                     classification: Arc::new(ClassificationScheduler::default()),
                     mail_rebuilds: Mutex::new(mail_rebuilds),
                     account_operations: AccountOperationLocks::default(),

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,6 +1,9 @@
 mod realtime;
 mod translation;
 
+#[cfg(test)]
+mod tauri_contracts_tests;
+
 use base64::{engine::general_purpose::STANDARD, Engine};
 use dakia_core::storage::MessageContentFetchAcquire;
 use dakia_core::{

--- a/apps/desktop/src-tauri/src/realtime.rs
+++ b/apps/desktop/src-tauri/src/realtime.rs
@@ -39,18 +39,18 @@ pub struct RealtimeSyncStatus {
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct MailArrival {
-    event_id: Uuid,
-    account_id: Uuid,
-    messages: Vec<MailSummary>,
-    detected_at: String,
+pub(crate) struct MailArrival {
+    pub(crate) event_id: Uuid,
+    pub(crate) account_id: Uuid,
+    pub(crate) messages: Vec<MailSummary>,
+    pub(crate) detected_at: String,
 }
 
 #[derive(Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
-struct MailHydrated {
-    account_id: Uuid,
-    message_id: String,
+pub(crate) struct MailHydrated {
+    pub(crate) account_id: Uuid,
+    pub(crate) message_id: String,
 }
 
 #[derive(Clone)]
@@ -406,6 +406,25 @@ struct HydrationResult {
     cancelled: bool,
 }
 
+async fn pending_hydration_event(
+    store: &Store,
+    account_id: Uuid,
+    outcome: &HydrationResult,
+) -> Option<MailHydrated> {
+    if outcome.cancelled || outcome.target.kind != HydrationKind::Pending {
+        return None;
+    }
+    let hydrated = outcome.result.as_ref().ok()?.as_ref()?;
+    let durable = store.message(&hydrated.id).await.ok().flatten()?;
+    if durable.account_id != account_id.to_string() {
+        return None;
+    }
+    Some(MailHydrated {
+        account_id,
+        message_id: hydrated.id.clone(),
+    })
+}
+
 #[derive(Clone)]
 struct HydrationContext {
     app: AppHandle,
@@ -685,23 +704,20 @@ async fn hydrate_after_sync(
         if outcome.cancelled {
             continue;
         }
+        if let Some(event) =
+            pending_hydration_event(&context.store, context.account.id, &outcome).await
+        {
+            tracing::info!(
+                account_id = %context.account.id,
+                message_id = %event.message_id,
+                hydration_ms = outcome.started.elapsed().as_millis(),
+                "new mail hydration complete"
+            );
+            let _ = context.app.emit("mail-hydrated", event);
+            notify_hydration_complete(&context.complete);
+            continue;
+        }
         match outcome.result {
-            Ok(Some(hydrated)) if outcome.target.kind == HydrationKind::Pending => {
-                tracing::info!(
-                    account_id = %context.account.id,
-                    message_id = %hydrated.id,
-                    hydration_ms = outcome.started.elapsed().as_millis(),
-                    "new mail hydration complete"
-                );
-                let _ = context.app.emit(
-                    "mail-hydrated",
-                    MailHydrated {
-                        account_id: context.account.id,
-                        message_id: hydrated.id,
-                    },
-                );
-                notify_hydration_complete(&context.complete);
-            }
             Ok(_) => {
                 context
                     .recent_failures
@@ -876,6 +892,13 @@ async fn fetch_and_cache_target(
     let message = service
         .fetch_message(account, &target.message.mailbox, target.message.uid as u32)
         .await?;
+    cache_hydrated_message(store, message).await
+}
+
+async fn cache_hydrated_message(
+    store: &Store,
+    message: MailSummary,
+) -> anyhow::Result<Option<MailSummary>> {
     if persist_display_cache(store, &message).await? {
         // Cache readiness is local state. Do not upsert the provider snapshot
         // here: a star/read operation may have finished while this body fetch
@@ -883,7 +906,10 @@ async fn fetch_and_cache_target(
         store
             .set_message_content_state(&message.id, "complete")
             .await?;
-        Ok(Some(message))
+        // Account removal can complete after the cache write but before event
+        // publication. Re-read the durable row so a late worker neither
+        // revives storage nor reports a hydration for a removed account.
+        Ok(store.message(&message.id).await?.map(|_| message))
     } else {
         Ok(None)
     }
@@ -1313,6 +1339,69 @@ mod tests {
             .unwrap());
         assert!(store.message(&local.id).await.unwrap().unwrap().is_flagged);
         assert!(store.starred_body(&local.id).await.unwrap().is_some());
+    }
+
+    #[tokio::test]
+    async fn late_pending_hydration_after_account_removal_caches_nothing_and_emits_nothing() {
+        let store = Store::in_memory().await.unwrap();
+        let account = dakia_core::AccountDraft {
+            email: "late-hydration@example.test".into(),
+            display_name: "Late hydration".into(),
+            provider_id: Some("fastmail".into()),
+            username: None,
+            imap_host: None,
+            imap_port: None,
+            imap_security: None,
+            smtp_host: None,
+            smtp_port: None,
+            smtp_security: None,
+            archive_mailbox: None,
+            spam_mailbox: None,
+        }
+        .into_account(dakia_core::provider::by_id("fastmail").unwrap());
+        store.save_account(&account).await.unwrap();
+
+        let mut fetched = message("removed-while-fetching");
+        fetched.account_id = account.id.to_string();
+        fetched.body_text = "late body".into();
+        let target = HydrationTarget {
+            kind: HydrationKind::Pending,
+            message: fetched.clone(),
+        };
+        store
+            .upsert_messages(std::slice::from_ref(&fetched))
+            .await
+            .unwrap();
+
+        let cached = cache_hydrated_message(&store, fetched).await.unwrap();
+        assert!(
+            cached.is_some(),
+            "the race must reach event publication with a completed cache"
+        );
+        store.delete_account(account.id).await.unwrap();
+        assert!(store.account(account.id).await.unwrap().is_none());
+        assert!(store
+            .message("removed-while-fetching")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .cached_message_content("removed-while-fetching")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(pending_hydration_event(
+            &store,
+            account.id,
+            &HydrationResult {
+                target,
+                started: Instant::now(),
+                result: Ok(cached),
+                cancelled: false,
+            },
+        )
+        .await
+        .is_none());
     }
 
     #[test]

--- a/apps/desktop/src-tauri/src/tauri_contracts_tests.rs
+++ b/apps/desktop/src-tauri/src/tauri_contracts_tests.rs
@@ -1,0 +1,189 @@
+use crate::realtime::{MailArrival, MailHydrated, RealtimeSyncStatus};
+use crate::{MessageContent, MessageContentCommandError, MessageContentErrorKind};
+use chrono::{DateTime, Utc};
+use dakia_core::{Attachment, AttachmentPresentation, MailSummary};
+use serde_json::{json, Value};
+use uuid::Uuid;
+
+fn fixture() -> Value {
+    serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../testdata/tauri-contracts/high-risk.json"
+    )))
+    .expect("Tauri contract fixture must be valid JSON")
+}
+
+fn fixture_message() -> MailSummary {
+    MailSummary {
+        id: "message-01".into(),
+        account_id: "0f452e8d-8d11-4643-944c-0e9f8f243311".into(),
+        mailbox: "INBOX".into(),
+        uid: 42,
+        message_id: None,
+        in_reply_to: None,
+        reference_ids: None,
+        thread_id: "thread-01".into(),
+        subject: "Quarterly update".into(),
+        from_name: Some("Mara Example".into()),
+        from_address: "mara@example.test".into(),
+        to_addresses: "alex@example.test".into(),
+        cc_addresses: String::new(),
+        bcc_addresses: String::new(),
+        reply_to_addresses: String::new(),
+        received_at: DateTime::parse_from_rfc3339("2026-07-30T09:15:00Z")
+            .expect("fixture time must be RFC 3339")
+            .with_timezone(&Utc),
+        snippet: "Quarterly update is ready.".into(),
+        body_text: "Quarterly update is ready.".into(),
+        body_html: None,
+        content_state: "headers_only".into(),
+        unsubscribe_kind: None,
+        unsubscribe_url: None,
+        is_read: false,
+        is_flagged: false,
+        has_attachments: false,
+        category: None,
+        classification_confidence: None,
+        classification_source: None,
+        classification_signals: String::new(),
+        attachments: Vec::new(),
+    }
+}
+
+#[test]
+fn message_content_success_and_error_envelopes_match_the_shared_fixture() {
+    let fixture = fixture();
+    let content = MessageContent {
+        body_text: "Quarterly update is ready.".into(),
+        body_html: None,
+        unsubscribe_kind: Some("web".into()),
+        attachments: vec![Attachment {
+            id: "attachment-01".into(),
+            message_id: "message-01".into(),
+            filename: "update.pdf".into(),
+            mime_type: "application/pdf".into(),
+            size_bytes: 4096,
+            is_inline: false,
+            presentation: AttachmentPresentation::Downloadable,
+            is_potentially_unsafe: false,
+        }],
+    };
+
+    assert_eq!(
+        serde_json::to_value(content).expect("message content must serialize for IPC"),
+        fixture["messageContent"]["success"]
+    );
+    assert_eq!(
+        serde_json::to_value(MessageContentCommandError {
+            kind: MessageContentErrorKind::ResourceLimit,
+        })
+        .expect("message-content error must serialize for IPC"),
+        fixture["messageContent"]["error"]
+    );
+    for (index, kind) in [
+        MessageContentErrorKind::ResourceLimit,
+        MessageContentErrorKind::Malformed,
+        MessageContentErrorKind::Undecodable,
+        MessageContentErrorKind::Unsupported,
+        MessageContentErrorKind::Transient,
+    ]
+    .into_iter()
+    .enumerate()
+    {
+        assert_eq!(
+            serde_json::to_value(MessageContentCommandError { kind })
+                .expect("message-content error variant must serialize"),
+            fixture["messageContent"]["errorVariants"][index]
+        );
+    }
+}
+
+#[test]
+fn provider_signature_inline_message_content_matches_the_shared_fixture() {
+    // provider-signature-inline is parsed from raw MIME into this shared contract
+    // by the core regression test before this native IPC serialization check.
+    let fixture = fixture();
+    assert_eq!(
+        fixture["realisticFixtureIds"]["providerSignature"],
+        "provider-signature-inline"
+    );
+    let content = MessageContent {
+        body_text: fixture["messageContent"]["providerSignature"]["body_text"]
+            .as_str()
+            .expect("provider body text must be a string")
+            .into(),
+        body_html: Some(
+            fixture["messageContent"]["providerSignature"]["body_html"]
+                .as_str()
+                .expect("provider HTML must be a string")
+                .into(),
+        ),
+        unsubscribe_kind: None,
+        attachments: vec![Attachment {
+            id: "provider-signature-pdf".into(),
+            message_id: "message-provider-signature".into(),
+            filename: "claim-documents.pdf".into(),
+            mime_type: "application/pdf".into(),
+            size_bytes: 3,
+            is_inline: false,
+            presentation: AttachmentPresentation::Downloadable,
+            is_potentially_unsafe: false,
+        }],
+    };
+
+    assert_eq!(
+        serde_json::to_value(content).expect("provider content must serialize for IPC"),
+        fixture["messageContent"]["providerSignature"]
+    );
+}
+
+#[test]
+fn mail_event_payloads_match_the_shared_fixture_casing_uuid_times_and_nulls() {
+    let fixture = fixture();
+    let account_id = Uuid::parse_str("0f452e8d-8d11-4643-944c-0e9f8f243311")
+        .expect("fixture account ID must be a UUID");
+    let arrival = MailArrival {
+        event_id: Uuid::parse_str("6e84311f-ff3a-4cbd-a037-a5bedc79f2f2")
+            .expect("fixture event ID must be a UUID"),
+        account_id,
+        messages: vec![fixture_message()],
+        detected_at: "2026-07-30T09:15:03Z".into(),
+    };
+    let hydrated = MailHydrated {
+        account_id,
+        message_id: "message-01".into(),
+    };
+    let idle = RealtimeSyncStatus {
+        account_id,
+        state: "idle".into(),
+        retry_at: None,
+        error_kind: None,
+    };
+    let retrying = RealtimeSyncStatus {
+        account_id,
+        state: "retrying".into(),
+        retry_at: Some("2026-07-30T09:20:00Z".into()),
+        error_kind: Some("connection".into()),
+    };
+
+    assert_eq!(
+        serde_json::to_value(arrival).expect("mail-arrived payload must serialize"),
+        fixture["events"]["mailArrived"]
+    );
+    assert_eq!(
+        serde_json::to_value(hydrated).expect("mail-hydrated payload must serialize"),
+        fixture["events"]["mailHydrated"]
+    );
+    assert_eq!(
+        json!({ "accountId": account_id }),
+        fixture["events"]["mailChanged"]
+    );
+    assert_eq!(
+        serde_json::to_value(idle).expect("idle sync state must serialize"),
+        fixture["events"]["mailSyncStateWithNulls"]
+    );
+    assert_eq!(
+        serde_json::to_value(retrying).expect("retrying sync state must serialize"),
+        fixture["events"]["mailSyncStateRetrying"]
+    );
+}

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dakia",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "identifier": "dev.dakia.mail",
   "build": {
     "beforeDevCommand": "npm run dev:desktop-web",

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -335,6 +335,56 @@ describe("App read state", () => {
     );
   });
 
+  it("updates every concrete duplicate copy instead of synthetic winner state", async () => {
+    const hiddenInbox = {
+      ...mocks.message,
+      id: "duplicate-inbox",
+      uid: 10,
+      message_id: "<duplicate@example.test>",
+      received_at: "2026-07-19T09:00:00Z",
+      is_read: false,
+      is_flagged: true,
+      has_attachments: true,
+    };
+    const visibleArchive = {
+      ...mocks.message,
+      id: "duplicate-archive",
+      uid: 11,
+      mailbox: "Archive",
+      message_id: "<duplicate@example.test>",
+      received_at: "2026-07-19T10:00:00Z",
+      is_read: true,
+      is_flagged: false,
+      has_attachments: false,
+    };
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages([visibleArchive, hiddenInbox]),
+      nextCursor: null,
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const row = await screen.findByText("Unread thread");
+    fireEvent.click(row.closest("button")!);
+    await waitFor(() =>
+      expect(mocks.api.setRead).toHaveBeenCalledWith(hiddenInbox.id, true),
+    );
+    expect(mocks.api.setRead).not.toHaveBeenCalledWith(visibleArchive.id, true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Remove star" }));
+    await waitFor(() => {
+      expect(mocks.api.setStarred).toHaveBeenCalledWith(hiddenInbox.id, false);
+      expect(mocks.api.setStarred).toHaveBeenCalledWith(
+        visibleArchive.id,
+        false,
+      );
+    });
+  });
+
   it("opens a conversation with its newest message focused", async () => {
     const older = {
       ...mocks.message,

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -27,7 +27,7 @@ import {
 } from "./mailActions";
 import { replyRecipients } from "./recipients";
 import { confirmNativeAction, showNativeMessage } from "./nativeFeedback";
-import { groupMessages } from "./threads";
+import { concreteThreadMessages, groupMessages } from "./threads";
 import { forwardBody, forwardSubject } from "./forward";
 import { formatReplyHistory } from "./replyHistory";
 import {
@@ -727,6 +727,7 @@ export default function App() {
     [smartSections],
   );
   useEffect(() => {
+    let disposed = false;
     let disposeAccount: () => void = () => undefined;
     let disposeSettings: () => void = () => undefined;
     let disposeNotifications: () => void = () => undefined;
@@ -758,14 +759,22 @@ export default function App() {
         })
         .catch(showError)
         .finally(() => setSyncStatus(undefined));
-    }).then((unlisten) => (disposeAccount = unlisten));
-    void onSettingsChanged(setAiSettings).then(
-      (unlisten) => (disposeSettings = unlisten),
-    );
+    }).then((unlisten) => {
+      if (disposed) unlisten();
+      else disposeAccount = unlisten;
+    });
+    void onSettingsChanged(setAiSettings).then((unlisten) => {
+      if (disposed) unlisten();
+      else disposeSettings = unlisten;
+    });
     void onNotificationSettingsChanged(setNotificationSettings).then(
-      (unlisten) => (disposeNotifications = unlisten),
+      (unlisten) => {
+        if (disposed) unlisten();
+        else disposeNotifications = unlisten;
+      },
     );
     return () => {
+      disposed = true;
       disposeAccount();
       disposeSettings();
       disposeNotifications();
@@ -816,6 +825,7 @@ export default function App() {
     };
   }, [removeAccountFromMain]);
   useEffect(() => {
+    let disposed = false;
     let dispose: () => void = () => undefined;
     void onMailIndexRebuilt(() => {
       setActive(undefined);
@@ -825,10 +835,17 @@ export default function App() {
         markSynced();
         setSyncStatus(undefined);
       });
-    }).then((unlisten) => (dispose = unlisten));
-    return () => dispose();
+    }).then((unlisten) => {
+      if (disposed) unlisten();
+      else dispose = unlisten;
+    });
+    return () => {
+      disposed = true;
+      dispose();
+    };
   }, [loadMessages]);
   useEffect(() => {
+    let disposed = false;
     let dispose: () => void = () => undefined;
     const showRebuildProgress = (progress: MailRebuildProgress) => {
       const account = accounts.find((item) => item.id === progress.accountId);
@@ -863,22 +880,32 @@ export default function App() {
       .mailRebuildStatus()
       .then(([progress]) => progress && showRebuildProgress(progress))
       .catch(showError);
-    void onMailRebuildProgress(showRebuildProgress).then(
-      (unlisten) => (dispose = unlisten),
-    );
-    return () => dispose();
+    void onMailRebuildProgress(showRebuildProgress).then((unlisten) => {
+      if (disposed) unlisten();
+      else dispose = unlisten;
+    });
+    return () => {
+      disposed = true;
+      dispose();
+    };
   }, [accounts, loadMessages]);
   useEffect(() => {
+    let disposed = false;
     let unlisten: () => void = () => undefined;
     void onComposeSent(() => {
       showStatus(t("feedback.sent"));
       void loadMessages();
     }).then((dispose) => {
-      unlisten = dispose;
+      if (disposed) dispose();
+      else unlisten = dispose;
     });
-    return () => unlisten();
+    return () => {
+      disposed = true;
+      unlisten();
+    };
   }, [loadMessages, showStatus, t]);
   useEffect(() => {
+    let disposed = false;
     let unlisten: () => void = () => undefined;
     void onOutboxChanged((event) => {
       setOutbox((current) =>
@@ -890,9 +917,13 @@ export default function App() {
           : current.filter((message) => message.id !== event.id),
       );
     }).then((dispose) => {
-      unlisten = dispose;
+      if (disposed) dispose();
+      else unlisten = dispose;
     });
-    return () => unlisten();
+    return () => {
+      disposed = true;
+      unlisten();
+    };
   }, []);
   useEffect(() => {
     if (!activeAccounts.length) return;
@@ -973,22 +1004,38 @@ export default function App() {
 
   useEffect(() => {
     const matchingThread = active
-      ? displayedThreads.find((thread) =>
-          thread.messages.some((message) => message.id === active.id),
+      ? displayedThreads.find(
+          (thread) =>
+            thread.messages.some((message) => message.id === active.id) ||
+            thread.id ===
+              `${active.account_id}:${active.thread_id || active.id}`,
         )
       : undefined;
     if (matchingThread) setActiveThreadSnapshot(matchingThread);
     setActive((current) => {
       if (!current) return current;
+      const thread = displayedThreads.find(
+        (item) =>
+          item.messages.some((message) => message.id === current.id) ||
+          item.id ===
+            `${current.account_id}:${current.thread_id || current.id}`,
+      );
+      if (!thread) return current;
       return (
-        displayedThreads
-          .flatMap((thread) => thread.messages)
-          .find((message) => message.id === current.id) ?? current
+        thread.messages.find((message) => message.id === current.id) ??
+        thread.messages.find(
+          (message) =>
+            current.message_id &&
+            message.message_id?.toLowerCase() ===
+              current.message_id.toLowerCase(),
+        ) ??
+        thread.latest
       );
     });
   }, [displayedThreads]);
 
   useEffect(() => {
+    let disposed = false;
     let dispose: () => void = () => undefined;
     const openNotification = async (extra: Record<string, unknown>) => {
       const currentWindow = getCurrentWindow();
@@ -1028,16 +1075,24 @@ export default function App() {
       ),
       onDesktopNotificationAction(openNotification),
     ]).then((listeners) => {
-      dispose = () => listeners.forEach((unlisten) => unlisten());
+      const unlistenAll = () => listeners.forEach((unlisten) => unlisten());
+      if (disposed) unlistenAll();
+      else dispose = unlistenAll;
     });
-    return () => dispose();
+    return () => {
+      disposed = true;
+      dispose();
+    };
   }, [accounts]);
 
   const activeThread = useMemo(
     () =>
       active
-        ? (displayedThreads.find((thread) =>
-            thread.messages.some((message) => message.id === active.id),
+        ? (displayedThreads.find(
+            (thread) =>
+              thread.messages.some((message) => message.id === active.id) ||
+              thread.id ===
+                `${active.account_id}:${active.thread_id || active.id}`,
           ) ??
           (activeThreadSnapshot?.messages.some(
             (message) => message.id === active.id,
@@ -1330,7 +1385,7 @@ export default function App() {
           : `${prefix} ${replyMessage.subject}`,
         body: replyHistory.body,
         bodyHtml: replyHistory.bodyHtml,
-        inReplyTo: replyMessage.message_id,
+        inReplyTo: replyMessage.message_id ?? undefined,
         references: [replyMessage.reference_ids, replyMessage.message_id]
           .filter(Boolean)
           .join(" "),
@@ -1400,7 +1455,8 @@ export default function App() {
   const toggleThreadStar = async (thread: MailThread, flagged: boolean) => {
     if (actionBusyRef.current) return;
     actionBusyRef.current = true;
-    const previous = thread.messages.map((message) => ({
+    const sourceMessages = concreteThreadMessages(thread);
+    const previous = sourceMessages.map((message) => ({
       id: message.id,
       is_flagged: message.is_flagged,
     }));
@@ -1411,6 +1467,9 @@ export default function App() {
       current.map((item) => ({
         ...item,
         messages: item.messages.map((message) => updateFlag(message, flagged)),
+        sourceMessages: item.sourceMessages?.map((message) =>
+          updateFlag(message, flagged),
+        ),
         latest: updateFlag(item.latest, flagged),
       })),
     );
@@ -1421,6 +1480,9 @@ export default function App() {
             const sectionThreads = current[id].threads.map((item) => ({
               ...item,
               messages: item.messages.map((message) =>
+                updateFlag(message, flagged),
+              ),
+              sourceMessages: item.sourceMessages?.map((message) =>
                 updateFlag(message, flagged),
               ),
               latest: updateFlag(item.latest, flagged),
@@ -1434,7 +1496,9 @@ export default function App() {
                     ? sectionThreads
                     : sectionThreads.filter(
                         (item) =>
-                          !item.messages.some((message) => message.is_flagged),
+                          !concreteThreadMessages(item).some(
+                            (message) => message.is_flagged,
+                          ),
                       ),
               },
             ];
@@ -1449,12 +1513,15 @@ export default function App() {
             messages: current.messages.map((message) =>
               updateFlag(message, flagged),
             ),
+            sourceMessages: current.sourceMessages?.map((message) =>
+              updateFlag(message, flagged),
+            ),
             latest: updateFlag(current.latest, flagged),
           }
         : current,
     );
     const results = await Promise.allSettled(
-      thread.messages.map((message) => api.setStarred(message.id, flagged)),
+      sourceMessages.map((message) => api.setStarred(message.id, flagged)),
     );
     const failed = new Set(
       results.flatMap((result, index) =>
@@ -1471,6 +1538,7 @@ export default function App() {
         current.map((item) => ({
           ...item,
           messages: item.messages.map(restoreFlag),
+          sourceMessages: item.sourceMessages?.map(restoreFlag),
           latest: restoreFlag(item.latest),
         })),
       );
@@ -1480,6 +1548,7 @@ export default function App() {
           ? {
               ...current,
               messages: current.messages.map(restoreFlag),
+              sourceMessages: current.sourceMessages?.map(restoreFlag),
               latest: restoreFlag(current.latest),
             }
           : current,
@@ -1499,7 +1568,7 @@ export default function App() {
     read: boolean,
     options?: { silent?: boolean },
   ) => {
-    const targets = thread.messages.filter(
+    const targets = concreteThreadMessages(thread).filter(
       (message) => message.is_read !== read,
     );
     if (!targets.length) return;
@@ -2140,14 +2209,18 @@ function updateThreadReadState(
   const messages = thread.messages.map((message) =>
     updateMessageReadState(message, ids, read),
   );
+  const sourceMessages = thread.sourceMessages?.map((message) =>
+    updateMessageReadState(message, ids, read),
+  );
   const latest =
     messages.find((message) => message.id === thread.latest.id) ??
     thread.latest;
   return {
     ...thread,
     messages,
+    sourceMessages,
     latest,
-    unread: messages.some((message) => !message.is_read),
+    unread: (sourceMessages ?? messages).some((message) => !message.is_read),
   };
 }
 
@@ -2169,14 +2242,18 @@ function restoreThreadReadState(
   const messages = thread.messages.map((message) =>
     restoreMessageReadState(message, failed, previous),
   );
+  const sourceMessages = thread.sourceMessages?.map((message) =>
+    restoreMessageReadState(message, failed, previous),
+  );
   const latest =
     messages.find((message) => message.id === thread.latest.id) ??
     thread.latest;
   return {
     ...thread,
     messages,
+    sourceMessages,
     latest,
-    unread: messages.some((message) => !message.is_read),
+    unread: (sourceMessages ?? messages).some((message) => !message.is_read),
   };
 }
 

--- a/apps/desktop/src/UtilityApps.tsx
+++ b/apps/desktop/src/UtilityApps.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import {
   disable as disableAutostart,
@@ -118,6 +118,8 @@ export function SettingsWindowApp() {
   const [realtimeStatuses, setRealtimeStatuses] = useState<
     RealtimeSyncStatus[]
   >([]);
+  const aiPersistenceQueueRef = useRef(Promise.resolve());
+  const aiSettingsGenerationRef = useRef(0);
 
   useEffect(() => {
     document.title = t("settings.title");
@@ -182,11 +184,19 @@ export function SettingsWindowApp() {
   }, [t]);
 
   const updateAi = (value: AiSettings) => {
-    if (value.apiKey !== ai.apiKey)
-      void api.saveAiApiKey(value.apiKey).catch(showError);
+    const generation = ++aiSettingsGenerationRef.current;
+    const apiKeyChanged = value.apiKey !== ai.apiKey;
     setAi(value);
     localStorage.setItem("dakia.ai", JSON.stringify({ ...value, apiKey: "" }));
-    void notifySettingsChanged(value);
+    aiPersistenceQueueRef.current = aiPersistenceQueueRef.current
+      .catch(() => undefined)
+      .then(async () => {
+        if (apiKeyChanged) await api.saveAiApiKey(value.apiKey);
+        if (generation === aiSettingsGenerationRef.current) {
+          await notifySettingsChanged({ ...value, apiKey: "" });
+        }
+      });
+    void aiPersistenceQueueRef.current.catch(showError);
   };
 
   const updateNotifications = (value: NotificationSettings) => {

--- a/apps/desktop/src/components/MailList.tsx
+++ b/apps/desktop/src/components/MailList.tsx
@@ -45,6 +45,7 @@ import type {
   MailThread,
   SyncStatus,
 } from "../types";
+import { concreteThreadMessages } from "../threads";
 import { EmptyState } from "./EmptyState";
 
 type Props = {
@@ -413,7 +414,6 @@ function ThreadRows({
   onOpen,
   onSelect,
   onCategorize,
-  onToggleStar,
   onReplyThread,
   onForwardThread,
   onActionThread,
@@ -428,12 +428,14 @@ function ThreadRows({
     y: number;
   }>();
   const contextThread = context?.thread;
-  const isSpam = contextThread?.messages.some(
-    (message) => message.mailbox.split("::", 1)[0] === "Spam",
-  );
-  const isStarred = contextThread?.messages.some(
-    (message) => message.is_flagged,
-  );
+  const isSpam =
+    contextThread &&
+    concreteThreadMessages(contextThread).some(
+      (message) => message.mailbox.split("::", 1)[0] === "Spam",
+    );
+  const isStarred =
+    contextThread &&
+    concreteThreadMessages(contextThread).some((message) => message.is_flagged);
   const isUnread = contextThread?.unread ?? false;
   useEffect(() => {
     if (!context) return;
@@ -565,16 +567,8 @@ function ThreadRows({
       </Menu>
       {threads.map((thread) => {
         const message = thread.latest;
-        const starredMessage = [...thread.messages]
-          .reverse()
-          .find((item) => item.is_flagged);
-        const starTarget =
-          starredMessage ??
-          [...thread.messages]
-            .reverse()
-            .find((item) => item.mailbox === "INBOX") ??
-          message;
-        const pending = thread.messages
+        const sourceMessages = concreteThreadMessages(thread);
+        const pending = sourceMessages
           .map((item) => pendingActions[item.id])
           .find(Boolean);
         return (
@@ -643,25 +637,25 @@ function ThreadRows({
                 role="button"
                 tabIndex={0}
                 aria-label={t(
-                  thread.messages.some((item) => item.is_flagged)
+                  sourceMessages.some((item) => item.is_flagged)
                     ? "actions.unstar"
                     : "actions.star",
                 )}
-                data-active={thread.messages.some((item) => item.is_flagged)}
+                data-active={sourceMessages.some((item) => item.is_flagged)}
                 onClick={(event) => {
                   event.stopPropagation();
-                  onToggleStar(
-                    starTarget,
-                    !thread.messages.some((item) => item.is_flagged),
+                  onToggleStarThread(
+                    thread,
+                    !sourceMessages.some((item) => item.is_flagged),
                   );
                 }}
                 onKeyDown={(event) => {
                   if (event.key === "Enter" || event.key === " ") {
                     event.preventDefault();
                     event.stopPropagation();
-                    onToggleStar(
-                      starTarget,
-                      !thread.messages.some((item) => item.is_flagged),
+                    onToggleStarThread(
+                      thread,
+                      !sourceMessages.some((item) => item.is_flagged),
                     );
                   }
                 }}
@@ -669,7 +663,7 @@ function ThreadRows({
                 <IconStar
                   size={15}
                   fill={
-                    thread.messages.some((item) => item.is_flagged)
+                    sourceMessages.some((item) => item.is_flagged)
                       ? "currentColor"
                       : "none"
                   }

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -10,7 +10,8 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import "../i18n";
 import { api, MessageContentError } from "../api";
 import freshdeskReplySection from "../test/fixtures/freshdesk-reply-section.html?raw";
-import type { MailSummary } from "../types";
+import type { MailSummary, MessageContent } from "../types";
+import highRiskContract from "../../testdata/tauri-contracts/high-risk.json";
 import { Reader } from "./Reader";
 
 const translationMocks = vi.hoisted(() => ({
@@ -470,6 +471,35 @@ describe("Reader unsubscribe action", () => {
       }),
     );
     expect(screen.queryByLabelText("Has attachments")).toBeNull();
+  });
+
+  it("renders provider-signature-inline shared message content", async () => {
+    expect(highRiskContract.realisticFixtureIds.providerSignature).toBe(
+      "provider-signature-inline",
+    );
+    vi.mocked(api.content).mockResolvedValue(
+      highRiskContract.messageContent.providerSignature as MessageContent,
+    );
+    render(
+      <MantineProvider>
+        <Reader {...props} message={{ ...message, has_attachments: true }} />
+      </MantineProvider>,
+    );
+
+    expect(await screen.findByText("claim-documents.pdf")).toBeVisible();
+    expect(screen.queryByText("image001.png")).toBeNull();
+    const renderedMessage = await screen.findByRole("document", {
+      name: "Weekly notes",
+    });
+    const emailSurface = renderedMessage.shadowRoot
+      ?.firstElementChild as HTMLElement | null;
+    const emailRoot = emailSurface?.shadowRoot;
+    expect(emailRoot?.querySelector("img")?.getAttribute("src")).toBe(
+      "data:image/png;base64,iVBORw0KGgo=",
+    );
+    expect(emailRoot?.textContent).toContain(
+      "Fictional confidential-message notice.",
+    );
   });
 
   it("lists returned downloadable attachments and saves all only when there are multiple", async () => {

--- a/apps/desktop/src/mailActions.test.ts
+++ b/apps/desktop/src/mailActions.test.ts
@@ -71,6 +71,33 @@ describe("mail action state", () => {
     ).toEqual(["INBOX"]);
   });
 
+  it("preserves hidden duplicate locators as action targets", () => {
+    const visibleArchive = {
+      ...message("visible"),
+      mailbox: "Archive",
+      message_id: "<same@example.test>",
+    };
+    const hiddenInbox = {
+      ...message("hidden"),
+      mailbox: "INBOX",
+      message_id: "<same@example.test>",
+    };
+    const thread: MailThread = {
+      id: "account:thread",
+      messages: [visibleArchive],
+      sourceMessages: [hiddenInbox, visibleArchive],
+      latest: visibleArchive,
+      unread: false,
+      hasAttachments: false,
+      participants: [],
+    };
+    expect(
+      conversationActionMessages(thread, "INBOX", "archive").map(
+        (item) => item.id,
+      ),
+    ).toEqual(["hidden"]);
+  });
+
   it("treats discovered Sent folders as Sent without acting on them", () => {
     const inbox = message("1");
     const sent = { ...message("2"), mailbox: "Sent::Sent Messages" };

--- a/apps/desktop/src/mailActions.ts
+++ b/apps/desktop/src/mailActions.ts
@@ -1,4 +1,5 @@
 import type { MailSummary, MailThread } from "./types";
+import { concreteThreadMessages } from "./threads";
 
 export type MailAction = "archive" | "spam" | "not_spam" | "trash";
 export type MailActionPhase = "exiting" | "restoring";
@@ -20,37 +21,38 @@ export function conversationActionMessages(
   view: string,
   action: MailAction,
 ) {
+  const messages = concreteThreadMessages(thread);
   if (action === "archive") {
     // Archiving removes only the Inbox label/copy. Sent history and already
     // archived members are reader context, not action targets.
-    return thread.messages.filter(
+    return messages.filter(
       (message) => mailboxFamily(message.mailbox) === "INBOX",
     );
   }
   if (action === "not_spam") {
-    return thread.messages.filter(
+    return messages.filter(
       (message) => mailboxFamily(message.mailbox) === "Spam",
     );
   }
   if (action === "trash") {
-    return thread.messages.filter(
+    return messages.filter(
       (message) =>
         !["Drafts", "Trash"].includes(mailboxFamily(message.mailbox)),
     );
   }
   if (view === "INBOX") {
-    return thread.messages.filter(
+    return messages.filter(
       (message) => mailboxFamily(message.mailbox) === "INBOX",
     );
   }
   if (view && !["unread", "starred"].includes(view)) {
-    return thread.messages.filter(
+    return messages.filter(
       (message) =>
         mailboxFamily(message.mailbox) === view &&
         !["Sent", "Drafts"].includes(mailboxFamily(message.mailbox)),
     );
   }
-  return thread.messages.filter(
+  return messages.filter(
     (message) =>
       !["Sent", "Drafts", "Spam", "Trash"].includes(
         mailboxFamily(message.mailbox),

--- a/apps/desktop/src/nativeWindows.ts
+++ b/apps/desktop/src/nativeWindows.ts
@@ -245,7 +245,8 @@ export async function notifyAccountUpdated(account: Account) {
 }
 
 export async function notifySettingsChanged(settings: AiSettings) {
-  if (isTauri()) await emitTo("main", "settings-changed", settings);
+  if (isTauri())
+    await emitTo("main", "settings-changed", { ...settings, apiKey: "" });
 }
 
 export async function notifyNotificationSettingsChanged(

--- a/apps/desktop/src/tauriContracts.test.ts
+++ b/apps/desktop/src/tauriContracts.test.ts
@@ -1,0 +1,252 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import fixture from "../testdata/tauri-contracts/high-risk.json";
+
+const eventMocks = vi.hoisted(() => ({
+  emitTo: vi.fn(),
+  listen: vi.fn(),
+}));
+const apiMocks = vi.hoisted(() => ({
+  channels: [] as Array<{ onmessage?: (message: unknown) => void }>,
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: apiMocks.invoke,
+  Channel: class {
+    onmessage?: (message: unknown) => void;
+
+    constructor() {
+      apiMocks.channels.push(this);
+    }
+  },
+}));
+
+vi.mock("@tauri-apps/api/event", () => eventMocks);
+vi.mock("@tauri-apps/api/window", () => ({ getCurrentWindow: vi.fn() }));
+vi.mock("@tauri-apps/api/webviewWindow", () => ({
+  getAllWebviewWindows: vi.fn(),
+  WebviewWindow: vi.fn(),
+}));
+
+type ListenHandler = (event: { payload: unknown }) => void;
+
+function decoded<T>(value: unknown): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+describe("Tauri payload contracts", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    apiMocks.channels.length = 0;
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  });
+
+  it("decodes native MessageContent success and sanitizes its error envelope", async () => {
+    apiMocks.invoke.mockImplementation((command: string) => {
+      if (command === fixture.commands.messageContent.command) {
+        return Promise.resolve(decoded(fixture.messageContent.success));
+      }
+      return Promise.resolve(undefined);
+    });
+    const { api } = await import("./api");
+
+    await expect(
+      api.content(fixture.commands.messageContent.arguments.messageId),
+    ).resolves.toEqual(fixture.messageContent.success);
+    expect(apiMocks.invoke).toHaveBeenCalledWith(
+      fixture.commands.messageContent.command,
+      fixture.commands.messageContent.arguments,
+    );
+
+    apiMocks.invoke.mockRejectedValueOnce(
+      decoded(fixture.messageContent.error),
+    );
+    await expect(
+      api.content(fixture.commands.messageContent.arguments.messageId),
+    ).rejects.toMatchObject({
+      ...fixture.messageContent.error,
+      retryable: false,
+      message: "Message content could not be loaded",
+    });
+
+    for (const variant of fixture.messageContent.errorVariants) {
+      apiMocks.invoke.mockRejectedValueOnce(decoded(variant));
+      await expect(
+        api.content(fixture.commands.messageContent.arguments.messageId),
+      ).rejects.toMatchObject({
+        kind: variant.kind,
+        retryable: variant.kind === "transient",
+        message: "Message content could not be loaded",
+      });
+    }
+  });
+
+  it("decodes provider-signature-inline through the native MessageContent boundary", async () => {
+    expect(fixture.realisticFixtureIds.providerSignature).toBe(
+      "provider-signature-inline",
+    );
+    apiMocks.invoke.mockResolvedValueOnce(
+      decoded(fixture.messageContent.providerSignature),
+    );
+    const { api } = await import("./api");
+
+    await expect(
+      api.content(fixture.commands.messageContent.arguments.messageId),
+    ).resolves.toEqual(fixture.messageContent.providerSignature);
+  });
+
+  it("uses the fixture's exact command names, top-level argument keys, and sync Channel", async () => {
+    const progress = vi.fn();
+    apiMocks.invoke.mockImplementation(
+      (command: string, arguments_: Record<string, unknown>) => {
+        if (command === fixture.commands.syncAccount.command) {
+          (
+            arguments_.onProgress as { onmessage?: (value: unknown) => void }
+          ).onmessage?.({ phase: "complete", completed: 1, total: 1 });
+        }
+        return Promise.resolve(undefined);
+      },
+    );
+    const { api } = await import("./api");
+    const commands = fixture.commands;
+
+    await api.hydrateMessage(commands.hydrateMessage.arguments.messageId);
+    await api.setCategory(
+      commands.setMessageCategory.arguments.messageId,
+      commands.setMessageCategory.arguments.category,
+    );
+    await api.setStarred(
+      commands.setMessageStarred.arguments.messageId,
+      commands.setMessageStarred.arguments.starred,
+    );
+    await api.setRead(
+      commands.setMessageRead.arguments.messageId,
+      commands.setMessageRead.arguments.read,
+    );
+    await api.action(
+      commands.applyMailboxAction.arguments.accountId,
+      commands.applyMailboxAction.arguments.mailbox,
+      commands.applyMailboxAction.arguments.uid,
+      commands.applyMailboxAction.arguments.action as "archive",
+    );
+    await api.sync(commands.syncAccount.arguments.accountId, progress);
+
+    expect(apiMocks.invoke.mock.calls).toEqual([
+      [commands.hydrateMessage.command, commands.hydrateMessage.arguments],
+      [
+        commands.setMessageCategory.command,
+        commands.setMessageCategory.arguments,
+      ],
+      [
+        commands.setMessageStarred.command,
+        commands.setMessageStarred.arguments,
+      ],
+      [commands.setMessageRead.command, commands.setMessageRead.arguments],
+      [
+        commands.applyMailboxAction.command,
+        commands.applyMailboxAction.arguments,
+      ],
+      [
+        commands.syncAccount.command,
+        {
+          ...commands.syncAccount.arguments,
+          onProgress: apiMocks.channels[0],
+        },
+      ],
+    ]);
+    expect(commands.syncAccount.arguments.onProgress).toBe("__TAURI_CHANNEL__");
+    expect(progress).toHaveBeenCalledWith({
+      phase: "complete",
+      completed: 1,
+      total: 1,
+    });
+  });
+
+  it("delivers camelCase event envelopes while preserving native null fields", async () => {
+    const handlers = new Map<string, ListenHandler>();
+    eventMocks.listen.mockImplementation(
+      async (event: string, handler: ListenHandler) => {
+        handlers.set(event, handler);
+        return vi.fn();
+      },
+    );
+    const { onMailArrived, onMailChanged, onMailHydrated, onMailSyncState } =
+      await import("./nativeWindows");
+    const arrived = vi.fn();
+    const changed = vi.fn();
+    const hydrated = vi.fn();
+    const syncStates = vi.fn();
+
+    await Promise.all([
+      onMailArrived(arrived),
+      onMailChanged(changed),
+      onMailHydrated(hydrated),
+      onMailSyncState(syncStates),
+    ]);
+
+    handlers.get("mail-arrived")?.({
+      payload: decoded(fixture.events.mailArrived),
+    });
+    handlers.get("mail-changed")?.({
+      payload: decoded(fixture.events.mailChanged),
+    });
+    handlers.get("mail-hydrated")?.({
+      payload: decoded(fixture.events.mailHydrated),
+    });
+    handlers.get("mail-sync-state")?.({
+      payload: decoded(fixture.events.mailSyncStateWithNulls),
+    });
+    handlers.get("mail-sync-state")?.({
+      payload: decoded(fixture.events.mailSyncStateRetrying),
+    });
+
+    expect(arrived).toHaveBeenCalledWith(fixture.events.mailArrived);
+    expect(changed).toHaveBeenCalledWith(fixture.events.mailChanged.accountId);
+    expect(hydrated).toHaveBeenCalledWith(fixture.events.mailHydrated);
+    expect(syncStates).toHaveBeenNthCalledWith(
+      1,
+      fixture.events.mailSyncStateWithNulls,
+    );
+    expect(syncStates).toHaveBeenNthCalledWith(
+      2,
+      fixture.events.mailSyncStateRetrying,
+    );
+    expect(fixture.events.mailSyncStateWithNulls).toHaveProperty(
+      "retryAt",
+      null,
+    );
+    expect(fixture.events.mailSyncStateWithNulls).toHaveProperty(
+      "errorKind",
+      null,
+    );
+  });
+
+  it("never broadcasts an AI API key across native windows", async () => {
+    const { notifySettingsChanged } = await import("./nativeWindows");
+    await notifySettingsChanged({
+      provider: "openai",
+      baseUrl: "https://api.example.test/",
+      model: "example-model",
+      apiKey: "production-shaped-secret",
+      executable: "",
+      modelPath: "",
+    });
+
+    expect(eventMocks.emitTo).toHaveBeenCalledWith(
+      "main",
+      "settings-changed",
+      expect.objectContaining({ apiKey: "" }),
+    );
+    expect(JSON.stringify(eventMocks.emitTo.mock.calls)).not.toContain(
+      "production-shaped-secret",
+    );
+  });
+});

--- a/apps/desktop/src/threads.test.ts
+++ b/apps/desktop/src/threads.test.ts
@@ -57,4 +57,141 @@ describe("groupMessages", () => {
       ]),
     ).toHaveLength(2);
   });
+
+  it("is invariant while retaining concrete duplicate locators without synthetic row state", () => {
+    const messages = permutationFixture(17);
+    const expected = groupMessages(messages);
+
+    for (let permutation = 0; permutation < 48; permutation += 1) {
+      expect(groupMessages(shuffle(messages, 1000 + permutation))).toEqual(
+        expected,
+      );
+    }
+
+    const sharedThread = expected.find(
+      (thread) => thread.id === "account-1:shared-thread",
+    )!;
+    expect(expected.map((thread) => thread.latest.id)).toEqual([
+      "other-thread-17",
+      "account-2-copy-17",
+      "shared-tie-b-17",
+    ]);
+    expect(sharedThread.messages.map((item) => item.id)).toEqual([
+      "shared-early-17",
+      "shared-copy-new-17",
+      "shared-tie-a-17",
+      "shared-tie-b-17",
+    ]);
+    expect(sharedThread.messages[1]).toMatchObject({
+      id: "shared-copy-new-17",
+      is_read: true,
+      has_attachments: false,
+    });
+    expect(sharedThread.sourceMessages?.map((item) => item.id)).toContain(
+      "shared-copy-old-17",
+    );
+    expect(sharedThread.unread).toBe(true);
+    expect(sharedThread.hasAttachments).toBe(true);
+    expect(sharedThread.participants).toEqual(["Amy Example", "Zoe Example"]);
+    expect(
+      expected.find((thread) => thread.id === "account-2:shared-thread"),
+    ).toMatchObject({
+      messages: [{ id: "account-2-copy-17" }],
+    });
+  });
+
+  it("keeps grouping, deduplication, ordering, and aggregates invariant across fixed seeds", () => {
+    for (const seed of [1, 19, 73, 211]) {
+      const messages = permutationFixture(seed);
+      const expected = groupMessages(messages);
+
+      for (let permutation = 0; permutation < 24; permutation += 1) {
+        expect(
+          groupMessages(shuffle(messages, seed * 100 + permutation)),
+        ).toEqual(expected);
+      }
+    }
+  });
 });
+
+function permutationFixture(seed: number): MailSummary[] {
+  const suffix = String(seed);
+  return [
+    message({
+      id: `shared-copy-old-${suffix}`,
+      uid: 10,
+      thread_id: "shared-thread",
+      message_id: `<COPY-${suffix}@example.com>`,
+      from_name: "Zoe Example",
+      received_at: "2026-07-19T10:00:00Z",
+      is_read: false,
+      has_attachments: true,
+    }),
+    message({
+      id: `shared-copy-new-${suffix}`,
+      uid: 11,
+      thread_id: "shared-thread",
+      message_id: `<copy-${suffix}@example.com>`,
+      from_name: "Zoe Example",
+      received_at: "2026-07-19T12:00:00Z",
+      is_read: true,
+      has_attachments: false,
+    }),
+    message({
+      id: `shared-early-${suffix}`,
+      uid: 12,
+      thread_id: "shared-thread",
+      message_id: `<early-${suffix}@example.com>`,
+      from_name: "Amy Example",
+      received_at: "2026-07-19T09:00:00Z",
+    }),
+    message({
+      id: `shared-tie-b-${suffix}`,
+      uid: 13,
+      thread_id: "shared-thread",
+      message_id: `<tie-b-${suffix}@example.com>`,
+      from_name: "Amy Example",
+      received_at: "2026-07-19T13:00:00Z",
+    }),
+    message({
+      id: `shared-tie-a-${suffix}`,
+      uid: 14,
+      thread_id: "shared-thread",
+      message_id: `<tie-a-${suffix}@example.com>`,
+      from_name: "Amy Example",
+      received_at: "2026-07-19T13:00:00Z",
+    }),
+    message({
+      id: `account-2-copy-${suffix}`,
+      account_id: "account-2",
+      uid: 15,
+      thread_id: "shared-thread",
+      message_id: `<COPY-${suffix}@example.com>`,
+      received_at: "2026-07-19T14:00:00Z",
+    }),
+    message({
+      id: `other-thread-${suffix}`,
+      uid: 16,
+      thread_id: "other-thread",
+      message_id: `<other-${suffix}@example.com>`,
+      received_at: "2026-07-19T15:00:00Z",
+    }),
+  ];
+}
+
+function shuffle<T>(values: readonly T[], seed: number): T[] {
+  const result = [...values];
+  let state = seed >>> 0;
+  const next = () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return state >>> 0;
+  };
+
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const other = next() % (index + 1);
+    [result[index], result[other]] = [result[other], result[index]];
+  }
+  return result;
+}

--- a/apps/desktop/src/threads.ts
+++ b/apps/desktop/src/threads.ts
@@ -10,41 +10,89 @@ export function groupMessages(messages: MailSummary[]): MailThread[] {
   return [...grouped.entries()]
     .map(([id, threadMessages]) => {
       const deduplicated = deduplicateCopies(threadMessages).sort(
-        (left, right) =>
-          new Date(left.received_at).getTime() -
-          new Date(right.received_at).getTime(),
+        compareMessagesByReceivedAt,
       );
       const latest = deduplicated[deduplicated.length - 1];
+      const sourceMessages = [...threadMessages].sort(
+        compareMessagesByReceivedAt,
+      );
       return {
         id,
         messages: deduplicated,
+        sourceMessages,
         latest,
-        unread: deduplicated.some((message) => !message.is_read),
-        hasAttachments: deduplicated.some((message) => message.has_attachments),
+        unread: sourceMessages.some((message) => !message.is_read),
+        hasAttachments: sourceMessages.some(
+          (message) => message.has_attachments,
+        ),
         participants: unique(
-          deduplicated.map(
+          sourceMessages.map(
             (message) => message.from_name || message.from_address,
           ),
         ),
       };
     })
-    .sort(
-      (left, right) =>
-        new Date(right.latest.received_at).getTime() -
-        new Date(left.latest.received_at).getTime(),
-    );
+    .sort((left, right) => {
+      const latestComparison = compareMessagesByReceivedAt(
+        right.latest,
+        left.latest,
+      );
+      return latestComparison || compareStrings(left.id, right.id);
+    });
 }
 
-function deduplicateCopies(messages: MailSummary[]) {
-  const seen = new Set<string>();
-  return messages.filter((message) => {
+function deduplicateCopies(messages: MailSummary[]): MailSummary[] {
+  const copiesByMessageId = new Map<string, MailSummary[]>();
+  for (const message of messages) {
     const key = message.message_id?.toLowerCase() || message.id;
-    if (seen.has(key)) return false;
-    seen.add(key);
-    return true;
-  });
+    copiesByMessageId.set(key, [
+      ...(copiesByMessageId.get(key) ?? []),
+      message,
+    ]);
+  }
+
+  return [...copiesByMessageId.values()].map(mergeCopies);
+}
+
+/**
+ * A duplicate's newest valid received time is its canonical display
+ * representation. Concrete copies remain on sourceMessages so actions never
+ * lose the mailbox/UID locator or manufacture state on the winning row.
+ */
+function mergeCopies(copies: MailSummary[]): MailSummary {
+  return [...copies].sort(compareMessagesByReceivedAt).at(-1)!;
+}
+
+export function concreteThreadMessages(thread: MailThread): MailSummary[] {
+  return thread.sourceMessages ?? thread.messages;
+}
+
+function compareMessagesByReceivedAt(
+  left: MailSummary,
+  right: MailSummary,
+): number {
+  const receivedAtComparison =
+    receivedAtMilliseconds(left) - receivedAtMilliseconds(right);
+  if (receivedAtComparison) return receivedAtComparison;
+
+  const messageIdComparison = compareStrings(
+    left.message_id?.toLowerCase() ?? "",
+    right.message_id?.toLowerCase() ?? "",
+  );
+  return messageIdComparison || compareStrings(left.id, right.id);
+}
+
+function receivedAtMilliseconds(message: MailSummary): number {
+  const value = new Date(message.received_at).getTime();
+  return Number.isFinite(value) ? value : Number.NEGATIVE_INFINITY;
+}
+
+function compareStrings(left: string, right: string): number {
+  if (left < right) return -1;
+  if (left > right) return 1;
+  return 0;
 }
 
 function unique(values: string[]) {
-  return [...new Set(values)];
+  return [...new Set(values)].sort(compareStrings);
 }

--- a/apps/desktop/src/threadsProperties.test.ts
+++ b/apps/desktop/src/threadsProperties.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from "vitest";
+import { groupMessages } from "./threads";
+import type { MailSummary } from "./types";
+
+const baseMessage = (overrides: Partial<MailSummary>): MailSummary => ({
+  id: "message-1",
+  account_id: "account-1",
+  mailbox: "INBOX",
+  uid: 1,
+  message_id: null,
+  thread_id: "shared-thread",
+  subject: "Subject",
+  from_name: null,
+  from_address: "sender@example.test",
+  to_addresses: "reader@example.test",
+  received_at: "2026-07-30T10:00:00Z",
+  snippet: "Snippet",
+  body_text: "Body",
+  is_read: true,
+  is_flagged: false,
+  has_attachments: false,
+  ...overrides,
+});
+
+describe("groupMessages fixed-seed invariants", () => {
+  it("is permutation-invariant for invalid dates, null Message-IDs, duplicate copies, and accounts", () => {
+    for (const seed of [0x1, 0x51f15e, 0xc0ffee, 0xffffffff]) {
+      const graph = generatedThreadGraph(seed);
+      const canonical = groupMessages(graph);
+
+      for (let permutation = 0; permutation < 32; permutation += 1) {
+        expect(groupMessages(shuffle(graph, seed ^ permutation))).toEqual(
+          canonical,
+        );
+      }
+
+      expect(canonical).toHaveLength(5);
+      expect(
+        canonical.filter((thread) => thread.id.endsWith(":shared-thread")),
+      ).toHaveLength(2);
+
+      const primary = canonical.find(
+        (thread) => thread.id === "account-1:shared-thread",
+      )!;
+      expect(primary.messages.map(({ id }) => id)).toEqual([
+        `invalid-empty-${seed}`,
+        `invalid-text-${seed}`,
+        `null-a-${seed}`,
+        `null-b-${seed}`,
+        `duplicate-new-${seed}`,
+        `valid-latest-${seed}`,
+      ]);
+      expect(primary.messages[4]).toMatchObject({
+        is_read: true,
+        has_attachments: false,
+      });
+      expect(primary.sourceMessages).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ id: `duplicate-old-${seed}` }),
+          expect.objectContaining({ id: `duplicate-new-${seed}` }),
+        ]),
+      );
+      expect(primary.unread).toBe(true);
+      expect(primary.hasAttachments).toBe(true);
+      expect(primary.participants).toEqual([
+        "Alpha Example",
+        "Beta Example",
+        "sender@example.test",
+      ]);
+    }
+  });
+
+  it("never collapses distinct null Message-ID messages and orders malformed dates deterministically", () => {
+    for (const seed of [3, 17, 101, 4099]) {
+      const nullCopies = Array.from({ length: 20 }, (_, index) =>
+        baseMessage({
+          id: `null-${seed}-${index.toString().padStart(2, "0")}`,
+          uid: index + 1,
+          message_id: null,
+          received_at: invalidDate(index),
+        }),
+      );
+
+      const expectedIds = nullCopies
+        .map(({ id }) => id)
+        .sort((left, right) => left.localeCompare(right));
+
+      for (let permutation = 0; permutation < 16; permutation += 1) {
+        const [thread] = groupMessages(
+          shuffle(nullCopies, seed * 100 + permutation),
+        );
+        expect(thread.messages.map(({ id }) => id)).toEqual(expectedIds);
+        expect(thread.latest.id).toBe(expectedIds.at(-1));
+      }
+    }
+  });
+});
+
+function generatedThreadGraph(seed: number): MailSummary[] {
+  return [
+    baseMessage({
+      id: `invalid-empty-${seed}`,
+      uid: 1,
+      message_id: `<invalid-empty-${seed}@example.test>`,
+      received_at: "",
+    }),
+    baseMessage({
+      id: `invalid-text-${seed}`,
+      uid: 2,
+      message_id: `<invalid-text-${seed}@example.test>`,
+      received_at: "not-a-date",
+      from_name: "Beta Example",
+    }),
+    baseMessage({
+      id: `null-a-${seed}`,
+      uid: 3,
+      message_id: null,
+      received_at: "2026-07-30T08:00:00Z",
+      from_name: "Alpha Example",
+    }),
+    baseMessage({
+      id: `null-b-${seed}`,
+      uid: 4,
+      message_id: null,
+      received_at: "2026-07-30T09:00:00Z",
+      from_name: "Alpha Example",
+    }),
+    baseMessage({
+      id: `duplicate-old-${seed}`,
+      uid: 5,
+      message_id: `<DuPlIcAtE-${seed}@example.test>`,
+      received_at: "2026-07-30T07:00:00Z",
+      is_read: false,
+      has_attachments: true,
+    }),
+    baseMessage({
+      id: `duplicate-new-${seed}`,
+      uid: 6,
+      mailbox: "Archive",
+      message_id: `<duplicate-${seed}@example.test>`,
+      received_at: "2026-07-30T10:00:00Z",
+    }),
+    baseMessage({
+      id: `valid-latest-${seed}`,
+      uid: 7,
+      message_id: `<latest-${seed}@example.test>`,
+      received_at: "2026-07-30T11:00:00Z",
+    }),
+    baseMessage({
+      id: `account-2-copy-${seed}`,
+      account_id: "account-2",
+      uid: 8,
+      message_id: `<duplicate-${seed}@example.test>`,
+      received_at: "2026-07-30T12:00:00Z",
+    }),
+    baseMessage({
+      id: `fallback-a-${seed}`,
+      uid: 9,
+      thread_id: "",
+      message_id: null,
+      received_at: "2026-07-30T13:00:00Z",
+    }),
+    baseMessage({
+      id: `fallback-b-${seed}`,
+      uid: 10,
+      thread_id: "",
+      message_id: null,
+      received_at: "2026-07-30T14:00:00Z",
+    }),
+    baseMessage({
+      id: `other-thread-${seed}`,
+      uid: 11,
+      thread_id: "other-thread",
+      message_id: null,
+      received_at: "2026-07-30T15:00:00Z",
+    }),
+  ];
+}
+
+function invalidDate(index: number): string {
+  return ["", "not-a-date", "2026-99-99", "NaN", "invalid"][index % 5];
+}
+
+function shuffle<T>(values: readonly T[], seed: number): T[] {
+  const result = [...values];
+  let state = seed >>> 0;
+  const next = () => {
+    state ^= state << 13;
+    state ^= state >>> 17;
+    state ^= state << 5;
+    return state >>> 0;
+  };
+
+  for (let index = result.length - 1; index > 0; index -= 1) {
+    const other = next() % (index + 1);
+    [result[index], result[other]] = [result[other], result[index]];
+  }
+  return result;
+}

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -41,12 +41,12 @@ export type MailSummary = {
   account_id: string;
   mailbox: string;
   uid: number;
-  message_id?: string;
-  in_reply_to?: string;
-  reference_ids?: string;
+  message_id?: string | null;
+  in_reply_to?: string | null;
+  reference_ids?: string | null;
   thread_id: string;
   subject: string;
-  from_name?: string;
+  from_name?: string | null;
   from_address: string;
   to_addresses: string;
   cc_addresses?: string;
@@ -55,9 +55,9 @@ export type MailSummary = {
   received_at: string;
   snippet: string;
   body_text: string;
-  body_html?: string;
+  body_html?: string | null;
   content_state?: "headers_only" | "hydrating" | "complete" | "failed";
-  unsubscribe_kind?: "one_click" | "web" | "mailto";
+  unsubscribe_kind?: "one_click" | "web" | "mailto" | null;
   is_read: boolean;
   is_flagged: boolean;
   has_attachments: boolean;
@@ -71,6 +71,8 @@ export type MailThread = {
   accountId?: string;
   threadId?: string;
   messages: MailSummary[];
+  /** All concrete mailbox/UID rows, including logical duplicate copies. */
+  sourceMessages?: MailSummary[];
   latest: MailSummary;
   messageCount?: number;
   unread: boolean;
@@ -109,8 +111,8 @@ export type Attachment = {
 };
 export type MessageContent = {
   body_text: string;
-  body_html?: string;
-  unsubscribe_kind?: "one_click" | "web" | "mailto";
+  body_html?: string | null;
+  unsubscribe_kind?: "one_click" | "web" | "mailto" | null;
   attachments: Attachment[];
 };
 export type MessageContentErrorKind =
@@ -167,8 +169,8 @@ export type MailHydrated = {
 export type RealtimeSyncStatus = {
   accountId: string;
   state: "connecting" | "idle" | "polling" | "retrying" | "paused";
-  retryAt?: string;
-  errorKind?: "connection" | "authentication";
+  retryAt?: string | null;
+  errorKind?: "connection" | "authentication" | null;
 };
 export type AiSettings = {
   provider: "ollama" | "openai" | "local";

--- a/apps/desktop/testdata/tauri-contract-origins.json
+++ b/apps/desktop/testdata/tauri-contract-origins.json
@@ -1,0 +1,24 @@
+{
+  "schemaVersion": 1,
+  "demoOnlyInvokes": [],
+  "eventOrigins": {
+    "account-connected": "frontend",
+    "account-removed": "native",
+    "account-updated": "frontend",
+    "compose-sent": "frontend",
+    "dakia://dropped-file-error": "native",
+    "dakia://dropped-file-receipt": "native",
+    "mail-arrived": "native",
+    "mail-changed": "native",
+    "mail-hydrated": "native",
+    "mail-index-rebuilt": "native",
+    "mail-rebuild-progress": "native",
+    "mail-sync-state": "native",
+    "menu-action": "native",
+    "notification-action": "native",
+    "notification-settings-changed": "frontend",
+    "outbox-changed": "frontend",
+    "select-account": "frontend",
+    "settings-changed": "frontend"
+  }
+}

--- a/apps/desktop/testdata/tauri-contracts/high-risk.json
+++ b/apps/desktop/testdata/tauri-contracts/high-risk.json
@@ -1,0 +1,162 @@
+{
+  "realisticFixtureIds": {
+    "providerSignature": "provider-signature-inline"
+  },
+  "messageContent": {
+    "success": {
+      "body_text": "Quarterly update is ready.",
+      "body_html": null,
+      "unsubscribe_kind": "web",
+      "attachments": [
+        {
+          "id": "attachment-01",
+          "message_id": "message-01",
+          "filename": "update.pdf",
+          "mime_type": "application/pdf",
+          "size_bytes": 4096,
+          "is_inline": false,
+          "presentation": "downloadable",
+          "is_potentially_unsafe": false
+        }
+      ]
+    },
+    "providerSignature": {
+      "body_text": "Redacted message content for a fictional insurance case.\n \n \nProvider Agent\nInsurance specialist\n\nExample Insurance AS\nExample Street 1\n \n \nFictional confidential-message notice.",
+      "body_html": "<html><body style=\"font-family:Arial,sans-serif\">\n<p>Redacted message content for a fictional insurance case.</p>\n<p>&nbsp;</p><p>&nbsp;</p>\n<table role=\"presentation\"><tr><td><strong>Provider Agent</strong><br>\nInsurance specialist<br><br>\nExample Insurance AS<br>Example Street 1<br>\n<img src=\"data:image/png;base64,iVBORw0KGgo=\" alt=\"Example Insurance\"></td></tr></table>\n<p>&nbsp;</p><p>&nbsp;</p>\n<small>Fictional confidential-message notice.</small>\n</body></html>",
+      "unsubscribe_kind": null,
+      "attachments": [
+        {
+          "id": "provider-signature-pdf",
+          "message_id": "message-provider-signature",
+          "filename": "claim-documents.pdf",
+          "mime_type": "application/pdf",
+          "size_bytes": 3,
+          "is_inline": false,
+          "presentation": "downloadable",
+          "is_potentially_unsafe": false
+        }
+      ]
+    },
+    "error": {
+      "kind": "resource_limit"
+    },
+    "errorVariants": [
+      { "kind": "resource_limit" },
+      { "kind": "malformed" },
+      { "kind": "undecodable" },
+      { "kind": "unsupported" },
+      { "kind": "transient" }
+    ]
+  },
+  "events": {
+    "mailArrived": {
+      "eventId": "6e84311f-ff3a-4cbd-a037-a5bedc79f2f2",
+      "accountId": "0f452e8d-8d11-4643-944c-0e9f8f243311",
+      "messages": [
+        {
+          "id": "message-01",
+          "account_id": "0f452e8d-8d11-4643-944c-0e9f8f243311",
+          "mailbox": "INBOX",
+          "uid": 42,
+          "message_id": null,
+          "in_reply_to": null,
+          "reference_ids": null,
+          "thread_id": "thread-01",
+          "subject": "Quarterly update",
+          "from_name": "Mara Example",
+          "from_address": "mara@example.test",
+          "to_addresses": "alex@example.test",
+          "cc_addresses": "",
+          "bcc_addresses": "",
+          "reply_to_addresses": "",
+          "received_at": "2026-07-30T09:15:00Z",
+          "snippet": "Quarterly update is ready.",
+          "body_text": "Quarterly update is ready.",
+          "body_html": null,
+          "content_state": "headers_only",
+          "unsubscribe_kind": null,
+          "is_read": false,
+          "is_flagged": false,
+          "has_attachments": false,
+          "category": null,
+          "classification_confidence": null,
+          "classification_source": null,
+          "classification_signals": ""
+        }
+      ],
+      "detectedAt": "2026-07-30T09:15:03Z"
+    },
+    "mailHydrated": {
+      "accountId": "0f452e8d-8d11-4643-944c-0e9f8f243311",
+      "messageId": "message-01"
+    },
+    "mailChanged": {
+      "accountId": "0f452e8d-8d11-4643-944c-0e9f8f243311"
+    },
+    "mailSyncStateWithNulls": {
+      "accountId": "0f452e8d-8d11-4643-944c-0e9f8f243311",
+      "state": "idle",
+      "retryAt": null,
+      "errorKind": null
+    },
+    "mailSyncStateRetrying": {
+      "accountId": "0f452e8d-8d11-4643-944c-0e9f8f243311",
+      "state": "retrying",
+      "retryAt": "2026-07-30T09:20:00Z",
+      "errorKind": "connection"
+    }
+  },
+  "commands": {
+    "messageContent": {
+      "command": "message_content",
+      "arguments": {
+        "messageId": "message-01"
+      }
+    },
+    "hydrateMessage": {
+      "command": "hydrate_message",
+      "arguments": {
+        "messageId": "message-01"
+      }
+    },
+    "setMessageCategory": {
+      "command": "set_message_category",
+      "arguments": {
+        "messageId": "message-01",
+        "category": "newsletters"
+      }
+    },
+    "setMessageStarred": {
+      "command": "set_message_starred",
+      "arguments": {
+        "messageId": "message-01",
+        "starred": true
+      }
+    },
+    "setMessageRead": {
+      "command": "set_message_read",
+      "arguments": {
+        "messageId": "message-01",
+        "read": false
+      }
+    },
+    "applyMailboxAction": {
+      "command": "apply_mailbox_action",
+      "arguments": {
+        "accountId": "0f452e8d-8d11-4643-944c-0e9f8f243311",
+        "mailbox": "INBOX",
+        "uid": 42,
+        "action": "archive"
+      }
+    },
+    "syncAccount": {
+      "command": "sync_account",
+      "arguments": {
+        "accountId": "0f452e8d-8d11-4643-944c-0e9f8f243311",
+        "limit": 50,
+        "full": false,
+        "onProgress": "__TAURI_CHANNEL__"
+      }
+    }
+  }
+}

--- a/crates/dakia-cli/Cargo.toml
+++ b/crates/dakia-cli/Cargo.toml
@@ -10,6 +10,10 @@ rust-version.workspace = true
 name = "dakia"
 path = "src/main.rs"
 
+[[bin]]
+name = "dakia-provider-smoke"
+path = "src/bin/provider-smoke.rs"
+
 [dependencies]
 anyhow.workspace = true
 base64.workspace = true
@@ -22,6 +26,7 @@ serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
+tempfile = "3"
 url.workspace = true
 uuid.workspace = true
 

--- a/crates/dakia-cli/Cargo.toml
+++ b/crates/dakia-cli/Cargo.toml
@@ -24,3 +24,6 @@ tokio.workspace = true
 tracing-subscriber.workspace = true
 url.workspace = true
 uuid.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/dakia-cli/src/bin/provider-smoke.rs
+++ b/crates/dakia-cli/src/bin/provider-smoke.rs
@@ -1,0 +1,183 @@
+use anyhow::{bail, Context, Result};
+use chrono::Utc;
+use dakia_core::{Account, AccountAuth, MailService, Security, Store};
+use serde::Deserialize;
+use std::{collections::BTreeMap, env, process::ExitCode, time::Duration};
+use tempfile::TempDir;
+use tokio::time::timeout;
+use uuid::Uuid;
+
+const PROVIDER_SMOKE_TIMEOUT: Duration = Duration::from_secs(45);
+const SMOKE_SUCCESS_MESSAGE: &str =
+    "Provider smoke passed: IMAP read-neutral sync and SMTP auth/QUIT completed.";
+const SMOKE_FAILURE_MESSAGE: &str =
+    "Provider smoke failed; no remote mailbox mutation was requested.";
+
+#[derive(Deserialize)]
+struct ProviderSmokeConfig {
+    version: u8,
+    provider: String,
+    #[serde(rename = "accountEmail")]
+    account_email: String,
+    imap: Endpoint,
+    smtp: Endpoint,
+    credentials: BTreeMap<String, String>,
+}
+
+#[derive(Deserialize)]
+struct Endpoint {
+    host: String,
+    port: u16,
+    security: EndpointSecurity,
+}
+
+#[derive(Deserialize, Clone, Copy)]
+#[serde(rename_all = "lowercase")]
+enum EndpointSecurity {
+    Tls,
+    Starttls,
+}
+
+impl From<EndpointSecurity> for Security {
+    fn from(value: EndpointSecurity) -> Self {
+        match value {
+            EndpointSecurity::Tls => Self::Tls,
+            EndpointSecurity::Starttls => Self::StartTls,
+        }
+    }
+}
+
+impl ProviderSmokeConfig {
+    fn password(&self) -> Result<&str> {
+        if self.version != 1
+            || self.provider.trim().is_empty()
+            || self.account_email.trim().is_empty()
+            || self.imap.host.trim().is_empty()
+            || self.smtp.host.trim().is_empty()
+        {
+            bail!("invalid provider smoke configuration");
+        }
+        let Some((kind, secret)) = self.credentials.iter().next() else {
+            bail!("invalid provider smoke credentials");
+        };
+        if self.credentials.len() != 1
+            || !matches!(kind.as_str(), "password" | "appPassword")
+            || secret.trim().is_empty()
+        {
+            // OAuth and other credential kinds are intentionally rejected:
+            // this narrow live smoke must not invent a refresh/token flow.
+            bail!("unsupported provider smoke credential kind");
+        }
+        Ok(secret)
+    }
+
+    fn account(&self) -> Account {
+        Account {
+            id: Uuid::new_v4(),
+            email: self.account_email.clone(),
+            account_name: self.account_email.clone(),
+            display_name: "Provider smoke".into(),
+            provider_id: self.provider.clone(),
+            auth: AccountAuth::Password {
+                username: self.account_email.clone(),
+            },
+            imap_host: self.imap.host.clone(),
+            imap_port: self.imap.port,
+            imap_security: self.imap.security.into(),
+            smtp_host: self.smtp.host.clone(),
+            smtp_port: self.smtp.port,
+            smtp_security: self.smtp.security.into(),
+            archive_mailbox: "Archive".into(),
+            spam_mailbox: "Spam".into(),
+            enabled: true,
+            created_at: Utc::now(),
+        }
+    }
+}
+
+async fn run_smoke(config: ProviderSmokeConfig, temp_dir: &TempDir) -> Result<()> {
+    let password = config.password()?.to_owned();
+    let account = config.account();
+    let store = Store::open(temp_dir.path().join("provider-smoke.db")).await?;
+    store.save_account(&account).await?;
+    let service = MailService::new(store);
+    service
+        .credentials()
+        .set_password(&account, &password)
+        .await?;
+
+    // The public IMAP probe authenticates and performs only CAPABILITY, LIST,
+    // read-only EXAMINE INBOX, and constant-size STATUS. It fetches no message
+    // content and cannot expand its remote work with mailbox size.
+    service.imap_auth_probe(&account).await?;
+    // This authenticates over the configured TLS/STARTTLS path and issues
+    // QUIT before MAIL/RCPT/DATA, so no SMTP envelope or body is submitted.
+    service.smtp_auth_probe(&account).await?;
+    Ok(())
+}
+
+async fn execute() -> Result<()> {
+    let raw = env::var("PROVIDER_SMOKE_CONFIG")
+        .map_err(|_| anyhow::anyhow!("provider smoke configuration is unavailable"))?;
+    let config: ProviderSmokeConfig = serde_json::from_str(&raw)
+        .map_err(|_| anyhow::anyhow!("invalid provider smoke configuration"))?;
+    let temp_dir = tempfile::Builder::new()
+        .prefix("dakia-provider-smoke-")
+        .tempdir()?;
+    let outcome = timeout(PROVIDER_SMOKE_TIMEOUT, run_smoke(config, &temp_dir)).await;
+    // The temporary SQLite database also contains the encrypted credential.
+    // Remove it regardless of a timeout, auth failure, or protocol error.
+    temp_dir
+        .close()
+        .context("could not remove temporary provider smoke state")?;
+    outcome.map_err(|_| anyhow::anyhow!("provider smoke timed out"))?
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    match execute().await {
+        Ok(()) => {
+            println!("{SMOKE_SUCCESS_MESSAGE}");
+            ExitCode::SUCCESS
+        }
+        Err(_) => {
+            // Never include the secret-backed configuration, endpoint, or
+            // account identity in CI logs.
+            eprintln!("{SMOKE_FAILURE_MESSAGE}");
+            ExitCode::FAILURE
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SECRET: &str = "must-not-appear-in-provider-smoke-output";
+
+    #[test]
+    fn live_smoke_rejects_oauth_style_credentials_without_echoing_their_value() {
+        let config: ProviderSmokeConfig = serde_json::from_value(serde_json::json!({
+            "version": 1,
+            "provider": "test-provider",
+            "accountEmail": "smoke@example.invalid",
+            "imap": { "host": "imap.example.invalid", "port": 993, "security": "tls" },
+            "smtp": { "host": "smtp.example.invalid", "port": 465, "security": "tls" },
+            "credentials": { "accessToken": SECRET },
+        }))
+        .unwrap();
+
+        let error = config.password().unwrap_err().to_string();
+        assert!(error.contains("unsupported provider smoke credential kind"));
+        assert!(!error.contains(SECRET));
+    }
+
+    #[test]
+    fn binary_log_messages_are_static_and_do_not_echo_config_values() {
+        for message in [SMOKE_SUCCESS_MESSAGE, SMOKE_FAILURE_MESSAGE] {
+            assert!(!message.contains(SECRET));
+            assert!(!message.contains("example.invalid"));
+            assert!(!message.contains("host"));
+        }
+    }
+}

--- a/crates/dakia-cli/src/main.rs
+++ b/crates/dakia-cli/src/main.rs
@@ -203,14 +203,21 @@ async fn main() -> Result<()> {
         },
         Command::Sync(args) => {
             let mail = MailService::new(store.clone());
-            for account in store
+            let accounts = store
                 .accounts()
                 .await?
                 .into_iter()
                 .filter(|item| args.account.map(|id| id == item.id).unwrap_or(true))
-            {
+                .collect::<Vec<_>>();
+            if args.account.is_some() && accounts.is_empty() {
+                bail!("account not found");
+            }
+            for account in accounts {
                 let count = if args.refresh_gmail_categories {
                     if account.provider_id != "gmail" {
+                        if args.account.is_some() {
+                            bail!("Gmail category refresh requires a Gmail account");
+                        }
                         continue;
                     }
                     mail.refresh_gmail_category_metadata(&account)
@@ -224,14 +231,14 @@ async fn main() -> Result<()> {
                         .with_context(|| format!("sync failed for {}", account.email))?
                 };
                 if cli.json {
-                    println!(
-                        "{}",
-                        serde_json::json!(if args.refresh_gmail_categories {
+                    print_value(
+                        &if args.refresh_gmail_categories {
                             serde_json::json!({"account_id":account.id,"refreshed_category_labels":count})
                         } else {
                             serde_json::json!({"account_id":account.id,"synced":count})
-                        })
-                    );
+                        },
+                        true,
+                    )?;
                 } else {
                     let action = if args.refresh_gmail_categories {
                         "refreshed Gmail category labels for"

--- a/crates/dakia-cli/tests/cli_subprocess.rs
+++ b/crates/dakia-cli/tests/cli_subprocess.rs
@@ -1,0 +1,514 @@
+use chrono::Utc;
+use dakia_core::{provider, Account, AccountDraft, MailSummary, Store};
+use serde_json::Value;
+use std::{
+    collections::BTreeSet,
+    path::Path,
+    process::{Output, Stdio},
+    time::Duration,
+};
+use tempfile::TempDir;
+use tokio::{
+    io::{AsyncBufReadExt, BufReader},
+    process::{Child, Command},
+    task::JoinSet,
+    time::{sleep, timeout},
+};
+use uuid::Uuid;
+
+const PROCESS_DEADLINE: Duration = Duration::from_secs(10);
+const CANCELLATION_DEADLINE: Duration = Duration::from_secs(2);
+const CLAIM_WORKER_READY: &str = "DAKIA_CROSS_PROCESS_CLAIM_READY";
+
+async fn run(args: &[&str]) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_dakia"));
+    command.args(args);
+    run_command(command).await
+}
+
+async fn run_with_data_dir(args: &[&str], data_dir: &Path) -> Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_dakia"));
+    command.args(args).env("DAKIA_DATA_DIR", data_dir);
+    run_command(command).await
+}
+
+async fn run_command(mut command: Command) -> Output {
+    command.kill_on_drop(true);
+    timeout(PROCESS_DEADLINE, command.output())
+        .await
+        .expect("CLI subprocess exceeded its deadline")
+        .expect("CLI subprocess could not be started")
+}
+
+/// Starts this integration-test binary in a separate process, not another
+/// task in this test runtime. The storage owner token is process-scoped, so
+/// this is the boundary that catches a fresh claim being stolen on open.
+async fn spawn_claim_worker(database: &Path, message_id: &str) -> Child {
+    let mut command = Command::new(std::env::current_exe().expect("test binary path"));
+    command
+        .args([
+            "--exact",
+            "cross_process_content_claim_worker",
+            "--nocapture",
+        ])
+        .env("DAKIA_CLI_CLAIM_WORKER_DATABASE", database)
+        .env("DAKIA_CLI_CLAIM_WORKER_MESSAGE_ID", message_id)
+        .env("DAKIA_CLI_CLAIM_WORKER_HOLD_MILLIS", "10000")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::inherit())
+        .kill_on_drop(true);
+    let mut child = command.spawn().expect("spawn isolated claim worker");
+    let stdout = child.stdout.take().expect("worker stdout");
+    let mut lines = BufReader::new(stdout).lines();
+
+    timeout(PROCESS_DEADLINE, async {
+        while let Some(line) = lines.next_line().await.expect("read worker stdout") {
+            if line == CLAIM_WORKER_READY {
+                return;
+            }
+        }
+        panic!("claim worker exited before acquiring its lease");
+    })
+    .await
+    .expect("claim worker did not acquire its lease before the deadline");
+    child
+}
+
+async fn seed_profile(directory: &Path, label: &str) -> (Account, MailSummary) {
+    let store = Store::open(directory.join("dakia.db"))
+        .await
+        .expect("open seed store");
+    let account = AccountDraft {
+        email: format!("{label}@example.test"),
+        display_name: format!("{label} account"),
+        provider_id: Some("custom".into()),
+        username: None,
+        imap_host: None,
+        imap_port: None,
+        imap_security: None,
+        smtp_host: None,
+        smtp_port: None,
+        smtp_security: None,
+        archive_mailbox: None,
+        spam_mailbox: None,
+    }
+    .into_account(provider::by_id("custom").expect("custom provider"));
+    store.save_account(&account).await.expect("save account");
+
+    let message = MailSummary {
+        id: format!("{label}-message"),
+        account_id: account.id.to_string(),
+        mailbox: "INBOX".into(),
+        uid: 1,
+        message_id: Some(format!("<{label}@example.test>")),
+        in_reply_to: None,
+        reference_ids: None,
+        thread_id: format!("{label}-thread"),
+        subject: format!("{label} durable subject"),
+        from_name: Some("Fixture sender".into()),
+        from_address: "sender@example.test".into(),
+        to_addresses: account.email.clone(),
+        cc_addresses: String::new(),
+        bcc_addresses: String::new(),
+        reply_to_addresses: String::new(),
+        received_at: Utc::now(),
+        snippet: format!("{label} durable body"),
+        body_text: format!("{label} durable body"),
+        body_html: None,
+        content_state: "complete".into(),
+        unsubscribe_kind: None,
+        unsubscribe_url: None,
+        is_read: false,
+        is_flagged: false,
+        has_attachments: false,
+        category: None,
+        classification_confidence: None,
+        classification_source: None,
+        classification_signals: String::new(),
+        attachments: Vec::new(),
+    };
+    store
+        .upsert_messages(std::slice::from_ref(&message))
+        .await
+        .expect("seed message");
+    drop(store);
+    (account, message)
+}
+
+fn assert_success_json(output: &Output) -> Value {
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(output.stderr, b"");
+    serde_json::from_slice(&output.stdout).expect("CLI stdout is JSON")
+}
+
+fn keys(value: &Value) -> BTreeSet<&str> {
+    value
+        .as_object()
+        .expect("JSON object")
+        .keys()
+        .map(String::as_str)
+        .collect()
+}
+
+#[tokio::test]
+async fn help_version_and_invalid_input_do_not_create_profile_state() {
+    let temporary = TempDir::new().expect("temporary directory");
+    let profile = temporary.path().join("never-created");
+    let profile_arg = profile.to_string_lossy().into_owned();
+
+    let help = run(&["--data-dir", &profile_arg, "--help"]).await;
+    assert_eq!(help.status.code(), Some(0));
+    assert_eq!(help.stderr, b"");
+    assert_eq!(
+        help.stdout,
+        concat!(
+            "Search, read, and send mail from the terminal\n\n",
+            "Usage: dakia [OPTIONS] <COMMAND>\n\n",
+            "Commands:\n",
+            "  account     \n  sync        \n  classify    \n  search      \n",
+            "  show        \n  attachment  \n  archive     \n  spam        \n",
+            "  trash       \n  delete      \n  send        \n  ai          \n",
+            "  help        Print this message or the help of the given subcommand(s)\n\n",
+            "Options:\n",
+            "      --data-dir <DATA_DIR>  [env: DAKIA_DATA_DIR=]\n",
+            "      --json                 \n",
+            "  -h, --help                 Print help\n",
+            "  -V, --version              Print version\n"
+        )
+        .as_bytes()
+    );
+
+    let version = run(&["--data-dir", &profile_arg, "--version"]).await;
+    assert_eq!(version.status.code(), Some(0));
+    assert_eq!(
+        version.stdout,
+        format!("dakia {}\n", env!("CARGO_PKG_VERSION")).as_bytes()
+    );
+    assert_eq!(version.stderr, b"");
+
+    let invalid = run(&["--data-dir", &profile_arg, "not-a-command"]).await;
+    assert_eq!(invalid.status.code(), Some(2));
+    assert_eq!(invalid.stdout, b"");
+    assert_eq!(
+        invalid.stderr,
+        concat!(
+            "error: unrecognized subcommand 'not-a-command'\n\n",
+            "Usage: dakia [OPTIONS] <COMMAND>\n\n",
+            "For more information, try '--help'.\n"
+        )
+        .as_bytes()
+    );
+
+    assert!(!profile.join("dakia.db").exists());
+    assert!(!profile.join("vault.key").exists());
+}
+
+#[tokio::test]
+async fn data_dir_overrides_environment_and_account_list_has_a_stable_json_schema() {
+    let temporary = TempDir::new().expect("temporary directory");
+    let environment_profile = temporary.path().join("environment");
+    let argument_profile = temporary.path().join("argument");
+    let (environment_account, _) = seed_profile(&environment_profile, "environment").await;
+    let (argument_account, _) = seed_profile(&argument_profile, "argument").await;
+    let argument_profile_arg = argument_profile.to_string_lossy().into_owned();
+
+    let output = run_with_data_dir(
+        &[
+            "--data-dir",
+            &argument_profile_arg,
+            "--json",
+            "account",
+            "list",
+        ],
+        &environment_profile,
+    )
+    .await;
+    let accounts = assert_success_json(&output);
+    let accounts = accounts.as_array().expect("account list is an array");
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(accounts[0]["id"], argument_account.id.to_string());
+    assert_eq!(accounts[0]["email"], argument_account.email);
+    assert_ne!(accounts[0]["id"], environment_account.id.to_string());
+    assert_eq!(
+        keys(&accounts[0]),
+        BTreeSet::from([
+            "account_name",
+            "archive_mailbox",
+            "auth",
+            "created_at",
+            "display_name",
+            "email",
+            "enabled",
+            "id",
+            "imap_host",
+            "imap_port",
+            "imap_security",
+            "provider_id",
+            "smtp_host",
+            "smtp_port",
+            "smtp_security",
+            "spam_mailbox",
+        ])
+    );
+    assert_eq!(
+        keys(&accounts[0]["auth"]),
+        BTreeSet::from(["type", "username"])
+    );
+    assert_eq!(accounts[0]["auth"]["type"], "password");
+}
+
+#[tokio::test]
+async fn sync_rejects_an_unknown_account_and_preserves_the_ndjson_contract() {
+    let temporary = TempDir::new().expect("temporary directory");
+    let profile = temporary.path().join("profile");
+    let profile_arg = profile.to_string_lossy().into_owned();
+    let unknown = Uuid::from_u128(0xfeed);
+
+    let missing = run(&[
+        "--data-dir",
+        &profile_arg,
+        "--json",
+        "sync",
+        "--account",
+        &unknown.to_string(),
+    ])
+    .await;
+    assert_eq!(missing.status.code(), Some(1));
+    assert_eq!(missing.stdout, b"");
+    assert_eq!(missing.stderr, b"Error: account not found\n");
+
+    let empty = run(&["--data-dir", &profile_arg, "--json", "sync"]).await;
+    assert_eq!(empty.status.code(), Some(0));
+    assert_eq!(empty.stderr, b"");
+    assert_eq!(empty.stdout, b"");
+}
+
+#[tokio::test]
+async fn restart_preserves_seeded_state_without_cross_profile_leakage() {
+    let temporary = TempDir::new().expect("temporary directory");
+    let profile_a = temporary.path().join("profile-a");
+    let profile_b = temporary.path().join("profile-b");
+    let (account_a, message_a) = seed_profile(&profile_a, "alpha").await;
+    let (account_b, message_b) = seed_profile(&profile_b, "bravo").await;
+    let profile_a_arg = profile_a.to_string_lossy().into_owned();
+    let profile_b_arg = profile_b.to_string_lossy().into_owned();
+
+    for _ in 0..2 {
+        let output = run(&[
+            "--data-dir",
+            &profile_a_arg,
+            "--json",
+            "search",
+            "durable",
+            "--account",
+            &account_a.id.to_string(),
+        ])
+        .await;
+        let messages = assert_success_json(&output);
+        let messages = messages.as_array().expect("search result is an array");
+        assert_eq!(messages.len(), 1);
+        assert_eq!(messages[0]["id"], message_a.id);
+        assert_eq!(messages[0]["account_id"], account_a.id.to_string());
+        assert_ne!(messages[0]["id"], message_b.id);
+    }
+
+    let output = run(&["--data-dir", &profile_b_arg, "--json", "search", "durable"]).await;
+    let messages = assert_success_json(&output);
+    let messages = messages.as_array().expect("search result is an array");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["id"], message_b.id);
+    assert_eq!(messages[0]["account_id"], account_b.id.to_string());
+    assert_ne!(messages[0]["id"], message_a.id);
+}
+
+#[tokio::test]
+async fn trash_and_delete_refuse_without_yes_and_leave_durable_state_unchanged() {
+    let temporary = TempDir::new().expect("temporary directory");
+    let profile = temporary.path().join("profile");
+    let (_, message) = seed_profile(&profile, "refusal").await;
+    let profile_arg = profile.to_string_lossy().into_owned();
+
+    for (command, expected_error) in [
+        ("trash", "Error: refusing to trash without --yes\n"),
+        (
+            "delete",
+            "Error: refusing to permanently delete without --yes\n",
+        ),
+    ] {
+        let output = run(&["--data-dir", &profile_arg, command, &message.id]).await;
+        assert_eq!(output.status.code(), Some(1));
+        assert_eq!(output.stdout, b"");
+        assert_eq!(output.stderr, expected_error.as_bytes());
+
+        let store = Store::open(profile.join("dakia.db"))
+            .await
+            .expect("reopen after refusal");
+        let stored = store.message(&message.id).await.expect("read message");
+        assert_eq!(
+            stored.as_ref().map(|item| &item.mailbox),
+            Some(&"INBOX".into())
+        );
+        assert_eq!(stored.as_ref().map(|item| item.uid), Some(1));
+        drop(store);
+    }
+}
+
+#[tokio::test]
+async fn concurrent_fresh_profile_startup_is_bounded_and_restartable() {
+    let temporary = TempDir::new().expect("temporary directory");
+    let profile = temporary.path().join("fresh-profile");
+    let profile_arg = profile.to_string_lossy().into_owned();
+    let mut processes = JoinSet::new();
+
+    for _ in 0..4 {
+        let profile_arg = profile_arg.clone();
+        processes.spawn(async move {
+            run(&["--data-dir", &profile_arg, "--json", "account", "list"]).await
+        });
+    }
+    while let Some(joined) = processes.join_next().await {
+        let output = joined.expect("startup task did not panic");
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "unexpected concurrent startup output: stdout={:?}, stderr={:?}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+        assert_eq!(output.stdout, b"[]\n");
+        assert_eq!(output.stderr, b"");
+    }
+
+    assert_eq!(
+        std::fs::read(profile.join("vault.key"))
+            .expect("vault key")
+            .len(),
+        32
+    );
+    assert!(profile.join("dakia.db").is_file());
+    let store = Store::open(profile.join("dakia.db"))
+        .await
+        .expect("reopen concurrently initialized profile");
+    assert!(store
+        .accounts()
+        .await
+        .expect("read initialized store")
+        .is_empty());
+    drop(store);
+
+    let restart = run(&["--data-dir", &profile_arg, "--json", "account", "list"]).await;
+    assert_eq!(restart.status.code(), Some(0));
+    assert_eq!(restart.stdout, b"[]\n");
+    assert_eq!(restart.stderr, b"");
+}
+
+#[tokio::test]
+async fn cancelling_a_blocking_worker_exits_bounded_without_corrupting_profile_state() {
+    let temporary = TempDir::new().expect("temporary directory");
+    let profile = temporary.path().join("profile");
+    let (account, message) = seed_profile(&profile, "cross-process-lease").await;
+    let database = profile.join("dakia.db");
+    let profile_arg = profile.to_string_lossy().into_owned();
+
+    let mut worker = spawn_claim_worker(&database, &message.id).await;
+    let store = Store::open(&database)
+        .await
+        .expect("open profile while another process fetches content");
+
+    assert!(
+        !store
+            .claim_message_content_fetch(&message.id)
+            .await
+            .expect("respect live worker lease"),
+        "a second process must not steal a fresh content-fetch lease"
+    );
+
+    worker
+        .start_kill()
+        .expect("start cancellation of blocking worker");
+    let status = timeout(CANCELLATION_DEADLINE, worker.wait())
+        .await
+        .expect("blocking worker did not exit within the cancellation deadline")
+        .expect("reap cancelled worker");
+    assert!(
+        !status.success(),
+        "cancelled worker must not report a clean completion"
+    );
+
+    assert!(
+        !store
+            .claim_message_content_fetch(&message.id)
+            .await
+            .expect("preserve fresh lease after owner crash"),
+        "cancellation must retain the fresh lease until its bounded stale timeout"
+    );
+    drop(store);
+
+    // The abruptly stopped worker has made its one transient lease durable,
+    // but it must not leave a partial account or message write behind. Reopen
+    // first through Store, then through the CLI's normal startup path.
+    let reopened = Store::open(&database)
+        .await
+        .expect("reopen profile after worker cancellation");
+    let accounts = reopened.accounts().await.expect("read restarted profile");
+    assert_eq!(accounts.len(), 1);
+    assert_eq!(accounts[0].id, account.id);
+    let stored = reopened
+        .message(&message.id)
+        .await
+        .expect("read durable message after cancellation")
+        .expect("seed message survives cancellation");
+    assert_eq!(stored.account_id, account.id.to_string());
+    assert_eq!(stored.mailbox, "INBOX");
+    assert_eq!(stored.uid, 1);
+    assert_eq!(stored.subject, message.subject);
+    assert_eq!(stored.snippet, message.snippet);
+    assert_eq!(stored.content_state, "complete");
+    drop(reopened);
+
+    let restart = run(&[
+        "--data-dir",
+        &profile_arg,
+        "--json",
+        "search",
+        "durable",
+        "--account",
+        &account.id.to_string(),
+    ])
+    .await;
+    let messages = assert_success_json(&restart);
+    let messages = messages
+        .as_array()
+        .expect("restart search result is an array");
+    assert_eq!(messages.len(), 1);
+    assert_eq!(messages[0]["id"], message.id);
+    assert_eq!(messages[0]["subject"], message.subject);
+}
+
+/// Worker half of
+/// `cancelling_a_blocking_worker_exits_bounded_without_corrupting_profile_state`.
+/// It is a no-op in the ordinary suite; the parent invokes it by exact name
+/// with the profile and message supplied in its environment.
+#[tokio::test]
+async fn cross_process_content_claim_worker() {
+    let Ok(database) = std::env::var("DAKIA_CLI_CLAIM_WORKER_DATABASE") else {
+        return;
+    };
+    let message_id = std::env::var("DAKIA_CLI_CLAIM_WORKER_MESSAGE_ID")
+        .expect("worker message id is configured");
+    let hold_millis = std::env::var("DAKIA_CLI_CLAIM_WORKER_HOLD_MILLIS")
+        .expect("worker hold duration is configured")
+        .parse::<u64>()
+        .expect("worker hold duration is an integer");
+    let store = Store::open(database).await.expect("worker opens profile");
+
+    assert!(
+        store
+            .claim_message_content_fetch(&message_id)
+            .await
+            .expect("worker claims message content"),
+        "worker owns the initial content-fetch lease"
+    );
+    println!("{CLAIM_WORKER_READY}");
+    sleep(Duration::from_millis(hold_millis)).await;
+}

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -19,8 +19,13 @@ use lettre::{
     message::{
         header::ContentType, Attachment as LettreAttachment, Mailbox, MultiPart, SinglePart,
     },
-    transport::smtp::authentication::{Credentials, Mechanism},
-    Address, AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor,
+    transport::smtp::{
+        authentication::{Credentials, Mechanism, DEFAULT_MECHANISMS},
+        client::{AsyncSmtpConnection, TlsParameters},
+        commands::{Data, Mail, Rcpt},
+        extension::{ClientId, Extension, MailBodyParameter, MailParameter},
+    },
+    Address, Message,
 };
 use mail_auth::{AuthenticatedMessage, DkimResult, MessageAuthenticator};
 use mail_parser::{
@@ -41,10 +46,13 @@ use std::{
     sync::Arc,
 };
 use tokio::{
-    io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader},
+    io::{
+        AsyncBufRead, AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt,
+        BufReader,
+    },
     net::TcpStream,
     sync::watch,
-    time::{timeout, Duration},
+    time::{timeout, timeout_at, Duration, Instant},
 };
 use tokio_rustls::{
     client::TlsStream,
@@ -306,10 +314,7 @@ impl MailService {
     ) -> Result<RealtimeCycle> {
         let secret = self.credentials.secret(account).await?;
         let mut client = ImapClient::connect(account).await?;
-        client
-            .authenticate(account, &secret)
-            .await
-            .context("IMAP authentication failed")?;
+        client.authenticate(account, &secret).await?;
         let capabilities = client.command("CAPABILITY").await?;
         let supports_idle = supports_idle(&capabilities);
         let select = client.command("SELECT INBOX").await?;
@@ -661,13 +666,40 @@ impl MailService {
             completed: 0,
             total: None,
         });
-        let secret = self.credentials.secret(account).await?;
         let mut client = ImapClient::connect(account).await?;
+        self.sync_mailboxes_with_progress_on_client(
+            &mut client,
+            account,
+            max_messages,
+            plans,
+            reset_before_sync,
+            on_progress,
+        )
+        .await
+    }
+
+    /// The transport-independent sync core is shared by the TLS production
+    /// path and scripted protocol tests. Keeping connection construction in
+    /// `sync_mailboxes_with_progress` preserves the production TLS policy.
+    async fn sync_mailboxes_with_progress_on_client<S, F>(
+        &self,
+        client: &mut ImapClient<S>,
+        account: &Account,
+        max_messages: u32,
+        plans: Vec<MailboxPlan>,
+        reset_before_sync: bool,
+        mut on_progress: F,
+    ) -> Result<SyncResult>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+        F: FnMut(SyncProgress),
+    {
         on_progress(SyncProgress {
             phase: "authenticating",
             completed: 0,
             total: None,
         });
+        let secret = self.credentials.secret(account).await?;
         client.authenticate(account, &secret).await?;
         let listing = client.command("LIST \"\" \"*\"").await.unwrap_or_default();
         let plans = resolve_special_mailboxes(plans, &listing);
@@ -950,10 +982,16 @@ impl MailService {
             };
             let uid_validity = parse_uid_validity(&selected)
                 .context("IMAP server omitted UIDVALIDITY after SELECT")?;
-            let state = match self.store.mailbox_catalog_state(account.id, &plan.storage).await? {
+            let state = match self
+                .store
+                .mailbox_catalog_state(account.id, &plan.storage)
+                .await?
+            {
                 Some(state) => state,
                 None if plan.local != "INBOX" => continue,
-                None => bail!("mailbox catalogue is not initialized; sync the account before refreshing recent mail"),
+                None => bail!(
+                    "mailbox catalogue is not initialized; sync the account before refreshing recent mail"
+                ),
             };
             verify_mailbox_uid_validity(uid_validity, state.uid_validity, "refreshing recent")?;
             let search = client.command(&recent_uid_search_command(&since)).await?;
@@ -1461,35 +1499,42 @@ impl MailService {
 
     pub async fn send(&self, account: &Account, draft: &ComposeMessage) -> Result<String> {
         let secret = self.credentials.secret(account).await?;
+        let endpoint = SmtpEndpoint {
+            host: account.smtp_host.clone(),
+            port: account.smtp_port,
+            tls_parameters: TlsParameters::new(account.smtp_host.clone())?,
+        };
+        self.send_with_smtp_endpoint(account, draft, &secret, endpoint, SMTP_SEND_TIMEOUT)
+            .await
+    }
+
+    async fn send_with_smtp_endpoint(
+        &self,
+        account: &Account,
+        draft: &ComposeMessage,
+        secret: &str,
+        endpoint: SmtpEndpoint,
+        deadline: Duration,
+    ) -> Result<String> {
         let email = build_compose_message(account, draft)?;
         let raw_email = email.formatted();
-        let credentials = Credentials::new(account.auth.username().to_owned(), secret.clone());
-        let mut transport_builder = match account.smtp_security {
-            Security::Tls => AsyncSmtpTransport::<Tokio1Executor>::relay(&account.smtp_host)?,
-            Security::StartTls => {
-                AsyncSmtpTransport::<Tokio1Executor>::starttls_relay(&account.smtp_host)?
-            }
-        }
-        .port(account.smtp_port)
-        .credentials(credentials);
-        if matches!(account.auth, AccountAuth::OAuth2 { .. }) {
-            transport_builder = transport_builder.authentication(vec![Mechanism::Xoauth2]);
-        }
-        let transport = transport_builder.build();
-        let response = timeout(
-            SMTP_SEND_TIMEOUT,
-            transport.send_raw(email.envelope(), &raw_email),
+        let response = send_smtp_raw(
+            account,
+            email.envelope(),
+            &raw_email,
+            secret,
+            endpoint,
+            deadline,
         )
-        .await
-        .context("SMTP send timed out")??;
+        .await?;
         if !smtp_saves_sent_copy(account) {
-            self.append_sent_copy(account, &secret, &raw_email)
+            self.append_sent_copy(account, secret, &raw_email)
                 .await
                 .context(
                     "message was sent, but it could not be saved in the account's Sent folder",
                 )?;
         }
-        Ok(response.message().collect::<Vec<_>>().join(" "))
+        Ok(response)
     }
 
     async fn append_sent_copy(
@@ -1506,6 +1551,120 @@ impl MailService {
         let _ = client.command("LOGOUT").await;
         Ok(())
     }
+}
+
+async fn send_smtp_raw(
+    account: &Account,
+    envelope: &Envelope,
+    raw_email: &[u8],
+    secret: &str,
+    endpoint: SmtpEndpoint,
+    deadline: Duration,
+) -> Result<String> {
+    let deadline_at = Instant::now() + deadline;
+    let client_id = ClientId::default();
+    let implicit_tls =
+        matches!(account.smtp_security, Security::Tls).then(|| endpoint.tls_parameters.clone());
+    let mut connection = smtp_before_data(
+        deadline_at,
+        AsyncSmtpConnection::connect_tokio1(
+            (&*endpoint.host, endpoint.port),
+            None,
+            &client_id,
+            implicit_tls,
+            None,
+        ),
+    )
+    .await?;
+
+    if matches!(account.smtp_security, Security::StartTls) {
+        smtp_before_data(
+            deadline_at,
+            connection.starttls(endpoint.tls_parameters, &client_id),
+        )
+        .await?;
+    }
+
+    let credentials = Credentials::new(account.auth.username().to_owned(), secret.to_owned());
+    let mechanisms: &[Mechanism] = match account.auth {
+        AccountAuth::OAuth2 { .. } => &[Mechanism::Xoauth2],
+        AccountAuth::Password { .. } => DEFAULT_MECHANISMS,
+    };
+    smtp_before_data(deadline_at, connection.auth(mechanisms, &credentials)).await?;
+
+    let mut mail_options = Vec::new();
+    let has_non_ascii_address = envelope
+        .from()
+        .into_iter()
+        .chain(envelope.to())
+        .any(|address| !address.to_string().is_ascii());
+    if has_non_ascii_address {
+        if !connection
+            .server_info()
+            .supports_feature(Extension::SmtpUtfEight)
+        {
+            bail!("Envelope contains non-ascii chars but server does not support SMTPUTF8");
+        }
+        mail_options.push(MailParameter::SmtpUtfEight);
+    }
+    if !raw_email.is_ascii() {
+        if !connection
+            .server_info()
+            .supports_feature(Extension::EightBitMime)
+        {
+            bail!("Message contains non-ascii chars but server does not support 8BITMIME");
+        }
+        mail_options.push(MailParameter::Body(MailBodyParameter::EightBitMime));
+    }
+
+    smtp_before_data(
+        deadline_at,
+        connection.command(Mail::new(envelope.from().cloned(), mail_options)),
+    )
+    .await?;
+    for recipient in envelope.to() {
+        smtp_before_data(
+            deadline_at,
+            connection.command(Rcpt::new(recipient.clone(), Vec::new())),
+        )
+        .await?;
+    }
+    smtp_before_data(deadline_at, connection.command(Data)).await?;
+
+    // Once the DATA terminator has been written, a missing final response is
+    // deliberately not retried as an ordinary failure: the relay may have
+    // accepted and queued the message before the connection disappeared.
+    let response = match timeout_at(deadline_at, connection.message(raw_email)).await {
+        Ok(Ok(response)) => response,
+        Ok(Err(error)) if error.is_transient() || error.is_permanent() => return Err(error.into()),
+        Ok(Err(error)) => {
+            return Err(error).context(
+                "SMTP final delivery status was not received after message submission; delivery may be uncertain",
+            );
+        }
+        Err(_) => bail!(
+            "SMTP final delivery status timed out after message submission; delivery may be uncertain"
+        ),
+    };
+    Ok(response.message().collect::<Vec<_>>().join(" "))
+}
+
+/// The logical account and the connection endpoint are normally identical.
+/// Tests may point the transport at a local TLS relay while retaining the
+/// account's provider-specific Sent-copy policy.
+struct SmtpEndpoint {
+    host: String,
+    port: u16,
+    tls_parameters: TlsParameters,
+}
+
+async fn smtp_before_data<T>(
+    deadline_at: Instant,
+    operation: impl std::future::Future<Output = std::result::Result<T, lettre::transport::smtp::Error>>,
+) -> Result<T> {
+    Ok(timeout_at(deadline_at, operation)
+        .await
+        .context("SMTP send timed out before message submission")??)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1842,8 +2001,8 @@ fn decode_outbound_attachments(
         })
         .collect()
 }
-struct ImapClient {
-    reader: BufReader<TlsStream<TcpStream>>,
+struct ImapClient<S = TlsStream<TcpStream>> {
+    reader: BufReader<S>,
     tag: u32,
 }
 struct ImapResponse {
@@ -1900,6 +2059,7 @@ fn body_item_section(value: &str) -> Option<&str> {
     Some(&value[start..end])
 }
 
+#[derive(Debug)]
 enum IdleOutcome {
     Changed,
     Renewed,
@@ -2837,12 +2997,15 @@ fn collect_attachment_candidates(part: &MimePart, candidates: &mut Vec<MimePart>
     }
 }
 
-async fn fetch_section_mime_headers(
-    client: &mut ImapClient,
+async fn fetch_section_mime_headers<S>(
+    client: &mut ImapClient<S>,
     uid: u32,
     path: &[usize],
     root_headers: Option<&[u8]>,
-) -> Result<Vec<u8>> {
+) -> Result<Vec<u8>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     if path.is_empty() {
         return root_headers
             .map(ToOwned::to_owned)
@@ -2858,15 +3021,18 @@ async fn fetch_section_mime_headers(
         .context("IMAP server did not return MIME part headers")
 }
 
-async fn fetch_selective_message(
-    client: &mut ImapClient,
+async fn fetch_selective_message<S>(
+    client: &mut ImapClient<S>,
     account: &Account,
     mailbox: &str,
     uid: u32,
     response_lines: &[String],
     headers: &[u8],
     structure: &MimePart,
-) -> Result<MailSummary> {
+) -> Result<MailSummary>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     let plan = selective_plan(structure)?;
     let mut total = 0usize;
     let mut decoded_text_parts = Vec::new();
@@ -3266,7 +3432,7 @@ fn gmail_all_mail_is_archive(lines: &[String]) -> bool {
         .any(|label| metadata.contains(label))
 }
 
-impl ImapClient {
+impl ImapClient<TlsStream<TcpStream>> {
     async fn connect(account: &Account) -> Result<Self> {
         let roots = RootCertStore {
             roots: webpki_roots::TLS_SERVER_ROOTS.to_vec(),
@@ -3284,15 +3450,23 @@ impl ImapClient {
         .context("could not connect to IMAP server")?;
         if account.imap_security == Security::StartTls {
             let mut plain = BufReader::new(tcp);
-            let mut greeting = String::new();
-            plain.read_line(&mut greeting).await?;
+            let greeting = timeout(
+                IMAP_COMMAND_TIMEOUT,
+                read_imap_line_limited(&mut plain, MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES),
+            )
+            .await
+            .context("IMAP greeting timed out")??;
             if !greeting.starts_with("* OK") {
                 bail!("IMAP server rejected connection: {}", greeting.trim());
             }
             plain.get_mut().write_all(b"D0000 STARTTLS\r\n").await?;
             plain.get_mut().flush().await?;
-            let mut response = String::new();
-            plain.read_line(&mut response).await?;
+            let response = timeout(
+                IMAP_COMMAND_TIMEOUT,
+                read_imap_line_limited(&mut plain, MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES),
+            )
+            .await
+            .context("IMAP STARTTLS response timed out")??;
             if !response.starts_with("D0000 OK") {
                 bail!("IMAP server rejected STARTTLS: {}", response.trim());
             }
@@ -3306,31 +3480,54 @@ impl ImapClient {
             .context("IMAP TLS handshake failed")?;
         let mut reader = BufReader::new(stream);
         if account.imap_security == Security::Tls {
-            let mut greeting = String::new();
-            reader.read_line(&mut greeting).await?;
+            let greeting = timeout(
+                IMAP_COMMAND_TIMEOUT,
+                read_imap_line_limited(&mut reader, MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES),
+            )
+            .await
+            .context("IMAP greeting timed out")??;
             if !greeting.starts_with("* OK") {
                 bail!("IMAP server rejected connection: {}", greeting.trim());
             }
         }
         Ok(Self { reader, tag: 0 })
     }
+}
 
+// Keeping command framing generic lets the protocol state machine be driven
+// by a deterministic local socket in tests. Production construction remains
+// the Rustls-only `ImapClient::connect` implementation above.
+impl<S> ImapClient<S>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
     async fn authenticate(&mut self, account: &Account, secret: &str) -> Result<()> {
-        match &account.auth {
-            AccountAuth::Password { username } => {
-                self.command(&format!(
+        let result = match &account.auth {
+            AccountAuth::Password { username } => self
+                .command(&format!(
                     "LOGIN {} {}",
                     quote_imap(username),
                     quote_imap(secret)
                 ))
-                .await?;
-            }
+                .await
+                .map(|_| ()),
             AccountAuth::OAuth2 { username, .. } => {
                 let auth =
                     STANDARD.encode(format!("user={username}\x01auth=Bearer {secret}\x01\x01"));
                 self.command(&format!("AUTHENTICATE XOAUTH2 {auth}"))
-                    .await?;
+                    .await
+                    .map(|_| ())
             }
+        };
+        if let Err(error) = result {
+            // A tagged NO/BAD while executing the authentication command is
+            // an authentication rejection. BYE, EOF, timeout, and other
+            // transport failures must remain retryable; callers use the
+            // authentication wording to decide whether realtime should pause.
+            if error.to_string().starts_with("IMAP command failed:") {
+                return Err(error).context("IMAP authentication rejected");
+            }
+            return Err(error);
         }
         Ok(())
     }
@@ -3352,12 +3549,15 @@ impl ImapClient {
         let mut pending_change = false;
         loop {
             let mut continuation = String::new();
-            timeout(
+            let read = timeout(
                 IMAP_COMMAND_TIMEOUT,
                 self.reader.read_line(&mut continuation),
             )
             .await
             .context("IMAP IDLE continuation timed out")??;
+            if read == 0 {
+                bail!("IMAP connection closed before IDLE continuation");
+            }
             if continuation.starts_with('+') {
                 break;
             }
@@ -3403,9 +3603,15 @@ impl ImapClient {
         self.reader.get_mut().flush().await?;
         loop {
             let mut line = String::new();
-            timeout(IMAP_COMMAND_TIMEOUT, self.reader.read_line(&mut line))
+            let read = timeout(IMAP_COMMAND_TIMEOUT, self.reader.read_line(&mut line))
                 .await
                 .context("IMAP IDLE termination timed out")??;
+            if read == 0 {
+                bail!("IMAP connection closed during IDLE termination");
+            }
+            if line.to_ascii_uppercase().starts_with("* BYE") {
+                bail!("IMAP server closed the connection during IDLE termination");
+            }
             if line.starts_with(&tag) {
                 if !line[tag.len()..].trim_start().starts_with("OK") {
                     bail!("IMAP IDLE termination failed: {}", line.trim());
@@ -3523,6 +3729,17 @@ impl ImapClient {
                 .read_command_line_limited(MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES)
                 .await?;
             transcript_bytes = reserve_imap_transcript_budget(transcript_bytes, line.len())?;
+            let upper = line.trim_start().to_ascii_uppercase();
+            let is_bye = upper.strip_prefix("* BYE").is_some_and(|suffix| {
+                suffix.is_empty()
+                    || suffix
+                        .as_bytes()
+                        .first()
+                        .is_some_and(u8::is_ascii_whitespace)
+            });
+            if is_bye {
+                bail!("IMAP server closed the connection: {}", line.trim());
+            }
             if is_untagged_fetch_start(&line) {
                 current_fetch_uid = None;
                 pending_fetch_literals.clear();
@@ -3559,7 +3776,6 @@ impl ImapClient {
                 if !line[tag.len()..].trim_start().starts_with("OK") {
                     bail!("IMAP command failed: {}", line.trim());
                 }
-                lines.push(line);
                 break;
             }
         }
@@ -3567,20 +3783,25 @@ impl ImapClient {
     }
 
     async fn read_command_line_limited(&mut self, max_bytes: usize) -> Result<String> {
-        let mut bytes = Vec::new();
-        loop {
-            let byte = self
-                .reader
-                .read_u8()
-                .await
-                .context("IMAP connection closed during command")?;
-            if bytes.len() >= max_bytes {
-                bail!("IMAP response line exceeds MIME safety limit");
-            }
-            bytes.push(byte);
-            if byte == b'\n' {
-                return String::from_utf8(bytes).context("IMAP response line is not valid UTF-8");
-            }
+        read_imap_line_limited(&mut self.reader, max_bytes)
+            .await
+            .context("IMAP connection closed during command")
+    }
+}
+
+async fn read_imap_line_limited<R>(reader: &mut R, max_bytes: usize) -> Result<String>
+where
+    R: AsyncBufRead + Unpin,
+{
+    let mut bytes = Vec::new();
+    loop {
+        let byte = reader.read_u8().await?;
+        if bytes.len() >= max_bytes {
+            bail!("IMAP response line exceeds MIME safety limit");
+        }
+        bytes.push(byte);
+        if byte == b'\n' {
+            return String::from_utf8(bytes).context("IMAP response line is not valid UTF-8");
         }
     }
 }
@@ -3723,9 +3944,15 @@ fn literal_data_item(line: &str) -> ImapLiteralItem {
 }
 
 fn literal_length(line: &str) -> Option<usize> {
+    let line = line.trim_end_matches(['\r', '\n']);
+    if !line.ends_with('}') {
+        return None;
+    }
     let start = line.rfind('{')? + 1;
-    let end = line[start..].find('}')? + start;
-    line[start..end].trim_end_matches('+').parse().ok()
+    let length = line[start..line.len() - 1].trim_end_matches('+');
+    (!length.is_empty() && length.bytes().all(|byte| byte.is_ascii_digit()))
+        .then(|| length.parse().ok())
+        .flatten()
 }
 
 fn quote_imap(value: &str) -> String {
@@ -5509,10 +5736,11 @@ pub fn safe_attachment_filename(value: &str, index: usize) -> String {
         value
     };
     let truncated = truncate_filename_bytes(value, 180);
+    let truncated = truncated.trim().trim_matches('.').trim();
     if truncated.is_empty() {
         format!("attachment-{}", index + 1)
     } else {
-        truncated
+        truncated.to_owned()
     }
 }
 
@@ -5542,6 +5770,7 @@ pub fn safe_mime_type(value: &str) -> String {
     let valid = value.split_once('/').is_some_and(|(kind, subtype)| {
         !kind.is_empty()
             && !subtype.is_empty()
+            && !subtype.contains('/')
             && value.chars().all(|character| {
                 character.is_ascii_alphanumeric()
                     || matches!(character, '/' | '.' | '+' | '-' | '_')
@@ -5586,6 +5815,620 @@ pub fn is_potentially_unsafe(filename: &str, mime_type: &str) -> bool {
 mod tests {
     use super::*;
     use crate::{provider, AccountDraft};
+    use lettre::transport::smtp::client::Certificate;
+    use tokio::{
+        io::{duplex, split, AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream},
+        net::{TcpListener, TcpStream},
+        sync::watch,
+    };
+    use tokio_rustls::{
+        rustls::{
+            pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer},
+            ServerConfig,
+        },
+        TlsAcceptor,
+    };
+
+    /// A deliberately small transcript harness. The client is the production
+    /// command state machine; only the transport is plain loopback TCP so the
+    /// fixture can control byte fragmentation without changing TLS policy.
+    async fn plain_imap_client_and_server() -> (ImapClient<TcpStream>, TcpStream) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let client = TcpStream::connect(address).await.unwrap();
+        let (server, _) = listener.accept().await.unwrap();
+        (
+            ImapClient {
+                reader: BufReader::new(client),
+                tag: 0,
+            },
+            server,
+        )
+    }
+
+    async fn scripted_command<R>(reader: &mut BufReader<R>) -> (String, String)
+    where
+        R: AsyncRead + Unpin,
+    {
+        let mut command = String::new();
+        reader.read_line(&mut command).await.unwrap();
+        let (tag, command) = command.trim_end().split_once(' ').unwrap();
+        (tag.to_owned(), command.to_owned())
+    }
+
+    async fn scripted_expect_command<R>(
+        reader: &mut BufReader<R>,
+        transcript: &mut Vec<String>,
+        expected: &str,
+    ) -> String
+    where
+        R: AsyncRead + Unpin,
+    {
+        let (tag, command) = scripted_command(reader).await;
+        transcript.push(command.clone());
+        assert_eq!(command, expected);
+        tag
+    }
+
+    async fn write_transcript_fragments(
+        writer: &mut tokio::net::tcp::OwnedWriteHalf,
+        fragments: &[&[u8]],
+    ) {
+        for fragment in fragments {
+            writer.write_all(fragment).await.unwrap();
+            writer.flush().await.unwrap();
+        }
+    }
+
+    async fn scripted_inbox_sync_server(
+        server: TcpStream,
+        uid_validity: u32,
+        remote_uids: &[u32],
+        fetched_uid: u32,
+        subject: &str,
+    ) -> Vec<String> {
+        let (read, mut write) = server.into_split();
+        let mut read = BufReader::new(read);
+        let mut transcript = Vec::new();
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            "LOGIN \"reader@example.test\" \"sync secret\"",
+        )
+        .await;
+        let response = format!("{tag} OK authenticated\r\n");
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+        let response = format!("* LIST (\\\\HasNoChildren) \"/\" \"INBOX\"\r\n{tag} OK listed\r\n");
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+        let response = format!(
+            "* {} EXISTS\r\n* OK [UIDVALIDITY {uid_validity}] UIDs valid\r\n{tag} OK selected\r\n",
+            remote_uids.len()
+        );
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "UID SEARCH ALL").await;
+        let response = format!(
+            "* SEARCH {}\r\n{tag} OK searched\r\n",
+            remote_uids
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(" ")
+        );
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        // Keep this exact single exchange in the transcript: a duplicate
+        // flags request previously doubled the provider work before download.
+        let tag =
+            scripted_expect_command(&mut read, &mut transcript, "UID FETCH 1:* (UID FLAGS)").await;
+        let flags = remote_uids
+            .iter()
+            .map(|uid| format!("* 1 FETCH (UID {uid} FLAGS ())\r\n"))
+            .collect::<String>();
+        let response = format!("{flags}{tag} OK flags\r\n");
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+        let response = format!(
+            "* {} EXISTS\r\n* OK [UIDVALIDITY {uid_validity}] UIDs valid\r\n{tag} OK selected\r\n",
+            remote_uids.len()
+        );
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let metadata_fields = "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]";
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            &format!("UID FETCH {fetched_uid} ({metadata_fields})"),
+        )
+        .await;
+        let headers = format!(
+            "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: {subject}\r\nMessage-ID: <{fetched_uid}@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
+        );
+        let response = format!(
+            "* 1 FETCH (UID {fetched_uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" RFC822.SIZE 5 BODYSTRUCTURE (\"TEXT\" \"PLAIN\" (\"CHARSET\" \"UTF-8\") NIL NIL \"7BIT\" 5 1) BODY[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)] {{{}}}\r\n",
+            headers.len()
+        );
+        write.write_all(response.as_bytes()).await.unwrap();
+        write.write_all(headers.as_bytes()).await.unwrap();
+        let response = format!(")\r\n{tag} OK metadata\r\n");
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            &format!("UID FETCH {fetched_uid} (BODY.PEEK[]<0.8192>)"),
+        )
+        .await;
+        let response = format!(
+            "* 1 FETCH (UID {fetched_uid} BODY[]<0> {{5}}\r\nhello)\r\n{tag} OK preview\r\n"
+        );
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let _ = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+        transcript
+    }
+
+    #[tokio::test]
+    async fn scripted_mail_service_inbox_sync_persists_incremental_uid_and_isolates_accounts() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("scripted-mail-service.sqlite");
+        let store = Store::open(&database).await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        let mut other_account = test_account();
+        other_account.email = "other@example.test".into();
+        other_account.account_name = other_account.email.clone();
+        store.save_account(&account).await.unwrap();
+        store.save_account(&other_account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+
+        let (mut first_client, first_server) = plain_imap_client_and_server().await;
+        let first_server = tokio::spawn(scripted_inbox_sync_server(
+            first_server,
+            77,
+            &[42],
+            42,
+            "Initial transcript message",
+        ));
+        let first = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut first_client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        assert_eq!(first.synced_count, 1);
+        assert!(
+            first.new_messages.is_empty(),
+            "initial catalogue is not new mail"
+        );
+        assert_eq!(
+            first_server.await.unwrap(),
+            vec![
+                "LOGIN \"reader@example.test\" \"sync secret\"",
+                "LIST \"\" \"*\"",
+                "SELECT \"INBOX\"",
+                "UID SEARCH ALL",
+                "UID FETCH 1:* (UID FLAGS)",
+                "SELECT \"INBOX\"",
+                "UID FETCH 42 (FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)])",
+                "UID FETCH 42 (BODY.PEEK[]<0.8192>)",
+                "LOGOUT",
+            ]
+        );
+
+        let (mut second_client, second_server) = plain_imap_client_and_server().await;
+        let second_server = tokio::spawn(scripted_inbox_sync_server(
+            second_server,
+            77,
+            &[42, 43],
+            43,
+            "Incremental transcript message",
+        ));
+        let second = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut second_client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        assert_eq!(second.synced_count, 1);
+        assert_eq!(
+            second
+                .new_messages
+                .iter()
+                .map(|message| message.uid)
+                .collect::<Vec<_>>(),
+            vec![43]
+        );
+
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [42, 43].into()
+        );
+        assert!(store
+            .mailbox_uids(other_account.id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            store
+                .message_by_locator(account.id, "INBOX", 43)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Incremental transcript message"
+        );
+        let state = store
+            .mailbox_catalog_state(account.id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.uid_validity, 77);
+        assert_eq!(state.remote_total, 2);
+        assert!(state.historical_complete);
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(43)
+        );
+        assert_eq!(
+            second_server.await.unwrap(),
+            vec![
+                "LOGIN \"reader@example.test\" \"sync secret\"",
+                "LIST \"\" \"*\"",
+                "SELECT \"INBOX\"",
+                "UID SEARCH ALL",
+                "UID FETCH 1:* (UID FLAGS)",
+                "SELECT \"INBOX\"",
+                "UID FETCH 43 (FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)])",
+                "UID FETCH 43 (BODY.PEEK[]<0.8192>)",
+                "LOGOUT",
+            ]
+        );
+
+        drop(service);
+        drop(store);
+        let reopened = Store::open(&database).await.unwrap();
+        assert_eq!(
+            reopened.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [42, 43].into()
+        );
+        assert!(reopened
+            .mailbox_uids(other_account.id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            reopened
+                .message_by_locator(account.id, "INBOX", 43)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Incremental transcript message"
+        );
+    }
+
+    // Test-only CA plus leaf certificate for 127.0.0.1/localhost. The
+    // private key is intentionally public: it exists solely to make the
+    // loopback TLS transcripts deterministic while still verifying a test CA.
+    const SMTP_TEST_CA_DER_BASE64: &str = "MIIBoDCCAUWgAwIBAgIUQltW8tjmRLr4QjHNjnIXOGd4oqcwCgYIKoZIzj0EAwIwHTEbMBkGA1UEAwwSRGFraWEgU01UUCB0ZXN0IENBMB4XDTI2MDczMDE2MDE1NFoXDTM2MDcyNzE2MDE1NFowHTEbMBkGA1UEAwwSRGFraWEgU01UUCB0ZXN0IENBMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEowlFdKeMeRMDaJroLiqhOMAQ1dKYMuoX/SXdgSSY0fIcL7K4mv7z8Xqg5iLrw84NQxGZt36GLxNaGfSLmCR6nqNjMGEwHQYDVR0OBBYEFKzJ36GY9x0+2bor86BZVX+U3mOLMB8GA1UdIwQYMBaAFKzJ36GY9x0+2bor86BZVX+U3mOLMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgKEMAoGCCqGSM49BAMCA0kAMEYCIQD5sjoNPPW9m+gCspyKyj9AOdgwZiavQhgDeIvu5hzVgQIhALJpuju+3/idyBTJ1qGomBG4aRuIO9cHhLwuMtAVtMvt";
+    const SMTP_TEST_CERT_DER_BASE64: &str = "MIIBxjCCAWygAwIBAgIUM95kwE13FWtKVQEkqO3f8DeMFAgwCgYIKoZIzj0EAwIwHTEbMBkGA1UEAwwSRGFraWEgU01UUCB0ZXN0IENBMB4XDTI2MDczMDE2MDE1NFoXDTM2MDcyNzE2MDE1NFowFDESMBAGA1UEAwwJbG9jYWxob3N0MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAElFRQ2c4qt7037iUsrzdKiDrS/euRkQ3z5uCpfrYsFVhe3g4ffc5IBLZDWSEUP0EJvyEOOg5KL1by1ZGYC/d+S6OBkjCBjzAMBgNVHRMBAf8EAjAAMA4GA1UdDwEB/wQEAwIHgDATBgNVHSUEDDAKBggrBgEFBQcDATAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwHQYDVR0OBBYEFM3UTgErLg6p5+pv13yFNths9Lb9MB8GA1UdIwQYMBaAFKzJ36GY9x0+2bor86BZVX+U3mOLMAoGCCqGSM49BAMCA0gAMEUCIEmgwMiWttP7OvYXRkvPm/5c64vpxLLtT+Jg6E4g+OnYAiEAp742aGep2AEwIRP9YXI8RLjhaseLGUQT7R4AWFwnYZE=";
+    const SMTP_TEST_KEY_DER_BASE64: &str = "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg8ZClgJ8kAl4AVnA0D9d0PXx2siCJiOmjud/vD1NKSqehRANCAASUVFDZziq3vTfuJSyvN0qIOtL965GRDfPm4Kl+tiwVWF7eDh99zkgEtkNZIRQ/QQm/IQ46DkovVvLVkZgL935L";
+
+    fn smtp_test_acceptor() -> TlsAcceptor {
+        let certificate = CertificateDer::from(STANDARD.decode(SMTP_TEST_CERT_DER_BASE64).unwrap());
+        let key = PrivateKeyDer::Pkcs8(PrivatePkcs8KeyDer::from(
+            STANDARD.decode(SMTP_TEST_KEY_DER_BASE64).unwrap(),
+        ));
+        let config = ServerConfig::builder()
+            .with_no_client_auth()
+            .with_single_cert(vec![certificate], key)
+            .unwrap();
+        TlsAcceptor::from(Arc::new(config))
+    }
+
+    fn smtp_test_account(security: Security, port: u16) -> Account {
+        let mut account = test_account();
+        account.email = "sender@example.test".into();
+        account.auth = AccountAuth::Password {
+            username: "sender@example.test".into(),
+        };
+        account.smtp_host = "127.0.0.1".into();
+        account.smtp_port = port;
+        account.smtp_security = security;
+        account
+    }
+
+    fn smtp_test_tls_parameters(account: &Account) -> TlsParameters {
+        let certificate =
+            Certificate::from_der(STANDARD.decode(SMTP_TEST_CA_DER_BASE64).unwrap()).unwrap();
+        TlsParameters::builder(account.smtp_host.clone())
+            .add_root_certificate(certificate)
+            .build()
+            .unwrap()
+    }
+
+    fn smtp_test_endpoint(account: &Account) -> SmtpEndpoint {
+        SmtpEndpoint {
+            host: account.smtp_host.clone(),
+            port: account.smtp_port,
+            tls_parameters: smtp_test_tls_parameters(account),
+        }
+    }
+
+    fn smtp_test_envelope() -> Envelope {
+        Envelope::new(
+            Some("sender@example.test".parse().unwrap()),
+            vec!["recipient@example.test".parse().unwrap()],
+        )
+        .unwrap()
+    }
+
+    async fn smtp_command<S>(connection: &mut BufReader<S>) -> String
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let mut command = String::new();
+        assert_ne!(connection.read_line(&mut command).await.unwrap(), 0);
+        command
+    }
+
+    async fn smtp_reply<S>(connection: &mut BufReader<S>, response: &str)
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        connection
+            .get_mut()
+            .write_all(response.as_bytes())
+            .await
+            .unwrap();
+        connection.get_mut().flush().await.unwrap();
+    }
+
+    async fn smtp_expect_ehlo_and_auth<S>(connection: &mut BufReader<S>, reject: bool)
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        assert!(smtp_command(connection).await.starts_with("EHLO "));
+        smtp_reply(
+            connection,
+            "250-localhost\r\n250-AUTH PLAIN\r\n250 8BITMIME\r\n",
+        )
+        .await;
+        let auth = smtp_command(connection).await;
+        assert_eq!(auth, "AUTH PLAIN AHNlbmRlckBleGFtcGxlLnRlc3QAc2VjcmV0\r\n");
+        smtp_reply(
+            connection,
+            if reject {
+                "535 5.7.8 invalid credentials\r\n"
+            } else {
+                "235 2.7.0 authenticated\r\n"
+            },
+        )
+        .await;
+    }
+
+    async fn smtp_expect_envelope_until_data<S>(connection: &mut BufReader<S>)
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        assert_eq!(
+            smtp_command(connection).await,
+            "MAIL FROM:<sender@example.test>\r\n"
+        );
+        smtp_reply(connection, "250 2.1.0 sender accepted\r\n").await;
+        assert_eq!(
+            smtp_command(connection).await,
+            "RCPT TO:<recipient@example.test>\r\n"
+        );
+        smtp_reply(connection, "250 2.1.5 recipient accepted\r\n").await;
+        assert_eq!(smtp_command(connection).await, "DATA\r\n");
+        smtp_reply(connection, "354 send message\r\n").await;
+    }
+
+    async fn smtp_read_message<S>(connection: &mut BufReader<S>) -> String
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let mut message = String::new();
+        loop {
+            let line = smtp_command(connection).await;
+            if line == ".\r\n" {
+                return message;
+            }
+            message.push_str(&line);
+        }
+    }
+
+    #[tokio::test]
+    async fn scripted_smtp_implicit_tls_rejects_a_recipient_after_authentication() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let account = smtp_test_account(Security::Tls, listener.local_addr().unwrap().port());
+        let acceptor = smtp_test_acceptor();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let stream = acceptor.accept(stream).await.unwrap();
+            let mut connection = BufReader::new(stream);
+            smtp_reply(&mut connection, "220 localhost ready\r\n").await;
+            smtp_expect_ehlo_and_auth(&mut connection, false).await;
+            assert_eq!(
+                smtp_command(&mut connection).await,
+                "MAIL FROM:<sender@example.test>\r\n"
+            );
+            smtp_reply(&mut connection, "250 2.1.0 sender accepted\r\n").await;
+            assert_eq!(
+                smtp_command(&mut connection).await,
+                "RCPT TO:<recipient@example.test>\r\n"
+            );
+            smtp_reply(&mut connection, "550 5.1.1 no such recipient\r\n").await;
+        });
+
+        let error = send_smtp_raw(
+            &account,
+            &smtp_test_envelope(),
+            b"From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: RCPT\r\n\r\nhello\r\n",
+            "secret",
+            smtp_test_endpoint(&account),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        server.await.unwrap();
+        assert!(error.to_string().contains("550"), "{error:#}");
+        assert!(!error.to_string().contains("may be uncertain"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn scripted_smtp_starttls_rejects_bad_credentials_before_envelope_submission() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let account = smtp_test_account(Security::StartTls, listener.local_addr().unwrap().port());
+        let acceptor = smtp_test_acceptor();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut plaintext = BufReader::new(stream);
+            smtp_reply(&mut plaintext, "220 localhost ready\r\n").await;
+            assert!(smtp_command(&mut plaintext).await.starts_with("EHLO "));
+            smtp_reply(
+                &mut plaintext,
+                "250-localhost\r\n250-STARTTLS\r\n250 AUTH PLAIN\r\n",
+            )
+            .await;
+            assert_eq!(smtp_command(&mut plaintext).await, "STARTTLS\r\n");
+            smtp_reply(&mut plaintext, "220 2.0.0 start TLS\r\n").await;
+
+            let stream = acceptor.accept(plaintext.into_inner()).await.unwrap();
+            let mut encrypted = BufReader::new(stream);
+            smtp_expect_ehlo_and_auth(&mut encrypted, true).await;
+        });
+
+        let error = send_smtp_raw(
+            &account,
+            &smtp_test_envelope(),
+            b"From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: auth\r\n\r\nhello\r\n",
+            "secret",
+            smtp_test_endpoint(&account),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        server.await.unwrap();
+        assert!(error.to_string().contains("535"), "{error:#}");
+        assert!(!error.to_string().contains("may be uncertain"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn scripted_smtp_starttls_eof_after_data_reports_uncertain_delivery() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let account = smtp_test_account(Security::StartTls, listener.local_addr().unwrap().port());
+        let acceptor = smtp_test_acceptor();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut plaintext = BufReader::new(stream);
+            smtp_reply(&mut plaintext, "220 localhost ready\r\n").await;
+            assert!(smtp_command(&mut plaintext).await.starts_with("EHLO "));
+            smtp_reply(
+                &mut plaintext,
+                "250-localhost\r\n250-STARTTLS\r\n250 AUTH PLAIN\r\n",
+            )
+            .await;
+            assert_eq!(smtp_command(&mut plaintext).await, "STARTTLS\r\n");
+            smtp_reply(&mut plaintext, "220 2.0.0 start TLS\r\n").await;
+
+            let stream = acceptor.accept(plaintext.into_inner()).await.unwrap();
+            let mut encrypted = BufReader::new(stream);
+            smtp_expect_ehlo_and_auth(&mut encrypted, false).await;
+            smtp_expect_envelope_until_data(&mut encrypted).await;
+            let message = smtp_read_message(&mut encrypted).await;
+            assert!(message.contains("Subject: uncertain delivery"));
+            // The terminating dot has been consumed, but the server closes
+            // before its final 250. The client cannot know whether the relay
+            // accepted, queued, or lost the submission.
+        });
+
+        let error = send_smtp_raw(
+            &account,
+            &smtp_test_envelope(),
+            b"From: sender@example.test\r\nTo: recipient@example.test\r\nSubject: uncertain delivery\r\n\r\nhello\r\n",
+            "secret",
+            smtp_test_endpoint(&account),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap_err();
+        server.await.unwrap();
+        assert!(
+            error.to_string().contains("delivery may be uncertain"),
+            "{error:#}"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_mail_service_send_builds_message_and_skips_duplicate_gmail_append() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let transport_account =
+            smtp_test_account(Security::Tls, listener.local_addr().unwrap().port());
+        let acceptor = smtp_test_acceptor();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let stream = acceptor.accept(stream).await.unwrap();
+            let mut connection = BufReader::new(stream);
+            smtp_reply(&mut connection, "220 localhost ready\r\n").await;
+            smtp_expect_ehlo_and_auth(&mut connection, false).await;
+            smtp_expect_envelope_until_data(&mut connection).await;
+            let message = smtp_read_message(&mut connection).await;
+            assert!(message.contains("Subject: MailService transcript"));
+            assert!(message.contains("plain body"));
+            assert!(message.contains("HTML body"));
+            smtp_reply(&mut connection, "250 2.0.0 queued as fixture-42\r\n").await;
+        });
+
+        let service = MailService::new(Store::in_memory().await.unwrap());
+        let endpoint = smtp_test_endpoint(&transport_account);
+        let mut gmail = transport_account;
+        // The exact production Gmail submission host is the provider contract
+        // that prevents a second IMAP APPEND after SMTP accepts the message.
+        gmail.smtp_host = "smtp.gmail.com".into();
+        let draft = ComposeMessage {
+            account_id: gmail.id,
+            to: vec!["recipient@example.test".into()],
+            cc: Vec::new(),
+            bcc: Vec::new(),
+            subject: "MailService transcript".into(),
+            body_text: "plain body".into(),
+            body_html: Some("<p>HTML body</p>".into()),
+            in_reply_to: None,
+            references: None,
+            attachments: Vec::new(),
+        };
+        let response = service
+            .send_with_smtp_endpoint(&gmail, &draft, "secret", endpoint, Duration::from_secs(1))
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(response.contains("queued as fixture-42"));
+    }
 
     fn test_account() -> Account {
         AccountDraft {
@@ -5638,6 +6481,221 @@ mod tests {
                 include_bytes!("../testdata/mime/truncated-multipart-lf.eml")
             }
             _ => panic!("unknown MIME corpus fixture: {name}"),
+        }
+    }
+
+    #[derive(Clone)]
+    struct FixtureImapSection {
+        headers: Vec<u8>,
+        body: Vec<u8>,
+    }
+
+    /// The conformance server derives its IMAP view from the exact checked-in
+    /// RFC822 bytes.  It deliberately does not use decoded parser contents:
+    /// selective fetches must receive the same transfer-encoded leaf bytes a
+    /// real server would return for BODY[section].
+    struct FixtureImapMessage {
+        bodystructure: String,
+        root_headers: Vec<u8>,
+        sections: BTreeMap<String, FixtureImapSection>,
+    }
+
+    fn fixture_imap_message(raw: &[u8]) -> Result<FixtureImapMessage> {
+        let parsed = parse_complete_message(raw)?;
+        let root = parsed.part(0).context("fixture parser omitted root part")?;
+        let mut sections = BTreeMap::new();
+        let bodystructure = fixture_bodystructure_part(&parsed, 0, raw, &[], &mut sections)?;
+        let root_headers = raw
+            .get(root.raw_header_offset() as usize..root.raw_body_offset() as usize)
+            .context("fixture root header offsets are invalid")?
+            .to_vec();
+        Ok(FixtureImapMessage {
+            bodystructure,
+            root_headers,
+            sections,
+        })
+    }
+
+    fn fixture_bodystructure_part(
+        message: &ParsedMessage<'_>,
+        part_id: u32,
+        raw: &[u8],
+        path: &[usize],
+        sections: &mut BTreeMap<String, FixtureImapSection>,
+    ) -> Result<String> {
+        let part = message
+            .part(part_id)
+            .context("fixture parser omitted MIME part")?;
+        let section = FixtureImapSection {
+            headers: raw
+                .get(part.raw_header_offset() as usize..part.raw_body_offset() as usize)
+                .context("fixture MIME header offsets are invalid")?
+                .to_vec(),
+            body: raw
+                .get(part.raw_body_offset() as usize..part.raw_end_offset() as usize)
+                .context("fixture MIME body offsets are invalid")?
+                .to_vec(),
+        };
+        sections.insert(section_name(path), section);
+
+        let content_type = part
+            .content_type()
+            .context("fixture MIME part omitted Content-Type")?;
+        if let Some(children) = part.sub_parts() {
+            let mut values = Vec::with_capacity(children.len() + 5);
+            for (index, child) in children.iter().enumerate() {
+                let mut child_path = path.to_vec();
+                child_path.push(index + 1);
+                values.push(fixture_bodystructure_part(
+                    message,
+                    *child,
+                    raw,
+                    &child_path,
+                    sections,
+                )?);
+            }
+            values.push(imap_fixture_string(
+                content_type.subtype().unwrap_or("mixed"),
+            ));
+            values.push(imap_fixture_params(content_type.attributes()));
+            values.push(imap_fixture_disposition(part));
+            values.push("NIL".into());
+            values.push("NIL".into());
+            return Ok(format!("({})", values.join(" ")));
+        }
+
+        let raw_size = part.raw_end_offset().saturating_sub(part.raw_body_offset()) as usize;
+        Ok(format!(
+            "({} {} {} {} NIL {} {} 0 {} NIL NIL)",
+            imap_fixture_string(content_type.ctype()),
+            imap_fixture_string(content_type.subtype().unwrap_or("plain")),
+            imap_fixture_params(content_type.attributes()),
+            part.content_id()
+                .map(imap_fixture_string)
+                .unwrap_or_else(|| "NIL".into()),
+            imap_fixture_string(part.content_transfer_encoding().unwrap_or("7BIT")),
+            raw_size,
+            imap_fixture_disposition(part),
+        ))
+    }
+
+    fn imap_fixture_params(attributes: Option<&[mail_parser::Attribute<'_>]>) -> String {
+        let Some(attributes) = attributes.filter(|attributes| !attributes.is_empty()) else {
+            return "NIL".into();
+        };
+        let mut values = Vec::with_capacity(attributes.len() * 2);
+        for attribute in attributes {
+            values.push(imap_fixture_string(&attribute.name));
+            values.push(imap_fixture_string(&attribute.value));
+        }
+        format!("({})", values.join(" "))
+    }
+
+    fn imap_fixture_disposition(part: &MessagePart<'_>) -> String {
+        let Some(disposition) = part.content_disposition() else {
+            return "NIL".into();
+        };
+        format!(
+            "({} {})",
+            imap_fixture_string(disposition.ctype()),
+            imap_fixture_params(disposition.attributes())
+        )
+    }
+
+    fn imap_fixture_string(value: &str) -> String {
+        format!(
+            "\"{}\"",
+            value
+                .replace('\\', "\\\\")
+                .replace('"', "\\\"")
+                .replace(['\r', '\n'], " ")
+        )
+    }
+
+    async fn serve_fixture_selective_sections(
+        stream: DuplexStream,
+        uid: u32,
+        sections: BTreeMap<String, FixtureImapSection>,
+    ) -> Result<BTreeSet<String>> {
+        let (read, mut write) = split(stream);
+        let mut reader = BufReader::new(read);
+        let mut served = BTreeSet::new();
+        loop {
+            let mut line = String::new();
+            if reader.read_line(&mut line).await? == 0 {
+                return Ok(served);
+            }
+            let (tag, command) = line
+                .trim_end()
+                .split_once(' ')
+                .context("fixture server received an untagged command")?;
+            let section = command
+                .split_once("BODY.PEEK[")
+                .and_then(|(_, rest)| rest.split_once(']'))
+                .map(|(section, _)| section)
+                .context("fixture server received a non-sectioned fetch")?;
+            let (path, mime_headers) = section
+                .strip_suffix(".MIME")
+                .map(|path| (path, true))
+                .unwrap_or((section, false));
+            let key = if path.eq_ignore_ascii_case("TEXT") {
+                ""
+            } else {
+                path
+            };
+            let item = sections
+                .get(key)
+                .with_context(|| format!("fixture server lacks BODY[{section}]"))?;
+            let bytes = if mime_headers {
+                &item.headers
+            } else {
+                &item.body
+            };
+            served.insert(section.to_owned());
+            write
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID {uid} BODY[{section}] {{{}}}\r\n",
+                        bytes.len()
+                    )
+                    .as_bytes(),
+                )
+                .await?;
+            write.write_all(bytes).await?;
+            write
+                .write_all(format!("\r\n)\r\n{tag} OK FETCH completed\r\n").as_bytes())
+                .await?;
+            write.flush().await?;
+        }
+    }
+
+    #[derive(Debug, PartialEq, Eq)]
+    struct SelectiveUserVisibleSemantics {
+        body_text: String,
+        body_html: Option<String>,
+        snippet: String,
+        attachments: Vec<(String, String, bool, String)>,
+    }
+
+    fn selective_user_visible_semantics(message: &MailSummary) -> SelectiveUserVisibleSemantics {
+        let mut attachments = message
+            .attachments
+            .iter()
+            .map(|attachment| {
+                (
+                    attachment.attachment.filename.clone(),
+                    attachment.attachment.mime_type.clone(),
+                    attachment.attachment.is_inline,
+                    format!("{:?}", attachment.attachment.presentation),
+                )
+            })
+            .collect::<Vec<_>>();
+        attachments.sort();
+        SelectiveUserVisibleSemantics {
+            body_text: message.body_text.clone(),
+            body_html: message.body_html.clone(),
+            snippet: message.snippet.clone(),
+            attachments,
         }
     }
 
@@ -5941,6 +6999,148 @@ mod tests {
             assert!(headers.snippet.is_empty(), "{name}");
             assert!(headers.body_text.is_empty(), "{name}");
             assert!(headers.attachments.is_empty(), "{name}");
+        }
+    }
+
+    #[tokio::test]
+    async fn realistic_selective_bodystructure_fixtures_match_complete_parser_and_starred_storage()
+    {
+        // Keep this list in lockstep with `selective-bodystructure` in the
+        // governed manifest. Each fixture is served as transfer-encoded IMAP
+        // sections generated from its actual raw RFC822 representation.
+        let cases = [
+            "attached-message-rfc822",
+            "format-flowed-delsp",
+            "linkedin-inline-content-id",
+            "multipart-attachment-container",
+            "provider-signature-inline",
+        ];
+        let manifest: serde_json::Value = serde_json::from_str(include_str!(
+            "../../../testdata/realistic-fixtures.manifest.json"
+        ))
+        .unwrap();
+        let mut declared = manifest["fixtures"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|fixture| {
+                fixture["path"]
+                    .as_str()
+                    .is_some_and(|path| path.ends_with(".eml"))
+                    && fixture["applicablePaths"].as_array().is_some_and(|paths| {
+                        paths
+                            .iter()
+                            .any(|path| path.as_str() == Some("selective-bodystructure"))
+                    })
+            })
+            .map(|fixture| {
+                fixture["id"]
+                    .as_str()
+                    .unwrap()
+                    .trim_start_matches("mime.")
+                    .to_owned()
+            })
+            .collect::<Vec<_>>();
+        declared.sort();
+        assert_eq!(
+            declared, cases,
+            "manifest selective fixtures must all be covered"
+        );
+        let account = test_account();
+        let response_lines = vec![
+            "* 1 FETCH (UID 1 FLAGS (\\Seen \\Flagged) INTERNALDATE \"21-Jul-2026 10:00:00 +0000\")"
+                .to_owned(),
+        ];
+        let mut complete_messages = Vec::new();
+
+        for (index, name) in cases.iter().enumerate() {
+            let raw = if *name == "provider-signature-inline" {
+                include_bytes!("../tests/fixtures/provider-signature-inline.eml").as_slice()
+            } else {
+                mime_corpus(name)
+            };
+            let uid = index as u32 + 1;
+            let complete = parse_message(&account, "INBOX", uid, &response_lines, raw, None)
+                .await
+                .unwrap_or_else(|error| panic!("{name} complete parse failed: {error}"));
+            let fixture = fixture_imap_message(raw)
+                .unwrap_or_else(|error| panic!("{name} fixture IMAP derivation failed: {error}"));
+            let structure = parse_bodystructure(&[format!(
+                "* 1 FETCH (UID {uid} BODYSTRUCTURE {})",
+                fixture.bodystructure
+            )])
+            .unwrap_or_else(|error| {
+                panic!("{name} generated BODYSTRUCTURE failed to parse: {error}")
+            });
+            let (client_transport, server_transport) =
+                duplex(MAX_RAW_MESSAGE_BYTES.min(1024 * 1024));
+            let server = tokio::spawn(serve_fixture_selective_sections(
+                server_transport,
+                uid,
+                fixture.sections,
+            ));
+            let mut client = ImapClient {
+                reader: BufReader::new(client_transport),
+                tag: 0,
+            };
+            let selective = fetch_selective_message(
+                &mut client,
+                &account,
+                "INBOX",
+                uid,
+                &response_lines,
+                &fixture.root_headers,
+                &structure,
+            )
+            .await
+            .unwrap_or_else(|error| panic!("{name} selective fetch failed: {error}"));
+            drop(client);
+            let served = server
+                .await
+                .unwrap_or_else(|error| panic!("{name} fixture server panicked: {error}"))
+                .unwrap_or_else(|error| panic!("{name} fixture server failed: {error}"));
+
+            assert!(
+                served
+                    .iter()
+                    .all(|section| { section.as_bytes().first().is_some_and(u8::is_ascii_digit) }),
+                "{name} selective fetch must use only nested BODY sections: {served:?}"
+            );
+            assert_eq!(
+                selective_user_visible_semantics(&selective),
+                selective_user_visible_semantics(&complete),
+                "{name} complete and selective user-visible content diverged"
+            );
+            complete_messages.push(complete);
+        }
+
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("selective-fixtures.sqlite");
+        let store = Store::open(&database).await.unwrap();
+        store.save_account(&account).await.unwrap();
+        store.upsert_messages(&complete_messages).await.unwrap();
+        drop(store);
+
+        let reopened = Store::open(&database).await.unwrap();
+        for complete in &complete_messages {
+            let stored = reopened.message(&complete.id).await.unwrap().unwrap();
+            assert_eq!(stored.body_text, complete.body_text, "{}", complete.id);
+            assert_eq!(stored.body_html, complete.body_html, "{}", complete.id);
+            assert_eq!(stored.snippet, complete.snippet, "{}", complete.id);
+            let metadata = reopened
+                .starred_attachment_metadata(&complete.id)
+                .await
+                .unwrap();
+            assert_eq!(
+                metadata.len(),
+                complete
+                    .attachments
+                    .iter()
+                    .filter(|attachment| attachment.attachment.presentation.is_downloadable())
+                    .count(),
+                "{}",
+                complete.id
+            );
         }
     }
 
@@ -6440,7 +7640,10 @@ mod tests {
         let headers = parse_header_message(&account, "INBOX", 3, &[], raw.as_bytes()).unwrap();
 
         for message in [complete, catalogue, headers] {
-            assert_eq!(message.to_addresses, "Primary <primary@example.test>, Team: second@example.test, Third <third@example.test>;");
+            assert_eq!(
+                message.to_addresses,
+                "Primary <primary@example.test>, Team: second@example.test, Third <third@example.test>;"
+            );
             assert_eq!(
                 message.cc_addresses,
                 "Mära <mara@example.test>, Other <other@example.test>"
@@ -7396,6 +8599,243 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn scripted_imap_transcript_handles_fragmented_literals_and_unsolicited_fetches() {
+        let (mut client, server) = plain_imap_client_and_server().await;
+        let server = tokio::spawn(async move {
+            let (read, mut write) = server.into_split();
+            let mut read = BufReader::new(read);
+            let (tag, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "UID FETCH 42 (BODY.PEEK[1])");
+
+            // Each protocol unit is intentionally split differently. The
+            // final requested literal appears before its UID, while the two
+            // preceding literals belong to unsolicited/wrong FETCH replies.
+            write_transcript_fragments(
+                &mut write,
+                &[
+                    b"* 1 FETCH (UID 7 BODY[1] {5}\r\nwr",
+                    b"ong)\r\n* 2 FETCH (UID 42 BODY[2] {5}\r\nother)\r\n",
+                    b"* 3 FETCH (BODY[1] {5}\r\nright UID 42)\r\n",
+                    format!("{tag} OK FETCH complete\r\n").as_bytes(),
+                ],
+            )
+            .await;
+        });
+
+        let mut response = client
+            .command_with_literal("UID FETCH 42 (BODY.PEEK[1])")
+            .await
+            .unwrap();
+        server.await.unwrap();
+
+        assert_eq!(
+            response.take_body_literal_for(42, "1").as_deref(),
+            Some(b"right".as_slice())
+        );
+        assert_eq!(response.literals.len(), 2);
+        assert!(response
+            .literals
+            .iter()
+            .any(|literal| literal.uid == Some(7)));
+        assert!(response.literals.iter().any(|literal| {
+            literal.uid == Some(42) && literal.data_item == ImapLiteralItem::Body("BODY[2]".into())
+        }));
+        assert_eq!(
+            response
+                .lines
+                .iter()
+                .filter(|line| line.starts_with("D0001 "))
+                .count(),
+            1,
+            "one tagged wire response must produce one transcript line"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_imap_rejects_bye_eof_and_oversize_literal_before_reading_it() {
+        let (mut bye_client, bye_server) = plain_imap_client_and_server().await;
+        let bye_server = tokio::spawn(async move {
+            let (read, mut write) = bye_server.into_split();
+            let mut read = BufReader::new(read);
+            let (_, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "NOOP");
+            write_transcript_fragments(&mut write, &[b"* B", b"YE maintenance\r\n"]).await;
+        });
+        let bye = bye_client.command("NOOP").await.unwrap_err();
+        bye_server.await.unwrap();
+        assert!(bye
+            .to_string()
+            .contains("IMAP server closed the connection: * BYE maintenance"));
+
+        let (mut eof_client, eof_server) = plain_imap_client_and_server().await;
+        let eof_server = tokio::spawn(async move {
+            let (read, _) = eof_server.into_split();
+            let mut read = BufReader::new(read);
+            let (_, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "NOOP");
+        });
+        let eof = eof_client.command("NOOP").await.unwrap_err();
+        eof_server.await.unwrap();
+        assert!(eof
+            .to_string()
+            .contains("IMAP connection closed during command"));
+
+        let (mut limited_client, limited_server) = plain_imap_client_and_server().await;
+        let limited_server = tokio::spawn(async move {
+            let (read, mut write) = limited_server.into_split();
+            let mut read = BufReader::new(read);
+            let (tag, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "UID FETCH 1 (BODY.PEEK[])");
+            write_transcript_fragments(
+                &mut write,
+                &[format!("* 1 FETCH (UID 1 BODY[] {{4}}\r\n{tag} OK ignored\r\n").as_bytes()],
+            )
+            .await;
+        });
+        let limited = match limited_client
+            .command_with_literal_limited("UID FETCH 1 (BODY.PEEK[])", 3)
+            .await
+        {
+            Ok(_) => panic!("oversize literal unexpectedly completed"),
+            Err(error) => error,
+        };
+        limited_server.await.unwrap();
+        assert!(limited
+            .to_string()
+            .contains("IMAP response literals exceed the 0 MiB safety limit"));
+    }
+
+    #[tokio::test]
+    async fn scripted_imap_idle_honours_cancellation_and_completes_the_done_exchange() {
+        let (mut client, server) = plain_imap_client_and_server().await;
+        let server = tokio::spawn(async move {
+            let (read, mut write) = server.into_split();
+            let mut read = BufReader::new(read);
+            let (tag, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "IDLE");
+            write_transcript_fragments(&mut write, &[b"+ id", b"ling\r\n"]).await;
+            let mut done = String::new();
+            read.read_line(&mut done).await.unwrap();
+            assert_eq!(done, "DONE\r\n");
+            write_transcript_fragments(
+                &mut write,
+                &[format!("{tag} OK IDLE completed\r\n").as_bytes()],
+            )
+            .await;
+        });
+
+        let (cancel, mut cancelled) = watch::channel(false);
+        let idle = tokio::spawn(async move { client.idle_until_change(&mut cancelled).await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel.send(true).unwrap();
+
+        assert!(matches!(
+            idle.await.unwrap().unwrap(),
+            IdleOutcome::Cancelled
+        ));
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn scripted_imap_idle_eof_and_bye_termination_fail_without_spinning() {
+        let (mut eof_client, eof_server) = plain_imap_client_and_server().await;
+        let eof_server = tokio::spawn(async move {
+            let (read, _) = eof_server.into_split();
+            let mut read = BufReader::new(read);
+            let (_, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "IDLE");
+        });
+        let (_cancel, mut not_cancelled) = watch::channel(false);
+        let eof = timeout(
+            Duration::from_secs(1),
+            eof_client.idle_until_change(&mut not_cancelled),
+        )
+        .await
+        .expect("IDLE EOF must not spin")
+        .unwrap_err();
+        eof_server.await.unwrap();
+        assert!(eof
+            .to_string()
+            .contains("IMAP connection closed before IDLE continuation"));
+
+        let (mut bye_client, bye_server) = plain_imap_client_and_server().await;
+        let bye_server = tokio::spawn(async move {
+            let (read, mut write) = bye_server.into_split();
+            let mut read = BufReader::new(read);
+            let (_, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "IDLE");
+            write.write_all(b"+ idling\r\n").await.unwrap();
+            write.flush().await.unwrap();
+            let mut done = String::new();
+            read.read_line(&mut done).await.unwrap();
+            assert_eq!(done, "DONE\r\n");
+            write.write_all(b"* BYE maintenance\r\n").await.unwrap();
+            write.flush().await.unwrap();
+        });
+        let (cancel, mut cancelled) = watch::channel(false);
+        let idle = tokio::spawn(async move { bye_client.idle_until_change(&mut cancelled).await });
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel.send(true).unwrap();
+        let bye = timeout(Duration::from_secs(1), idle)
+            .await
+            .expect("IDLE BYE termination must not spin")
+            .unwrap()
+            .unwrap_err();
+        bye_server.await.unwrap();
+        assert!(bye
+            .to_string()
+            .contains("IMAP server closed the connection during IDLE termination"));
+    }
+
+    #[tokio::test]
+    async fn authentication_distinguishes_rejection_from_retryable_bye() {
+        let account = test_account();
+
+        let (mut bye_client, bye_server) = plain_imap_client_and_server().await;
+        let bye_server = tokio::spawn(async move {
+            let (read, mut write) = bye_server.into_split();
+            let mut read = BufReader::new(read);
+            let (_, command) = scripted_command(&mut read).await;
+            assert!(command.starts_with("LOGIN ") || command.starts_with("AUTHENTICATE XOAUTH2 "));
+            write
+                .write_all(b"* BYE [UNAVAILABLE] maintenance\r\n")
+                .await
+                .unwrap();
+            write.flush().await.unwrap();
+        });
+        let bye = bye_client
+            .authenticate(&account, "secret")
+            .await
+            .unwrap_err();
+        bye_server.await.unwrap();
+        assert!(!bye
+            .to_string()
+            .to_ascii_lowercase()
+            .contains("authentication"));
+
+        let (mut rejected_client, rejected_server) = plain_imap_client_and_server().await;
+        let rejected_server = tokio::spawn(async move {
+            let (read, mut write) = rejected_server.into_split();
+            let mut read = BufReader::new(read);
+            let (tag, command) = scripted_command(&mut read).await;
+            assert!(command.starts_with("LOGIN ") || command.starts_with("AUTHENTICATE XOAUTH2 "));
+            write
+                .write_all(format!("{tag} NO invalid credentials\r\n").as_bytes())
+                .await
+                .unwrap();
+            write.flush().await.unwrap();
+        });
+        let rejected = rejected_client
+            .authenticate(&account, "secret")
+            .await
+            .unwrap_err();
+        rejected_server.await.unwrap();
+        assert!(rejected
+            .to_string()
+            .contains("IMAP authentication rejected"));
+    }
+
     #[test]
     fn uid_after_a_body_literal_backfills_only_that_fetch_response() {
         let mut literals = vec![ImapLiteral {
@@ -7482,6 +8922,13 @@ mod tests {
         .into_account(provider::by_id("gmail").unwrap());
 
         assert!(smtp_saves_sent_copy(&gmail));
+        // SMTP acceptance is not a durable Sent-copy guarantee for generic
+        // providers. Only this exact Gmail submission host opts out of the
+        // subsequent IMAP APPEND path.
+        gmail.smtp_host = "SMTP.GMAIL.COM.".into();
+        assert!(smtp_saves_sent_copy(&gmail));
+        gmail.smtp_host = "smtp.gmail.com.example.test".into();
+        assert!(!smtp_saves_sent_copy(&gmail));
         gmail.smtp_host = "smtp.example.com".into();
         assert!(!smtp_saves_sent_copy(&gmail));
     }
@@ -7489,6 +8936,9 @@ mod tests {
     #[test]
     fn extracts_literal_lengths() {
         assert_eq!(literal_length("* 1 FETCH (RFC822 {42}\r\n"), Some(42));
+        assert_eq!(literal_length("* LIST (\\Sent) \"/\" \"{5}\"\r\n"), None);
+        assert_eq!(literal_length("* OK server says {5} later\r\n"), None);
+        assert_eq!(literal_length("* 1 FETCH (BODY[] {5+}\r\n"), Some(5));
     }
     #[test]
     fn parses_search() {
@@ -7797,6 +9247,29 @@ For you, Alex =E2=80=94 related to your saved topic."
         let message = parse_message(&test_account(), "INBOX", 2965, &[], raw.as_bytes(), None)
             .await
             .unwrap();
+        let contract: serde_json::Value = serde_json::from_str(include_str!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../../apps/desktop/testdata/tauri-contracts/high-risk.json"
+        )))
+        .unwrap();
+        let provider_content = &contract["messageContent"]["providerSignature"];
+        assert_eq!(provider_content["body_text"], message.body_text);
+        assert_eq!(
+            provider_content["body_html"],
+            serde_json::to_value(&message.body_html).unwrap()
+        );
+        assert_eq!(
+            provider_content["attachments"][0]["filename"],
+            message.attachments[0].attachment.filename
+        );
+        assert_eq!(
+            provider_content["attachments"][0]["mime_type"],
+            message.attachments[0].attachment.mime_type
+        );
+        assert_eq!(
+            provider_content["attachments"][0]["presentation"],
+            serde_json::to_value(message.attachments[0].attachment.presentation).unwrap()
+        );
 
         assert!(message
             .body_html

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -64,6 +64,11 @@ use url::{Host, Url};
 const IMAP_CONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 const IMAP_COMMAND_TIMEOUT: Duration = Duration::from_secs(60);
 const SMTP_SEND_TIMEOUT: Duration = Duration::from_secs(60);
+/// A provider smoke must authenticate the configured SMTP transport without
+/// ever starting a message transaction. Keep this distinct from the normal
+/// send deadline so an opt-in diagnostic cannot hold a manual CI runner for a
+/// full delivery timeout.
+const SMTP_AUTH_PROBE_TIMEOUT: Duration = Duration::from_secs(20);
 const DKIM_VERIFY_TIMEOUT: Duration = Duration::from_secs(5);
 const UNSUBSCRIBE_TIMEOUT: Duration = Duration::from_secs(15);
 const MAX_ATTACHMENT_BYTES: usize = 25 * 1024 * 1024;
@@ -286,6 +291,36 @@ impl MailService {
     }
     pub fn credentials(&self) -> &CredentialStore {
         &self.credentials
+    }
+
+    /// Verify authenticated production IMAP connectivity without fetching
+    /// message data or changing remote mailbox state. This intentionally stops
+    /// after capability, mailbox discovery, read-only INBOX examination, and
+    /// constant-size mailbox status so a provider smoke remains bounded even
+    /// when an account has a large mailbox.
+    pub async fn imap_auth_probe(&self, account: &Account) -> Result<()> {
+        let mut client = ImapClient::connect(account).await?;
+        self.imap_auth_probe_with_client(&mut client, account).await
+    }
+
+    async fn imap_auth_probe_with_client<S>(
+        &self,
+        client: &mut ImapClient<S>,
+        account: &Account,
+    ) -> Result<()>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let secret = self.credentials.secret(account).await?;
+        client.authenticate(account, &secret).await?;
+        client.command("CAPABILITY").await?;
+        client.command("LIST \"\" \"INBOX\"").await?;
+        client.command("EXAMINE \"INBOX\"").await?;
+        client
+            .command("STATUS \"INBOX\" (UIDVALIDITY UIDNEXT)")
+            .await?;
+        let _ = client.command("LOGOUT").await;
+        Ok(())
     }
 
     pub async fn sync_inbox(&self, account: &Account, max_messages: u32) -> Result<usize> {
@@ -1508,6 +1543,21 @@ impl MailService {
             .await
     }
 
+    /// Verify the production SMTP connection, TLS/STARTTLS upgrade, and
+    /// credentials without submitting any mail. The probe always sends QUIT
+    /// immediately after successful authentication; it never sends MAIL,
+    /// RCPT, DATA, or a message body.
+    pub async fn smtp_auth_probe(&self, account: &Account) -> Result<()> {
+        let secret = self.credentials.secret(account).await?;
+        let endpoint = SmtpEndpoint {
+            host: account.smtp_host.clone(),
+            port: account.smtp_port,
+            tls_parameters: TlsParameters::new(account.smtp_host.clone())?,
+        };
+        smtp_auth_probe_with_smtp_endpoint(account, &secret, endpoint, SMTP_AUTH_PROBE_TIMEOUT)
+            .await
+    }
+
     async fn send_with_smtp_endpoint(
         &self,
         account: &Account,
@@ -1551,6 +1601,46 @@ impl MailService {
         let _ = client.command("LOGOUT").await;
         Ok(())
     }
+}
+
+async fn smtp_auth_probe_with_smtp_endpoint(
+    account: &Account,
+    secret: &str,
+    endpoint: SmtpEndpoint,
+    deadline: Duration,
+) -> Result<()> {
+    let deadline_at = Instant::now() + deadline;
+    let client_id = ClientId::default();
+    let implicit_tls =
+        matches!(account.smtp_security, Security::Tls).then(|| endpoint.tls_parameters.clone());
+    let mut connection = smtp_probe_before_quit(
+        deadline_at,
+        AsyncSmtpConnection::connect_tokio1(
+            (&*endpoint.host, endpoint.port),
+            None,
+            &client_id,
+            implicit_tls,
+            None,
+        ),
+    )
+    .await?;
+
+    if matches!(account.smtp_security, Security::StartTls) {
+        smtp_probe_before_quit(
+            deadline_at,
+            connection.starttls(endpoint.tls_parameters, &client_id),
+        )
+        .await?;
+    }
+
+    let credentials = Credentials::new(account.auth.username().to_owned(), secret.to_owned());
+    let mechanisms: &[Mechanism] = match account.auth {
+        AccountAuth::OAuth2 { .. } => &[Mechanism::Xoauth2],
+        AccountAuth::Password { .. } => DEFAULT_MECHANISMS,
+    };
+    smtp_probe_before_quit(deadline_at, connection.auth(mechanisms, &credentials)).await?;
+    smtp_probe_before_quit(deadline_at, connection.quit()).await?;
+    Ok(())
 }
 
 async fn send_smtp_raw(
@@ -1665,6 +1755,15 @@ async fn smtp_before_data<T>(
     Ok(timeout_at(deadline_at, operation)
         .await
         .context("SMTP send timed out before message submission")??)
+}
+
+async fn smtp_probe_before_quit<T>(
+    deadline_at: Instant,
+    operation: impl std::future::Future<Output = std::result::Result<T, lettre::transport::smtp::Error>>,
+) -> Result<T> {
+    Ok(timeout_at(deadline_at, operation)
+        .await
+        .context("SMTP authentication probe timed out")??)
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -5973,6 +6072,72 @@ mod tests {
         transcript
     }
 
+    async fn scripted_imap_probe_server(server: TcpStream) -> Vec<String> {
+        let (read, mut write) = server.into_split();
+        let mut read = BufReader::new(read);
+        let mut transcript = Vec::new();
+
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            "LOGIN \"reader@example.test\" \"probe secret\"",
+        )
+        .await;
+        write
+            .write_all(format!("{tag} OK authenticated\r\n").as_bytes())
+            .await
+            .unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "CAPABILITY").await;
+        write
+            .write_all(
+                format!("* CAPABILITY IMAP4rev1 UIDPLUS\r\n{tag} OK capability\r\n").as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"INBOX\"").await;
+        write
+            .write_all(
+                format!("* LIST (\\\\HasNoChildren) \"/\" \"INBOX\"\r\n{tag} OK listed\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "EXAMINE \"INBOX\"").await;
+        write
+            .write_all(
+                format!("* 3 EXISTS\r\n* OK [UIDVALIDITY 19] UIDs valid\r\n{tag} OK examined\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            "STATUS \"INBOX\" (UIDVALIDITY UIDNEXT)",
+        )
+        .await;
+        // A constant-size status response proves the probe does not request a
+        // UID list, FETCH, flag change, or any per-message follow-up work.
+        write
+            .write_all(
+                format!("* STATUS \"INBOX\" (UIDVALIDITY 19 UIDNEXT 44)\r\n{tag} OK status\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+        write
+            .write_all(format!("* BYE done\r\n{tag} OK logout\r\n").as_bytes())
+            .await
+            .unwrap();
+        transcript
+    }
+
     #[tokio::test]
     async fn scripted_mail_service_inbox_sync_persists_incremental_uid_and_isolates_accounts() {
         let directory = tempfile::tempdir().unwrap();
@@ -6127,6 +6292,37 @@ mod tests {
                 .unwrap()
                 .subject,
             "Incremental transcript message"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_mail_service_imap_auth_probe_uses_read_only_constant_size_commands() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store);
+        let account = test_account();
+        service
+            .credentials()
+            .set_password(&account, "probe secret")
+            .await
+            .unwrap();
+        let (mut client, server) = plain_imap_client_and_server().await;
+        let server = tokio::spawn(scripted_imap_probe_server(server));
+
+        service
+            .imap_auth_probe_with_client(&mut client, &account)
+            .await
+            .unwrap();
+        assert_eq!(
+            server.await.unwrap(),
+            vec![
+                "LOGIN \"reader@example.test\" \"probe secret\"",
+                "CAPABILITY",
+                "LIST \"\" \"INBOX\"",
+                "EXAMINE \"INBOX\"",
+                "STATUS \"INBOX\" (UIDVALIDITY UIDNEXT)",
+                "LOGOUT",
+            ],
+            "the probe must not request UID lists, FETCH, flag changes, or any per-message work"
         );
     }
 
@@ -6336,6 +6532,70 @@ mod tests {
         server.await.unwrap();
         assert!(error.to_string().contains("535"), "{error:#}");
         assert!(!error.to_string().contains("may be uncertain"), "{error:#}");
+    }
+
+    #[tokio::test]
+    async fn scripted_smtp_implicit_tls_auth_probe_quits_without_an_envelope() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let account = smtp_test_account(Security::Tls, listener.local_addr().unwrap().port());
+        let acceptor = smtp_test_acceptor();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let stream = acceptor.accept(stream).await.unwrap();
+            let mut connection = BufReader::new(stream);
+            smtp_reply(&mut connection, "220 localhost ready\r\n").await;
+            smtp_expect_ehlo_and_auth(&mut connection, false).await;
+            // MAIL, RCPT, and DATA would all fail this exact next-command
+            // assertion. A successful probe has no envelope side effects.
+            assert_eq!(smtp_command(&mut connection).await, "QUIT\r\n");
+            smtp_reply(&mut connection, "221 2.0.0 bye\r\n").await;
+        });
+
+        smtp_auth_probe_with_smtp_endpoint(
+            &account,
+            "secret",
+            smtp_test_endpoint(&account),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        server.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn scripted_smtp_starttls_auth_probe_quits_without_an_envelope() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let account = smtp_test_account(Security::StartTls, listener.local_addr().unwrap().port());
+        let acceptor = smtp_test_acceptor();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.unwrap();
+            let mut plaintext = BufReader::new(stream);
+            smtp_reply(&mut plaintext, "220 localhost ready\r\n").await;
+            assert!(smtp_command(&mut plaintext).await.starts_with("EHLO "));
+            smtp_reply(
+                &mut plaintext,
+                "250-localhost\r\n250-STARTTLS\r\n250 AUTH PLAIN\r\n",
+            )
+            .await;
+            assert_eq!(smtp_command(&mut plaintext).await, "STARTTLS\r\n");
+            smtp_reply(&mut plaintext, "220 2.0.0 start TLS\r\n").await;
+
+            let stream = acceptor.accept(plaintext.into_inner()).await.unwrap();
+            let mut encrypted = BufReader::new(stream);
+            smtp_expect_ehlo_and_auth(&mut encrypted, false).await;
+            assert_eq!(smtp_command(&mut encrypted).await, "QUIT\r\n");
+            smtp_reply(&mut encrypted, "221 2.0.0 bye\r\n").await;
+        });
+
+        smtp_auth_probe_with_smtp_endpoint(
+            &account,
+            "secret",
+            smtp_test_endpoint(&account),
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        server.await.unwrap();
     }
 
     #[tokio::test]

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -14,12 +14,12 @@ use sqlx::{
 };
 use std::{
     collections::{HashMap, HashSet},
-    fs::OpenOptions,
-    io::{ErrorKind, Write},
-    path::Path,
+    fs::{File, FileTimes, OpenOptions},
+    io::{ErrorKind, Read, Write},
+    path::{Path, PathBuf},
     str::FromStr,
-    sync::Arc,
-    time::Duration,
+    sync::{Arc, OnceLock},
+    time::{Duration, Instant, SystemTime},
 };
 
 #[cfg(unix)]
@@ -39,6 +39,20 @@ const MESSAGE_CONTENT_CACHE_RECENT_WINDOW_DAYS: i64 = 30;
 /// part when interpreted by the sectioned MIME planner.
 const ATTACHMENT_PRESENTATION_CACHE_VERSION: &str = "2";
 const ATTACHMENT_PRESENTATION_VERSION: i64 = 2;
+/// Foreground readers wait at most 60 seconds for another body fetch. Keep a
+/// short grace period beyond that before a crashed process's lease may be
+/// replaced, while preserving fresh claims across concurrently open processes.
+const MESSAGE_CONTENT_FETCH_LEASE_SECONDS: i64 = 90;
+/// All stores opened by this process share a fetch-claim owner. This lets a
+/// second connection respect work already in flight, while a new process can
+/// discard claims left by the previous process during migration.
+static MESSAGE_CONTENT_FETCH_OWNER: OnceLock<String> = OnceLock::new();
+
+fn message_content_fetch_owner() -> &'static str {
+    MESSAGE_CONTENT_FETCH_OWNER
+        .get_or_init(|| uuid::Uuid::new_v4().to_string())
+        .as_str()
+}
 
 #[derive(Clone)]
 pub struct Store {
@@ -52,6 +66,8 @@ pub struct Store {
 pub struct MessageContentFetchClaim {
     store: Store,
     message_id: String,
+    owner: String,
+    renewal: tokio::task::JoinHandle<()>,
     released: bool,
 }
 
@@ -68,8 +84,9 @@ pub enum MessageContentFetchAcquire {
 
 impl MessageContentFetchClaim {
     pub async fn release(mut self) -> Result<()> {
+        self.renewal.abort();
         self.store
-            .release_message_content_fetch(&self.message_id)
+            .release_message_content_fetch_for_owner(&self.message_id, &self.owner)
             .await?;
         self.released = true;
         Ok(())
@@ -81,11 +98,15 @@ impl Drop for MessageContentFetchClaim {
         if self.released {
             return;
         }
+        self.renewal.abort();
         let store = self.store.clone();
         let message_id = self.message_id.clone();
+        let owner = self.owner.clone();
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                let _ = store.release_message_content_fetch(&message_id).await;
+                let _ = store
+                    .release_message_content_fetch_for_owner(&message_id, &owner)
+                    .await;
             });
         }
     }
@@ -168,6 +189,9 @@ pub struct MailConversation {
     pub account_id: String,
     pub thread_id: String,
     pub messages: Vec<MailSummary>,
+    /// Every concrete mailbox/UID locator, including logical Message-ID
+    /// copies that are collapsed in `messages` for display.
+    pub source_messages: Vec<MailSummary>,
     pub latest: MailSummary,
     pub message_count: usize,
     pub unread: bool,
@@ -392,12 +416,25 @@ impl Store {
         // write transactions can otherwise race while upgrading their SQLite
         // locks. A single local connection queues those short DB sections and
         // prevents an account watcher from losing an arrival to SQLITE_BUSY.
-        let pool = SqlitePoolOptions::new()
-            .max_connections(1)
-            .connect_with(options)
-            .await?;
+        let connect_deadline = Instant::now() + Duration::from_secs(10);
+        let pool = loop {
+            match SqlitePoolOptions::new()
+                .max_connections(1)
+                .connect_with(options.clone())
+                .await
+            {
+                Ok(pool) => break pool,
+                Err(error)
+                    if is_sqlite_busy_message(&error.to_string())
+                        && Instant::now() < connect_deadline =>
+                {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                Err(error) => return Err(error.into()),
+            }
+        };
         let store = Self { pool, vault_key };
-        store.migrate().await?;
+        store.migrate_with_busy_retry().await?;
         Ok(store)
     }
 
@@ -407,8 +444,24 @@ impl Store {
             pool,
             vault_key: Arc::new(random_bytes()?),
         };
-        store.migrate().await?;
+        store.migrate_with_busy_retry().await?;
         Ok(store)
+    }
+
+    async fn migrate_with_busy_retry(&self) -> Result<()> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match self.migrate().await {
+                Ok(()) => return Ok(()),
+                Err(error)
+                    if (is_sqlite_busy(&error) || is_sqlite_migration_race(&error))
+                        && Instant::now() < deadline =>
+                {
+                    tokio::time::sleep(Duration::from_millis(50)).await;
+                }
+                Err(error) => return Err(error),
+            }
+        }
     }
 
     async fn migrate(&self) -> Result<()> {
@@ -435,7 +488,7 @@ impl Store {
             "CREATE TABLE IF NOT EXISTS starred_attachment_metadata (id TEXT PRIMARY KEY, message_id TEXT NOT NULL REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, filename TEXT NOT NULL, mime_type TEXT NOT NULL, size_bytes INTEGER NOT NULL, is_inline INTEGER NOT NULL DEFAULT 0, presentation TEXT NOT NULL DEFAULT 'unknown', is_potentially_unsafe INTEGER NOT NULL DEFAULT 0)",
             "CREATE TABLE IF NOT EXISTS message_content_cache (message_id TEXT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, content_state TEXT NOT NULL CHECK(content_state = 'complete'), body_text TEXT NOT NULL, body_html TEXT, unsubscribe_kind TEXT, attachments_json TEXT NOT NULL, byte_size INTEGER NOT NULL CHECK(byte_size >= 0), last_accessed INTEGER NOT NULL)",
             "CREATE INDEX IF NOT EXISTS message_content_cache_lru ON message_content_cache(last_accessed, message_id)",
-            "CREATE TABLE IF NOT EXISTS message_content_fetches (message_id TEXT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, claimed_at TEXT NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS message_content_fetches (message_id TEXT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, claimed_at TEXT NOT NULL, claim_owner TEXT NOT NULL DEFAULT '')",
             "CREATE TABLE IF NOT EXISTS app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
             "CREATE TABLE IF NOT EXISTS mailbox_catalog_state (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, remote_name TEXT NOT NULL, uid_validity INTEGER NOT NULL, remote_total INTEGER NOT NULL DEFAULT 0, historical_complete INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox))",
             "CREATE TABLE IF NOT EXISTS mail_rebuild_jobs (account_id TEXT PRIMARY KEY, phase TEXT NOT NULL, completed INTEGER NOT NULL DEFAULT 0, total INTEGER, updated_at TEXT NOT NULL)",
@@ -446,10 +499,25 @@ impl Store {
                 .await
                 .with_context(|| format!("storage migration statement failed: {statement}"))?;
         }
-        // Fetch claims coordinate only concurrent work in this process. A
-        // previous process cannot still be downloading, so never let its
-        // transient rows block a fresh store after restart.
-        sqlx::query("DELETE FROM message_content_fetches")
+        let fetch_claim_columns: Vec<(i64, String, String, i64, Option<String>, i64)> =
+            sqlx::query_as("PRAGMA table_info(message_content_fetches)")
+                .fetch_all(&self.pool)
+                .await?;
+        if !fetch_claim_columns
+            .iter()
+            .any(|column| column.1 == "claim_owner")
+        {
+            sqlx::query(
+                "ALTER TABLE message_content_fetches ADD COLUMN claim_owner TEXT NOT NULL DEFAULT ''",
+            )
+            .execute(&self.pool)
+            .await?;
+        }
+        // A CLI and the desktop can open this database concurrently. Preserve
+        // every fresh lease regardless of process owner; only work old enough
+        // to have outlived the foreground wait window is safe to discard.
+        sqlx::query("DELETE FROM message_content_fetches WHERE claimed_at <= ?")
+            .bind(Utc::now() - chrono::Duration::seconds(MESSAGE_CONTENT_FETCH_LEASE_SECONDS))
             .execute(&self.pool)
             .await?;
         // Provider work can outlive a UI action (for example, a hydration
@@ -1234,11 +1302,23 @@ impl Store {
         messages: &[MailSummary],
     ) -> Result<Vec<MailSummary>> {
         let account_id = account_id.to_string();
+        if messages
+            .iter()
+            .any(|message| message.account_id != account_id || message.mailbox != mailbox)
+        {
+            return Err(anyhow!(
+                "sync batch message does not match the requested account or mailbox"
+            ));
+        }
         // Keep the existence check and all provider-derived writes in one
         // transaction.  This prevents a late realtime cycle from reporting
         // arrivals for an account removed between its IMAP fetch and local
         // publication.
-        let mut tx = self.pool.begin().await?;
+        // Two independent Store connections can both begin a deferred read
+        // transaction before either publishes. Acquire the SQLite write lease
+        // first so the loser waits rather than failing while upgrading its
+        // read lock to a write lock.
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
         let account_removed: bool = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM deleted_account_tombstones WHERE account_id = ?)",
         )
@@ -1248,6 +1328,15 @@ impl Store {
         if account_removed {
             tx.rollback().await?;
             return Err(anyhow!("account was removed"));
+        }
+        let account_exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM accounts WHERE id = ?)")
+                .bind(&account_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if !account_exists {
+            tx.rollback().await?;
+            return Err(anyhow!("account does not exist"));
         }
         let initialized: bool = sqlx::query_scalar(
             "SELECT EXISTS(SELECT 1 FROM mailbox_sync_state WHERE account_id = ? AND mailbox = ?)",
@@ -1931,14 +2020,27 @@ impl Store {
     }
 
     /// Claims a local message for an in-flight body fetch. Claims are
-    /// intentionally transient and are cleared when the store starts.
+    /// transient leases shared by every process using the profile. A stale
+    /// lease may be replaced after the bounded foreground wait window, while
+    /// the owner token prevents an old guard from releasing its replacement.
     pub async fn claim_message_content_fetch(&self, message_id: &str) -> Result<bool> {
+        self.claim_message_content_fetch_for_owner(message_id, message_content_fetch_owner())
+            .await
+    }
+
+    async fn claim_message_content_fetch_for_owner(
+        &self,
+        message_id: &str,
+        owner: &str,
+    ) -> Result<bool> {
         Ok(sqlx::query(
-            "INSERT OR IGNORE INTO message_content_fetches(message_id, claimed_at) SELECT ?, ? WHERE EXISTS (SELECT 1 FROM messages WHERE id = ?)",
+            "INSERT INTO message_content_fetches(message_id, claimed_at, claim_owner) SELECT ?, ?, ? WHERE EXISTS (SELECT 1 FROM messages WHERE id = ?) ON CONFLICT(message_id) DO UPDATE SET claimed_at = excluded.claimed_at, claim_owner = excluded.claim_owner WHERE message_content_fetches.claimed_at <= ?",
         )
         .bind(message_id)
         .bind(Utc::now())
+        .bind(owner)
         .bind(message_id)
+        .bind(Utc::now() - chrono::Duration::seconds(MESSAGE_CONTENT_FETCH_LEASE_SECONDS))
         .execute(&self.pool)
         .await?
         .rows_affected()
@@ -1949,14 +2051,42 @@ impl Store {
         &self,
         message_id: &str,
     ) -> Result<Option<MessageContentFetchClaim>> {
-        Ok(self
-            .claim_message_content_fetch(message_id)
+        let owner = uuid::Uuid::new_v4().to_string();
+        if !self
+            .claim_message_content_fetch_for_owner(message_id, &owner)
             .await?
-            .then(|| MessageContentFetchClaim {
-                store: self.clone(),
-                message_id: message_id.to_owned(),
-                released: false,
-            }))
+        {
+            return Ok(None);
+        }
+        let renewal_store = self.clone();
+        let renewal_message_id = message_id.to_owned();
+        let renewal_owner = owner.clone();
+        let renewal = tokio::spawn(async move {
+            let interval = Duration::from_secs(
+                u64::try_from(MESSAGE_CONTENT_FETCH_LEASE_SECONDS / 3).unwrap_or(30),
+            );
+            loop {
+                tokio::time::sleep(interval).await;
+                let renewed = sqlx::query(
+                    "UPDATE message_content_fetches SET claimed_at = ? WHERE message_id = ? AND claim_owner = ?",
+                )
+                .bind(Utc::now())
+                .bind(&renewal_message_id)
+                .bind(&renewal_owner)
+                .execute(&renewal_store.pool)
+                .await;
+                if !matches!(renewed, Ok(result) if result.rows_affected() == 1) {
+                    break;
+                }
+            }
+        });
+        Ok(Some(MessageContentFetchClaim {
+            store: self.clone(),
+            message_id: message_id.to_owned(),
+            owner,
+            renewal,
+            released: false,
+        }))
     }
 
     /// Acquires a fetch claim while preserving why it was unavailable.
@@ -1984,8 +2114,18 @@ impl Store {
     }
 
     pub async fn release_message_content_fetch(&self, message_id: &str) -> Result<()> {
-        sqlx::query("DELETE FROM message_content_fetches WHERE message_id = ?")
+        self.release_message_content_fetch_for_owner(message_id, message_content_fetch_owner())
+            .await
+    }
+
+    async fn release_message_content_fetch_for_owner(
+        &self,
+        message_id: &str,
+        owner: &str,
+    ) -> Result<()> {
+        sqlx::query("DELETE FROM message_content_fetches WHERE message_id = ? AND claim_owner = ?")
             .bind(message_id)
+            .bind(owner)
             .execute(&self.pool)
             .await?;
         Ok(())
@@ -2474,10 +2614,14 @@ impl Store {
         }
         let conversations = grouped
             .into_iter()
-            .filter_map(|((account_id, thread_id), messages)| {
-                let messages = deduplicate_message_copies(messages, query.mailbox.as_deref());
+            .filter_map(|((account_id, thread_id), source_messages)| {
+                // Keep every durable locator for mutation fan-out. `messages`
+                // below is only the mailbox-preferred reader/list projection,
+                // so it may intentionally collapse logical Message-ID copies.
+                let messages =
+                    deduplicate_message_copies(source_messages.clone(), query.mailbox.as_deref());
                 let latest = messages.last()?.clone();
-                let mut participants = messages
+                let mut participants = source_messages
                     .iter()
                     .map(|message| {
                         message
@@ -2494,11 +2638,14 @@ impl Store {
                     account_id,
                     thread_id,
                     message_count: messages.len(),
-                    unread: messages.iter().any(|message| !message.is_read),
-                    has_attachments: messages.iter().any(|message| message.has_attachments),
+                    unread: source_messages.iter().any(|message| !message.is_read),
+                    has_attachments: source_messages
+                        .iter()
+                        .any(|message| message.has_attachments),
                     participants,
                     latest,
                     messages,
+                    source_messages,
                 })
             })
             .collect::<Vec<_>>();
@@ -3169,15 +3316,38 @@ fn load_or_create_vault_key(path: &Path) -> Result<[u8; VAULT_KEY_LEN]> {
         Ok(bytes) => parse_vault_key(path, &bytes),
         Err(error) if error.kind() == ErrorKind::NotFound => {
             let key = random_bytes()?;
+            let temporary_path = path.with_file_name(format!(
+                ".{}.{}.tmp",
+                path.file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("vault"),
+                uuid::Uuid::new_v4()
+            ));
             let mut options = OpenOptions::new();
             options.write(true).create_new(true);
             #[cfg(unix)]
             options.mode(0o600);
-            match options.open(path) {
+            match options.open(&temporary_path) {
                 Ok(mut file) => {
                     file.write_all(&key)?;
                     file.sync_all()?;
-                    Ok(key)
+                    drop(file);
+                    match publish_vault_key(&temporary_path, path, true) {
+                        Ok(()) => {
+                            if temporary_path.exists() {
+                                std::fs::remove_file(&temporary_path)?;
+                            }
+                            Ok(key)
+                        }
+                        Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                            std::fs::remove_file(&temporary_path)?;
+                            parse_vault_key(path, &std::fs::read(path)?)
+                        }
+                        Err(error) => {
+                            let _ = std::fs::remove_file(&temporary_path);
+                            Err(error.into())
+                        }
+                    }
                 }
                 Err(error) if error.kind() == ErrorKind::AlreadyExists => {
                     parse_vault_key(path, &std::fs::read(path)?)
@@ -3186,6 +3356,264 @@ fn load_or_create_vault_key(path: &Path) -> Result<[u8; VAULT_KEY_LEN]> {
             }
         }
         Err(error) => Err(error.into()),
+    }
+}
+
+fn publish_vault_key(
+    temporary_path: &Path,
+    path: &Path,
+    try_hard_link: bool,
+) -> std::io::Result<()> {
+    publish_vault_key_with_stale_after(temporary_path, path, try_hard_link, Duration::from_secs(10))
+}
+
+fn publish_vault_key_with_stale_after(
+    temporary_path: &Path,
+    path: &Path,
+    try_hard_link: bool,
+    stale_after: Duration,
+) -> std::io::Result<()> {
+    publish_vault_key_with_stale_after_and_hook(
+        temporary_path,
+        path,
+        try_hard_link,
+        stale_after,
+        || {},
+    )
+}
+
+fn publish_vault_key_with_stale_after_and_hook<F>(
+    temporary_path: &Path,
+    path: &Path,
+    try_hard_link: bool,
+    stale_after: Duration,
+    after_lock_acquired: F,
+) -> std::io::Result<()>
+where
+    F: FnOnce(),
+{
+    let hard_link_result = if try_hard_link {
+        std::fs::hard_link(temporary_path, path)
+    } else {
+        Err(std::io::Error::new(
+            ErrorKind::Unsupported,
+            "hard links disabled for test",
+        ))
+    };
+    match hard_link_result {
+        Ok(()) => return Ok(()),
+        Err(error) if error.kind() == ErrorKind::AlreadyExists => return Err(error),
+        Err(error)
+            if !matches!(
+                error.kind(),
+                ErrorKind::Unsupported | ErrorKind::PermissionDenied | ErrorKind::Other
+            ) =>
+        {
+            return Err(error);
+        }
+        Err(_) => {}
+    }
+
+    // Some valid profile locations (for example exFAT and network mounts) do
+    // not support hard links. Serialize the fallback with a create-new lock,
+    // then atomically rename the already-fsynced temporary file. Contenders
+    // never observe partial key bytes and the winner never overwrites an
+    // existing canonical key.
+    let mut lock = VaultPublishLock::acquire(path, stale_after)?;
+    after_lock_acquired();
+    // Stop before checking ownership so the final token check observes stable
+    // lock contents. A stale-lock taker moves the lock aside before acquiring
+    // its own create-new lock, so a slow old publisher can never publish over
+    // or clean up the replacement owner's work.
+    lock.stop_heartbeat();
+    let result = if !lock.is_owned()? {
+        Err(std::io::Error::new(
+            ErrorKind::PermissionDenied,
+            "lost ownership of vault key publication lock",
+        ))
+    } else if path.exists() {
+        Err(std::io::Error::new(
+            ErrorKind::AlreadyExists,
+            "vault key already published",
+        ))
+    } else if !lock.is_owned()? {
+        // Keep this second check directly adjacent to the rename. The lock
+        // serializes all Dakia publishers and this prevents a reclaimed old
+        // owner from replacing a newer canonical key in the fallback path.
+        Err(std::io::Error::new(
+            ErrorKind::PermissionDenied,
+            "lost ownership of vault key publication lock",
+        ))
+    } else {
+        // `temporary_path` was fsynced before acquiring the lock. The lock is
+        // create-new and checked immediately above, so fallback publishers
+        // retain the same no-replace canonical semantics as the hard-link
+        // path while still supporting filesystems without hard links.
+        std::fs::rename(temporary_path, path)
+    };
+    let _ = lock.release_if_owned();
+    result
+}
+
+struct VaultPublishLock {
+    path: PathBuf,
+    token: String,
+    heartbeat: Option<VaultPublishHeartbeat>,
+}
+
+struct VaultPublishHeartbeat {
+    stop: std::sync::mpsc::Sender<()>,
+    worker: std::thread::JoinHandle<()>,
+}
+
+impl VaultPublishLock {
+    fn acquire(canonical_path: &Path, stale_after: Duration) -> std::io::Result<Self> {
+        let path = vault_publish_lock_path(canonical_path);
+        let deadline = Instant::now() + stale_after;
+        let token = uuid::Uuid::new_v4().to_string();
+        loop {
+            match OpenOptions::new().write(true).create_new(true).open(&path) {
+                Ok(mut file) => {
+                    file.write_all(token.as_bytes())?;
+                    file.sync_all()?;
+                    drop(file);
+                    return Ok(Self {
+                        path: path.clone(),
+                        token: token.clone(),
+                        heartbeat: VaultPublishHeartbeat::start(&path, &token, stale_after),
+                    });
+                }
+                Err(error) if error.kind() == ErrorKind::AlreadyExists => {
+                    if canonical_path.exists() {
+                        return Err(std::io::Error::new(
+                            ErrorKind::AlreadyExists,
+                            "vault key already published",
+                        ));
+                    }
+                    if vault_publish_lock_is_stale(&path, stale_after) {
+                        // Move, rather than unlink, a stale lock. A live
+                        // holder that was paused can then detect that its
+                        // token no longer owns `path` before final publish or
+                        // cleanup; it cannot delete the contender's lock.
+                        match move_stale_vault_publish_lock(&path) {
+                            Ok(()) => continue,
+                            Err(ref error) if error.kind() == ErrorKind::NotFound => continue,
+                            Err(error) => return Err(error),
+                        }
+                    }
+                    if Instant::now() >= deadline {
+                        return Err(std::io::Error::new(
+                            ErrorKind::TimedOut,
+                            "timed out waiting for vault key publication",
+                        ));
+                    }
+                    std::thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => return Err(error),
+            }
+        }
+    }
+
+    fn is_owned(&self) -> std::io::Result<bool> {
+        match std::fs::read_to_string(&self.path) {
+            Ok(contents) => Ok(contents == self.token),
+            Err(error) if error.kind() == ErrorKind::NotFound => Ok(false),
+            Err(error) => Err(error),
+        }
+    }
+
+    fn stop_heartbeat(&mut self) {
+        if let Some(heartbeat) = self.heartbeat.take() {
+            let _ = heartbeat.stop.send(());
+            let _ = heartbeat.worker.join();
+        }
+    }
+
+    fn release_if_owned(&mut self) -> std::io::Result<()> {
+        self.stop_heartbeat();
+        if self.is_owned()? {
+            match std::fs::remove_file(&self.path) {
+                Ok(()) => Ok(()),
+                Err(ref error) if error.kind() == ErrorKind::NotFound => Ok(()),
+                Err(error) => Err(error),
+            }
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl Drop for VaultPublishLock {
+    fn drop(&mut self) {
+        self.stop_heartbeat();
+    }
+}
+
+impl VaultPublishHeartbeat {
+    fn start(path: &Path, token: &str, stale_after: Duration) -> Option<Self> {
+        if stale_after.is_zero() {
+            return None;
+        }
+        let interval = stale_after
+            .checked_div(3)
+            .unwrap_or(stale_after)
+            .max(Duration::from_millis(1))
+            .min(Duration::from_secs(1));
+        let path = path.to_owned();
+        let token = token.to_owned();
+        let (stop, worker_stop) = std::sync::mpsc::channel();
+        let worker = std::thread::spawn(move || loop {
+            match worker_stop.recv_timeout(interval) {
+                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                    refresh_vault_publish_lock(&path, &token);
+                }
+            }
+        });
+        Some(Self { stop, worker })
+    }
+}
+
+fn vault_publish_lock_path(path: &Path) -> PathBuf {
+    path.with_file_name(format!(
+        ".{}.publish.lock",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("vault")
+    ))
+}
+
+fn vault_publish_lock_is_stale(path: &Path, stale_after: Duration) -> bool {
+    std::fs::metadata(path)
+        .and_then(|metadata| metadata.modified())
+        .ok()
+        .and_then(|modified| modified.elapsed().ok())
+        .is_some_and(|age| age >= stale_after)
+}
+
+fn move_stale_vault_publish_lock(path: &Path) -> std::io::Result<()> {
+    let stale_path = path.with_file_name(format!(
+        ".{}.stale.{}",
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .unwrap_or("vault"),
+        uuid::Uuid::new_v4()
+    ));
+    std::fs::rename(path, &stale_path)?;
+    match std::fs::remove_file(&stale_path) {
+        Ok(()) => Ok(()),
+        Err(ref error) if error.kind() == ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(error),
+    }
+}
+
+fn refresh_vault_publish_lock(path: &Path, token: &str) {
+    let Ok(mut file) = File::open(path) else {
+        return;
+    };
+    let mut contents = String::new();
+    if file.read_to_string(&mut contents).is_ok() && contents == token {
+        let _ = file.set_times(FileTimes::new().set_modified(SystemTime::now()));
     }
 }
 
@@ -3250,6 +3678,22 @@ fn fts_query(input: &str) -> String {
         .map(|token| format!("\"{}\"*", token.replace('"', "\"\"")))
         .collect::<Vec<_>>()
         .join(" AND ")
+}
+
+fn is_sqlite_busy(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| is_sqlite_busy_message(&cause.to_string()))
+}
+
+fn is_sqlite_busy_message(message: &str) -> bool {
+    message.contains("database is locked") || message.contains("database is busy")
+}
+
+fn is_sqlite_migration_race(error: &anyhow::Error) -> bool {
+    error
+        .chain()
+        .any(|cause| cause.to_string().contains("duplicate column name"))
 }
 
 pub fn stable_message_id(account_id: AccountId, mailbox: &str, uid: u32) -> String {
@@ -3412,6 +3856,42 @@ mod tests {
         message.mailbox = mailbox.into();
         message.received_at = received_at;
         message
+    }
+
+    fn account_with_id(id: uuid::Uuid, email: &str) -> Account {
+        let mut account = AccountDraft {
+            email: email.into(),
+            display_name: "Storage test".into(),
+            provider_id: Some("fastmail".into()),
+            username: None,
+            imap_host: None,
+            imap_port: None,
+            imap_security: None,
+            smtp_host: None,
+            smtp_port: None,
+            smtp_security: None,
+            archive_mailbox: None,
+            spam_mailbox: None,
+        }
+        .into_account(provider::by_id("fastmail").unwrap());
+        account.id = id;
+        account
+    }
+
+    async fn save_test_account(store: &Store, id: uuid::Uuid) {
+        store
+            .save_account(&account_with_id(id, &format!("{id}@example.test")))
+            .await
+            .unwrap();
+    }
+
+    fn fixed_seed_order(len: usize, mut seed: u64) -> Vec<usize> {
+        let mut order = (0..len).collect::<Vec<_>>();
+        for index in (1..len).rev() {
+            seed = seed.wrapping_mul(6_364_136_223_846_793_005).wrapping_add(1);
+            order.swap(index, (seed as usize) % (index + 1));
+        }
+        order
     }
 
     #[tokio::test]
@@ -4273,7 +4753,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn message_content_fetch_claims_cascade_and_clear_on_restart() {
+    async fn message_content_fetch_claims_cascade_and_preserve_fresh_cross_process_leases() {
         let directory = tempfile::tempdir().unwrap();
         let path = directory.path().join("dakia.db");
         let store = Store::open(&path).await.unwrap();
@@ -4319,10 +4799,82 @@ mod tests {
             .await
             .unwrap();
         assert!(store.claim_message_content_fetch(&fresh.id).await.unwrap());
+        sqlx::query("UPDATE message_content_fetches SET claim_owner = 'other-live-process' WHERE message_id = ?")
+            .bind(&fresh.id)
+            .execute(&store.pool)
+            .await
+            .unwrap();
         drop(store);
 
         let store = Store::open(&path).await.unwrap();
+        assert!(
+            !store.claim_message_content_fetch(&fresh.id).await.unwrap(),
+            "opening another process must preserve a fresh foreign claim"
+        );
+        store
+            .release_message_content_fetch(&fresh.id)
+            .await
+            .unwrap();
+        assert!(
+            !store.claim_message_content_fetch(&fresh.id).await.unwrap(),
+            "a guard from another owner must not release the foreign claim"
+        );
+        sqlx::query("UPDATE message_content_fetches SET claimed_at = ? WHERE message_id = ?")
+            .bind(Utc::now() - chrono::Duration::seconds(MESSAGE_CONTENT_FETCH_LEASE_SECONDS + 1))
+            .bind(&fresh.id)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        assert!(
+            store.claim_message_content_fetch(&fresh.id).await.unwrap(),
+            "a claim older than the bounded lease must be replaceable"
+        );
+        store
+            .release_message_content_fetch(&fresh.id)
+            .await
+            .unwrap();
         assert!(store.claim_message_content_fetch(&fresh.id).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn expired_fetch_takeover_cannot_be_released_by_the_old_guard() {
+        let store = Store::in_memory().await.unwrap();
+        let message = message("Lease owner", "preview");
+        let message_id = message.id.clone();
+        store.upsert_messages(&[message]).await.unwrap();
+
+        let first = store
+            .acquire_message_content_fetch(&message_id)
+            .await
+            .unwrap()
+            .unwrap();
+        sqlx::query("UPDATE message_content_fetches SET claimed_at = ? WHERE message_id = ?")
+            .bind(Utc::now() - chrono::Duration::seconds(MESSAGE_CONTENT_FETCH_LEASE_SECONDS + 1))
+            .bind(&message_id)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        let replacement = store
+            .acquire_message_content_fetch(&message_id)
+            .await
+            .unwrap()
+            .expect("an expired claim should be replaceable");
+
+        first.release().await.unwrap();
+        assert!(
+            store
+                .acquire_message_content_fetch(&message_id)
+                .await
+                .unwrap()
+                .is_none(),
+            "an old guard must not release a newer owner's claim"
+        );
+        replacement.release().await.unwrap();
+        assert!(store
+            .acquire_message_content_fetch(&message_id)
+            .await
+            .unwrap()
+            .is_some());
     }
 
     #[tokio::test]
@@ -4350,6 +4902,7 @@ mod tests {
             .await
             .unwrap();
         let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
         let mut source = message("Source", "preview");
         source.id = stable_message_id(account_id, "INBOX", 1);
         source.account_id = account_id.to_string();
@@ -5394,6 +5947,7 @@ mod tests {
     async fn completed_mailbox_action_rejects_a_late_realtime_write() {
         let store = Store::in_memory().await.unwrap();
         let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
         let mut stale_realtime_header = message("Archive me", "Stale header");
         stale_realtime_header.id = stable_message_id(account_id, "INBOX", 41);
         stale_realtime_header.account_id = account_id.to_string();
@@ -5615,6 +6169,21 @@ mod tests {
             .unwrap();
         assert_eq!(conversations[0].message_count, 1);
         assert_eq!(conversations[0].messages[0].mailbox, "INBOX");
+        assert_eq!(conversations[0].source_messages.len(), 2);
+        assert_eq!(
+            conversations[0]
+                .source_messages
+                .iter()
+                .map(|message| (message.id.as_str(), message.mailbox.as_str(), message.uid))
+                .collect::<HashSet<_>>(),
+            HashSet::from([("inbox-copy", "INBOX", 1), ("archive-copy", "Archive", 2)])
+        );
+        // The UI shows the selected mailbox representative, while mutation
+        // callers receive both concrete account/mailbox/UID locators.
+        assert_eq!(conversations[0].messages.len(), 1);
+        assert_eq!(conversations[0].messages[0].id, "inbox-copy");
+        let serialized = serde_json::to_value(&conversations[0]).unwrap();
+        assert_eq!(serialized["sourceMessages"].as_array().unwrap().len(), 2);
     }
 
     #[tokio::test]
@@ -5835,6 +6404,89 @@ mod tests {
         assert!(conversations
             .iter()
             .all(|conversation| conversation.message_count == 1));
+    }
+
+    #[tokio::test]
+    async fn fixed_seed_thread_graphs_are_invariant_to_insert_and_chunk_order_across_accounts() {
+        let first_account = uuid::Uuid::from_u128(0x4f40_2cf7_237a_4c70_8d52_6af4_6fd1_0101);
+        let second_account = uuid::Uuid::from_u128(0x4f40_2cf7_237a_4c70_8d52_6af4_6fd1_0102);
+        let base_time = DateTime::<Utc>::UNIX_EPOCH;
+        let mut graph = Vec::new();
+        for (account_id, prefix) in [(first_account, "first"), (second_account, "second")] {
+            let mut root = message("Quarterly plan", "root");
+            root.id = format!("{prefix}-root");
+            root.account_id = account_id.to_string();
+            root.uid = 1;
+            root.message_id = Some("<shared-root@example.test>".into());
+            root.received_at = base_time;
+
+            let mut reply = message("Re: Quarterly plan", "reply");
+            reply.id = format!("{prefix}-reply");
+            reply.account_id = account_id.to_string();
+            reply.uid = 2;
+            reply.message_id = Some("<shared-reply@example.test>".into());
+            reply.in_reply_to = Some("<shared-root@example.test>".into());
+            reply.reference_ids = Some("<shared-root@example.test>".into());
+            reply.received_at = base_time + chrono::Duration::seconds(1);
+
+            let mut deep_reply = message("Re: Quarterly plan", "deep reply");
+            deep_reply.id = format!("{prefix}-deep-reply");
+            deep_reply.account_id = account_id.to_string();
+            deep_reply.uid = 3;
+            deep_reply.message_id = Some("<shared-deep-reply@example.test>".into());
+            deep_reply.in_reply_to = Some("<shared-reply@example.test>".into());
+            deep_reply.reference_ids =
+                Some("<shared-root@example.test> <shared-reply@example.test>".into());
+            deep_reply.received_at = base_time + chrono::Duration::seconds(2);
+            graph.extend([root, reply, deep_reply]);
+        }
+
+        let first = Store::in_memory().await.unwrap();
+        for chunk in fixed_seed_order(graph.len(), 0x7e57_1e55).chunks(2) {
+            let messages = chunk
+                .iter()
+                .map(|index| graph[*index].clone())
+                .collect::<Vec<_>>();
+            first.upsert_messages(&messages).await.unwrap();
+        }
+        let second = Store::in_memory().await.unwrap();
+        for chunk in fixed_seed_order(graph.len(), 0x9b5d_cafe).chunks(3) {
+            let messages = chunk
+                .iter()
+                .map(|index| graph[*index].clone())
+                .collect::<Vec<_>>();
+            second.upsert_messages(&messages).await.unwrap();
+        }
+
+        let mut first_threads = first
+            .search(&SearchQuery::default())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|message| (message.id, message.thread_id))
+            .collect::<Vec<_>>();
+        let mut second_threads = second
+            .search(&SearchQuery::default())
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|message| (message.id, message.thread_id))
+            .collect::<Vec<_>>();
+        first_threads.sort();
+        second_threads.sort();
+        assert_eq!(first_threads, second_threads);
+        assert!(first_threads
+            .iter()
+            .all(|(_, thread_id)| thread_id == "shared-root@example.test"));
+        assert_eq!(
+            first
+                .search_conversations(&SearchQuery::default())
+                .await
+                .unwrap()
+                .len(),
+            2,
+            "same RFC message ids must remain isolated by account"
+        );
     }
 
     #[tokio::test]
@@ -6069,6 +6721,7 @@ mod tests {
     async fn synced_messages_establish_a_silent_baseline_then_report_new_unread_mail() {
         let store = Store::in_memory().await.unwrap();
         let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
         let mut baseline = message("Earlier mail", "Already in the inbox");
         baseline.account_id = account_id.to_string();
 
@@ -6117,6 +6770,7 @@ mod tests {
         let mut writes = tokio::task::JoinSet::new();
         for index in 0..20 {
             let account_id = uuid::Uuid::new_v4();
+            save_test_account(&store, account_id).await;
             let waiting_store = store.clone();
             let waiting_barrier = barrier.clone();
             let mut incoming = message(&format!("Concurrent arrival {index}"), "Notify me");
@@ -6142,9 +6796,216 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn independent_stores_preserve_live_claims_and_finish_contended_sync_durably() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("independent-stores.db");
+        let account_id = uuid::Uuid::from_u128(0x4f40_2cf7_237a_4c70_8d52_6af4_6fd1_0001);
+        let first = Store::open(&path).await.unwrap();
+        let account = account_with_id(account_id, "independent-store@example.test");
+        first.save_account(&account).await.unwrap();
+
+        let mut first_message = message("Contended 01", "durable payload");
+        first_message.id = stable_message_id(account_id, "INBOX", 1);
+        first_message.account_id = account_id.to_string();
+        first_message.uid = 1;
+        first_message.received_at = DateTime::<Utc>::UNIX_EPOCH;
+        first
+            .save_synced_messages(account_id, "INBOX", &[first_message.clone()])
+            .await
+            .unwrap();
+        let claim = first
+            .acquire_message_content_fetch(&first_message.id)
+            .await
+            .unwrap()
+            .expect("first connection owns the fetch");
+
+        let second = Store::open(&path).await.unwrap();
+        assert!(matches!(
+            second
+                .acquire_message_content_fetch_outcome(&first_message.id)
+                .await
+                .unwrap(),
+            MessageContentFetchAcquire::Busy
+        ));
+        claim.release().await.unwrap();
+
+        let mut batch = vec![first_message];
+        for uid in 2..=12 {
+            let mut incoming = message(&format!("Contended {uid:02}"), "durable payload");
+            incoming.id = stable_message_id(account_id, "INBOX", uid);
+            incoming.account_id = account_id.to_string();
+            incoming.uid = i64::from(uid);
+            incoming.received_at =
+                DateTime::<Utc>::UNIX_EPOCH + chrono::Duration::seconds(i64::from(uid));
+            batch.push(incoming);
+        }
+        let barrier = Arc::new(tokio::sync::Barrier::new(3));
+        let first_barrier = barrier.clone();
+        let first_store = first.clone();
+        let first_batch = batch.clone();
+        let first_write = tokio::spawn(async move {
+            first_barrier.wait().await;
+            first_store
+                .save_synced_messages(account_id, "INBOX", &first_batch)
+                .await
+        });
+        let second_barrier = barrier.clone();
+        let second_store = second.clone();
+        let mut second_batch = batch;
+        second_batch.reverse();
+        let second_write = tokio::spawn(async move {
+            second_barrier.wait().await;
+            second_store
+                .save_synced_messages(account_id, "INBOX", &second_batch)
+                .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            barrier.wait().await;
+            first_write.await.unwrap().unwrap();
+            second_write.await.unwrap().unwrap();
+        })
+        .await
+        .expect("two independently opened stores must complete their contended writes");
+
+        assert_eq!(
+            second
+                .search(&SearchQuery {
+                    account_ids: vec![account_id],
+                    ..Default::default()
+                })
+                .await
+                .unwrap()
+                .len(),
+            12
+        );
+        assert_eq!(
+            second
+                .highest_mailbox_uid(account_id, "INBOX")
+                .await
+                .unwrap(),
+            Some(12)
+        );
+
+        drop(second);
+        drop(first);
+        let reopened = Store::open(&path).await.unwrap();
+        assert_eq!(
+            reopened
+                .message_by_locator(account_id, "INBOX", 1)
+                .await
+                .unwrap()
+                .expect("committed message survives reopening")
+                .subject,
+            "Contended 01"
+        );
+        assert_eq!(
+            reopened
+                .highest_mailbox_uid(account_id, "INBOX")
+                .await
+                .unwrap(),
+            Some(12)
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_fresh_store_opens_retry_migration_locking_within_the_busy_window() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("simultaneous-open.db");
+        let barrier = Arc::new(tokio::sync::Barrier::new(5));
+        let mut opens = tokio::task::JoinSet::new();
+        for _ in 0..4 {
+            let path = path.clone();
+            let barrier = barrier.clone();
+            opens.spawn(async move {
+                barrier.wait().await;
+                Store::open(path).await
+            });
+        }
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            barrier.wait().await;
+            while let Some(opened) = opens.join_next().await {
+                opened.unwrap().unwrap();
+            }
+        })
+        .await
+        .expect("fresh Store::open calls must resolve migration contention within 10 seconds");
+    }
+
+    #[tokio::test]
+    async fn synced_message_batch_rejects_mixed_scope_without_durable_changes() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::from_u128(0x4f40_2cf7_237a_4c70_8d52_6af4_6fd1_0002);
+        let other_account_id = uuid::Uuid::from_u128(0x4f40_2cf7_237a_4c70_8d52_6af4_6fd1_0003);
+        let mut valid = message("Valid input", "must not be partially stored");
+        valid.id = stable_message_id(account_id, "INBOX", 1);
+        valid.account_id = account_id.to_string();
+        valid.uid = 1;
+        let mut wrong_account = valid.clone();
+        wrong_account.id = stable_message_id(other_account_id, "INBOX", 2);
+        wrong_account.account_id = other_account_id.to_string();
+        wrong_account.uid = 2;
+
+        let error = store
+            .save_synced_messages(account_id, "INBOX", &[valid.clone(), wrong_account])
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("does not match the requested account or mailbox"));
+        assert!(store
+            .message_by_locator(account_id, "INBOX", 1)
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account_id, "INBOX")
+                .await
+                .unwrap(),
+            None
+        );
+
+        let mut wrong_mailbox = valid;
+        wrong_mailbox.id = stable_message_id(account_id, "Archive", 3);
+        wrong_mailbox.mailbox = "Archive".into();
+        wrong_mailbox.uid = 3;
+        assert!(store
+            .save_synced_messages(account_id, "INBOX", &[wrong_mailbox])
+            .await
+            .is_err());
+        assert!(store
+            .message_by_locator(account_id, "Archive", 3)
+            .await
+            .unwrap()
+            .is_none());
+
+        let missing_account_id = uuid::Uuid::from_u128(0x4f40_2cf7_237a_4c70_8d52_6af4_6fd1_0004);
+        let mut missing_account = message("Missing account", "must not be stored");
+        missing_account.id = stable_message_id(missing_account_id, "INBOX", 4);
+        missing_account.account_id = missing_account_id.to_string();
+        missing_account.uid = 4;
+        assert!(store
+            .save_synced_messages(missing_account_id, "INBOX", &[missing_account])
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("account does not exist"));
+        assert_eq!(
+            store
+                .highest_mailbox_uid(missing_account_id, "INBOX")
+                .await
+                .unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
     async fn notification_baseline_never_reports_non_inbox_mail() {
         let store = Store::in_memory().await.unwrap();
         let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
         store
             .save_synced_messages(account_id, "Archive", &[])
             .await
@@ -6164,6 +7025,7 @@ mod tests {
     async fn complete_hydration_marks_transient_content_without_duplicate_rows() {
         let store = Store::in_memory().await.unwrap();
         let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
         let mut headers = message("Fast arrival", "");
         headers.account_id = account_id.to_string();
         headers.id = stable_message_id(account_id, "INBOX", 1);
@@ -6190,6 +7052,7 @@ mod tests {
     async fn uidvalidity_change_resets_mailbox_and_notification_baseline() {
         let store = Store::in_memory().await.unwrap();
         let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
         let mut old = message("Old UID namespace", "old");
         old.account_id = account_id.to_string();
         store
@@ -6477,6 +7340,114 @@ mod tests {
         }
     }
 
+    #[test]
+    fn vault_key_publication_falls_back_without_hard_links() {
+        let directory = tempfile::tempdir().unwrap();
+        let temporary = directory.path().join(".vault.key.test.tmp");
+        let canonical = directory.path().join(VAULT_KEY_FILE);
+        let key = [7_u8; VAULT_KEY_LEN];
+        std::fs::write(&temporary, key).unwrap();
+
+        publish_vault_key(&temporary, &canonical, false).unwrap();
+        assert_eq!(std::fs::read(&canonical).unwrap(), key);
+        assert!(!temporary.exists());
+
+        let contender = directory.path().join(".vault.key.contender.tmp");
+        std::fs::write(&contender, [9_u8; VAULT_KEY_LEN]).unwrap();
+        assert_eq!(
+            publish_vault_key(&contender, &canonical, false)
+                .unwrap_err()
+                .kind(),
+            ErrorKind::AlreadyExists
+        );
+        assert_eq!(std::fs::read(&canonical).unwrap(), key);
+
+        std::fs::remove_file(&canonical).unwrap();
+        let abandoned_lock = vault_publish_lock_path(&canonical);
+        std::fs::write(&abandoned_lock, "crashed-publisher").unwrap();
+        let recovered = directory.path().join(".vault.key.recovered.tmp");
+        std::fs::write(&recovered, [8_u8; VAULT_KEY_LEN]).unwrap();
+        publish_vault_key_with_stale_after(&recovered, &canonical, false, Duration::ZERO).unwrap();
+        assert_eq!(std::fs::read(&canonical).unwrap(), [8_u8; VAULT_KEY_LEN]);
+        assert!(!abandoned_lock.exists());
+    }
+
+    #[test]
+    fn slow_vault_publisher_heartbeats_while_a_contender_waits() {
+        let directory = tempfile::tempdir().unwrap();
+        let canonical = directory.path().join(VAULT_KEY_FILE);
+        let holder_temporary = directory.path().join(".vault.key.holder.tmp");
+        let contender_temporary = directory.path().join(".vault.key.contender.tmp");
+        std::fs::write(&holder_temporary, [3_u8; VAULT_KEY_LEN]).unwrap();
+        std::fs::write(&contender_temporary, [4_u8; VAULT_KEY_LEN]).unwrap();
+        let (holder_ready_tx, holder_ready_rx) = std::sync::mpsc::channel();
+        let (finish_holder_tx, finish_holder_rx) = std::sync::mpsc::channel();
+        let holder_path = holder_temporary.clone();
+        let canonical_path = canonical.clone();
+
+        let holder = std::thread::spawn(move || {
+            publish_vault_key_with_stale_after_and_hook(
+                &holder_path,
+                &canonical_path,
+                false,
+                Duration::from_millis(40),
+                || {
+                    holder_ready_tx.send(()).unwrap();
+                    finish_holder_rx.recv().unwrap();
+                },
+            )
+        });
+        holder_ready_rx.recv().unwrap();
+        // Wait beyond the stale budget: without the heartbeat, the contender
+        // would remove the live holder's lock and publish its own key.
+        std::thread::sleep(Duration::from_millis(120));
+        assert_eq!(
+            publish_vault_key_with_stale_after(
+                &contender_temporary,
+                &canonical,
+                false,
+                Duration::from_millis(40),
+            )
+            .unwrap_err()
+            .kind(),
+            ErrorKind::TimedOut
+        );
+        assert!(!canonical.exists());
+        finish_holder_tx.send(()).unwrap();
+        holder.join().unwrap().unwrap();
+        assert_eq!(std::fs::read(&canonical).unwrap(), [3_u8; VAULT_KEY_LEN]);
+        assert!(contender_temporary.exists());
+        assert!(!vault_publish_lock_path(&canonical).exists());
+    }
+
+    #[test]
+    fn vault_publisher_that_loses_its_lock_cannot_publish_or_remove_replacement() {
+        let directory = tempfile::tempdir().unwrap();
+        let canonical = directory.path().join(VAULT_KEY_FILE);
+        let temporary = directory.path().join(".vault.key.displaced.tmp");
+        std::fs::write(&temporary, [5_u8; VAULT_KEY_LEN]).unwrap();
+        let replacement_lock = vault_publish_lock_path(&canonical);
+
+        let error = publish_vault_key_with_stale_after_and_hook(
+            &temporary,
+            &canonical,
+            false,
+            Duration::from_secs(1),
+            || {
+                std::fs::remove_file(&replacement_lock).unwrap();
+                std::fs::write(&replacement_lock, "new-owner-token").unwrap();
+            },
+        )
+        .unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert!(!canonical.exists());
+        assert!(temporary.exists());
+        assert_eq!(
+            std::fs::read_to_string(&replacement_lock).unwrap(),
+            "new-owner-token"
+        );
+    }
+
     #[tokio::test]
     async fn encrypted_secrets_detect_tampering_and_can_be_deleted() {
         let store = Store::in_memory().await.unwrap();
@@ -6658,8 +7629,13 @@ mod tests {
             .upsert_messages(std::slice::from_ref(&orphan))
             .await
             .unwrap();
-        initial
-            .save_synced_messages(orphan_id, "INBOX", &[orphan.clone()])
+        // Simulate state created by a pre-guard build. The public sync path
+        // now rejects a missing account, so legacy-orphan repair is exercised
+        // by inserting the old durable row directly.
+        sqlx::query("INSERT INTO mailbox_sync_state(account_id, mailbox, initialized_at, highest_uid) VALUES (?, 'INBOX', ?, 41)")
+            .bind(orphan_id.to_string())
+            .bind(Utc::now())
+            .execute(&initial.pool)
             .await
             .unwrap();
         initial

--- a/crates/dakia-core/tests/mail_boundary_properties.rs
+++ b/crates/dakia-core/tests/mail_boundary_properties.rs
@@ -1,0 +1,191 @@
+use dakia_core::mail::{is_potentially_unsafe, safe_attachment_filename, safe_mime_type};
+use mail_parser::{MessageParser, MimeHeaders};
+
+const BANNED_FILENAME_CHARACTERS: &[char] = &[
+    ':', '<', '>', '"', '|', '?', '*', '\u{200e}', '\u{200f}', '\u{202a}', '\u{202b}', '\u{202c}',
+    '\u{202d}', '\u{202e}', '\u{2066}', '\u{2067}', '\u{2068}', '\u{2069}',
+];
+
+#[test]
+fn fixed_seed_filenames_are_bounded_idempotent_and_path_safe() {
+    for seed in [1, 0x51f15e, 0xc0ffee, u32::MAX] {
+        let mut random = XorShift32(seed);
+        for index in 0..512 {
+            let candidate = random_filename(&mut random);
+            let sanitized = safe_attachment_filename(&candidate, index);
+
+            assert!(!sanitized.is_empty(), "seed={seed} input={candidate:?}");
+            assert!(
+                sanitized.len() <= 180,
+                "seed={seed} output exceeded byte limit: {sanitized:?}"
+            );
+            assert!(
+                !sanitized.chars().any(char::is_control),
+                "seed={seed} output retained a control: {sanitized:?}"
+            );
+            assert!(
+                !sanitized
+                    .chars()
+                    .any(|character| BANNED_FILENAME_CHARACTERS.contains(&character)),
+                "seed={seed} output retained a banned character: {sanitized:?}"
+            );
+            assert!(!sanitized.contains(['/', '\\']));
+            assert_eq!(
+                safe_attachment_filename(&sanitized, index),
+                sanitized,
+                "sanitization must be idempotent for seed={seed}"
+            );
+        }
+    }
+}
+
+#[test]
+fn long_multibyte_filenames_preserve_utf8_boundaries_and_short_extensions() {
+    for seed in [7, 73, 7331, 0xdeadbeef] {
+        let mut random = XorShift32(seed);
+        for index in 0..128 {
+            let stem = (0..256)
+                .map(|_| ["é", "猫", "🙂", "a"][random.next_usize(4)])
+                .collect::<String>();
+            let extension = ["pdf", "tar.gz", "eml", "txt"][random.next_usize(4)];
+            let candidate = format!("{stem}.{extension}");
+            let sanitized = safe_attachment_filename(&candidate, index);
+            let final_extension = extension.rsplit('.').next().unwrap();
+
+            assert!(sanitized.len() <= 180);
+            assert!(sanitized.ends_with(&format!(".{final_extension}")));
+            assert!(std::str::from_utf8(sanitized.as_bytes()).is_ok());
+        }
+    }
+}
+
+#[test]
+fn fixed_seed_mime_types_are_canonical_or_fail_closed() {
+    let valid = [
+        ("TEXT/PLAIN", "text/plain"),
+        ("application/vnd.api+json", "application/vnd.api+json"),
+        (" image/svg+xml ", "image/svg+xml"),
+        ("application/x-custom_1", "application/x-custom_1"),
+    ];
+    for (input, expected) in valid {
+        assert_eq!(safe_mime_type(input), expected);
+        assert_eq!(safe_mime_type(&safe_mime_type(input)), expected);
+    }
+
+    for invalid in [
+        "",
+        "text",
+        "/plain",
+        "text/",
+        "text/plain; charset=utf-8",
+        "text/plain\r\nX-Evil: yes",
+        "text//plain",
+        "te xt/plain",
+        "🦀/plain",
+    ] {
+        assert_eq!(safe_mime_type(invalid), "application/octet-stream");
+    }
+}
+
+#[test]
+fn executable_detection_is_case_insensitive_and_survives_mime_normalization() {
+    for extension in [
+        "app", "bat", "cmd", "com", "command", "exe", "js", "jse", "msi", "ps1", "scpt", "sh",
+        "vbs", "wsf",
+    ] {
+        assert!(is_potentially_unsafe(
+            &format!("invoice.{extension}"),
+            "application/octet-stream"
+        ));
+        assert!(is_potentially_unsafe(
+            &format!("INVOICE.{}", extension.to_ascii_uppercase()),
+            "application/octet-stream"
+        ));
+    }
+
+    for mime in [
+        "APPLICATION/X-MSDOWNLOAD",
+        "APPLICATION/X-SH",
+        "APPLICATION/X-APPLE-DISKIMAGE",
+    ] {
+        assert!(is_potentially_unsafe(
+            "innocent-name",
+            &safe_mime_type(mime)
+        ));
+    }
+
+    assert!(is_potentially_unsafe(
+        "invoice.pdf.exe",
+        "application/octet-stream"
+    ));
+    assert!(!is_potentially_unsafe("invoice.exe.pdf", "application/pdf"));
+}
+
+#[test]
+fn pinned_mail_parser_runtime_decodes_filename_parameters_and_content_ids_as_expected() {
+    let filenames = MessageParser::new()
+        .parse(include_bytes!(
+            "../testdata/mime/filename-parameters-and-encodings.eml"
+        ))
+        .expect("checked-in filename fixture must parse");
+    let decoded_names = filenames
+        .parts
+        .iter()
+        .filter_map(|part| part.attachment_name())
+        .map(|name| safe_attachment_filename(name, 0))
+        .collect::<Vec<_>>();
+
+    assert!(decoded_names.contains(&"quarterly report final.pdf".to_owned()));
+    assert!(decoded_names.contains(&"report-test.txt".to_owned()));
+    assert!(decoded_names.contains(&"invoice;final.pdf".to_owned()));
+    assert!(decoded_names
+        .iter()
+        .all(|name| !name.contains(['/', '\\', '\u{202e}'])));
+
+    let cid_message = MessageParser::new()
+        .parse(include_bytes!(
+            "../testdata/mime/linkedin-inline-content-id.eml"
+        ))
+        .expect("checked-in CID fixture must parse");
+    let content_ids = cid_message
+        .parts
+        .iter()
+        .filter_map(|part| part.content_id())
+        .collect::<Vec<_>>();
+
+    assert_eq!(content_ids, ["text-body", "html-body"]);
+    assert_eq!(
+        cid_message.body_text(0).as_deref().map(str::trim),
+        Some("Redacted plain text=content with a foldedline.")
+    );
+    assert!(cid_message
+        .body_html(0)
+        .as_deref()
+        .is_some_and(|html| html.contains("Redacted HTML=content")));
+}
+
+struct XorShift32(u32);
+
+impl XorShift32 {
+    fn next(&mut self) -> u32 {
+        self.0 ^= self.0 << 13;
+        self.0 ^= self.0 >> 17;
+        self.0 ^= self.0 << 5;
+        self.0
+    }
+
+    fn next_usize(&mut self, upper_bound: usize) -> usize {
+        self.next() as usize % upper_bound
+    }
+}
+
+fn random_filename(random: &mut XorShift32) -> String {
+    const ALPHABET: &[&str] = &[
+        "a", "Z", "0", " ", ".", "/", "\\", ":", "<", ">", "\"", "|", "?", "*", "\0", "\r", "\n",
+        "\u{200f}", "\u{202e}", "\u{2066}", "é", "猫", "🙂",
+    ];
+    let length = random.next_usize(260);
+    (0..length)
+        .map(|_| ALPHABET[random.next_usize(ALPHABET.len())])
+        .collect()
+}

--- a/docs/publishing-macos-release.md
+++ b/docs/publishing-macos-release.md
@@ -26,11 +26,14 @@ signed final artifact instead.
 The builder:
 
 1. assembles, Developer ID signs, and verifies the Apple Silicon app;
-2. verifies packaged executable, classifier resources, and legal notices;
-3. runs the packaged-app startup check on the release Mac;
+2. verifies the packaged app and CLI executables, Apple-Silicon architecture,
+   matching Developer ID ownership/version, classifier resources, and legal
+   notices;
+3. runs isolated packaged CLI and app startup checks on the release Mac;
 4. notarizes and staples the app;
 5. rebuilds, notarizes, staples, mounts, and verifies the DMG;
-6. archives that same final app and signs the exact archive bytes for Tauri.
+6. archives that same final app, extracts and repeats the app/CLI acceptance
+   checks on the archive contents, then signs the exact archive bytes for Tauri.
 
 The publisher uses immutable versioned R2 paths, anonymously verifies the
 published bytes, validates the updater manifest, and publishes `latest.json`

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -1,0 +1,34 @@
+# Dakia v0.3.1
+
+This release improves the reliability of mailbox actions, sending, and live
+updates while strengthening the checks used to ship Dakia safely.
+
+## Improvements and fixes
+
+- Mail actions now target every concrete duplicate copy in a conversation,
+  preventing the stale-row case caused by collapsing duplicate copies for
+  display.
+- Sending now reports when the final SMTP delivery status is uncertain after
+  message submission, rather than presenting it as an ordinary definite
+  failure.
+- Live updates no longer publish a completed hydration after the account was
+  removed, and desktop event listeners clean up registrations that resolve
+  after their window closes.
+- Message-content loading fails promptly when a message was removed instead of
+  waiting for a background fetch that can never complete.
+- Added regression checks for CLI/desktop state, payload, cancellation, and
+  cross-process-access contracts.
+
+## Release quality
+
+- Added realistic, redacted mail fixtures and broader IMAP, SMTP, storage,
+  threading, CLI, frontend, and native-command regression coverage.
+- Added scoped, non-required GitHub Actions validation workflows, repeatable
+  coverage measurement, and a bounded read-only provider authentication smoke
+  test.
+- Strengthened Apple-Silicon packaged-app and updater-archive checks for the
+  bundled CLI, signing identity, version, architecture, and notarization.
+
+## Download
+
+Dakia v0.3.1 supports Apple Silicon Macs.

--- a/docs/releases/v0.3.1.md
+++ b/docs/releases/v0.3.1.md
@@ -23,7 +23,8 @@ updates while strengthening the checks used to ship Dakia safely.
 
 - Added realistic, redacted mail fixtures and broader IMAP, SMTP, storage,
   threading, CLI, frontend, and native-command regression coverage.
-- Added scoped, non-required GitHub Actions validation workflows, repeatable
+- Added scoped GitHub Actions validation workflows with the applicable-scope
+  check required on protected branches, repeatable
   coverage measurement, and a bounded read-only provider authentication smoke
   test.
 - Strengthened Apple-Silicon packaged-app and updater-archive checks for the

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,12 +1,29 @@
 # Testing and Fixture Strategy
 
-Status: implementation plan
+Status: activated deterministic source lanes implemented; connector/event-path
+gaps, external activation, and measured evidence pending
 
 Baseline reviewed: `origin/main` at `0a3182e` on 2026-07-30
 
-This document defines how Dakia should prevent repeats of production issues
-without returning to slow, expensive GitHub Actions. It is a plan, not a claim
-that the described harnesses, workflows, or gates already exist.
+This document defines how Dakia prevents repeats of production issues without
+returning to slow, expensive GitHub Actions. The activated source-controlled
+harnesses, workflows, fixture governance, and gates in the delivery state are
+implemented; the explicitly named integration gaps remain work rather than
+completed coverage.
+
+The following acceptance evidence deliberately remains external to this source
+change:
+
+- making the pull-request validation status required and measuring three
+  representative hosted runs;
+- reviewing and committing a coverage baseline after three repeat green runs;
+- enabling credentials for a live-provider smoke test;
+- Apple-Silicon WebKit acceptance when a change affects native layout or
+  interaction; and
+- building, signing, notarizing, or publishing a release.
+
+None of those unperformed activities is reported as a pass. Automated Intel Mac
+testing remains an owner-authorized waiver, not acceptance evidence.
 
 ## Goals
 
@@ -118,8 +135,10 @@ only "does not panic."
 
 Build reusable local TLS and STARTTLS servers with ordered expectations,
 dynamic IMAP tags, exact transcripts, fault injection, and short test-specific
-deadlines. Drive public `MailService` sync, send, and realtime operations
-through temporary SQLite and a test event sink.
+deadlines. Drive the public `MailService` entry points where construction can
+be controlled; otherwise exercise their internal, injectable transport seams
+through temporary SQLite. Treat Tauri realtime publication as a separate
+event-sink integration boundary, not as evidence from a core protocol test.
 
 The blocking scenario set should include:
 
@@ -135,7 +154,17 @@ The blocking scenario set should include:
 - Inbox versus Sent event semantics, remote flag/deletion reconciliation,
   restart recovery, and account isolation.
 
-Protocol tests assert both the exact conversation and final SQLite/event state.
+Core protocol tests assert exact conversations and final SQLite outcomes;
+Tauri-targeted tests assert the event-state contracts they own.
+
+Current deterministic coverage uses the internal injected-client sync seam and
+the injected SMTP transport seam. It covers a file-backed two-pass sync and
+the Gmail-specific rule that skips a duplicate IMAP `APPEND` after successful
+SMTP submission. It does not construct the public IMAP connector, run the
+Tauri realtime loop through its event sink, or exercise a generic (non-Gmail)
+SMTP success followed by an IMAP `APPEND` failure. Those remain future
+connector/event-path scenarios; the latter must prove that the returned error
+preserves the distinction between successful delivery and an unsaved Sent copy.
 
 ### State, persistence, and process boundaries
 
@@ -254,6 +283,31 @@ They are disabled by default, have explicit job timeouts, and require a manual
 reason/input. No scheduled workflow is enabled without separate approval and a
 measured cost estimate.
 
+The initial manual workflow is deliberately useful without overstating its
+scope:
+
+- the coverage dispatch installs pinned `cargo-llvm-cov` and Vitest V8 coverage
+  tooling, writes Rust and frontend LCOV reports, and emits a candidate JSON;
+  if `testdata/coverage/baseline.json` has been intentionally reviewed, it
+  fails on any line, branch, or function ratio regression. The workflow never
+  writes the baseline itself.
+- the fuzz dispatch currently runs the checked-in, bounded fixed-seed thread
+  property and MIME corpus regressions three times. This is not an unbounded
+  generative fuzz pass; a future target must check in its seed corpus and
+  resource budget before it is described as one.
+- the provider dispatch is protected by both the explicit boolean input and
+  environment secret. It validates the secret JSON contract without printing
+  it or opening a network connection. A successful dispatch means only that
+  the provider harness configuration is well-formed, not that a live provider
+  succeeded. Connecting a `MailService` harness to a provider remains a
+  separately approved operation. `DAKIA_PROVIDER_SMOKE_CONFIG` uses version
+  `1` and contains
+  a provider label, account email, IMAP and SMTP endpoints (`host`, integer
+  `port`, and `tls` or `starttls` security), plus exactly one credential field
+  (`password`, `accessToken`, `refreshToken`, or `clientSecret`). Keep the JSON
+  solely in the protected environment secret; do not commit an example with a
+  real address or value.
+
 Apple-Silicon native verification and the entire release flow stay local. CI
 never receives signing, notarization, OAuth, R2, or production mailbox secrets.
 
@@ -279,21 +333,30 @@ Semantic fixture inventory and contract completeness remain blocking on every
 relevant pull request; coverage is a periodic non-regression guard, not a
 substitute for those gates.
 
-## Delivery sequence
+## Delivery state
 
-1. Add the tested change classifier and minimal Linux workflow. Measure three
-   representative runs before making it required.
-2. Add the fixture manifest, redaction validator, ownership, and automatic
-   corpus enumeration.
-3. Make existing raw fixtures equivalent across complete, selective, storage,
-   Tauri, and Reader paths.
-4. Add the scripted IMAP/SMTP harness and provider capability profiles.
-5. Enforce bidirectional Tauri command/event contracts.
-6. Add deterministic concurrency, locking, restart, and CLI subprocess tests.
-7. Add fixed-seed properties, then manual fuzzing and the periodic coverage
-   ratchet.
-8. Add disabled manual provider-smoke infrastructure. Enabling credentials or
-   scheduling it is a separately approved change.
+1. The tested change classifier and one-job Linux workflow are checked in.
+   Measure three representative hosted runs before making the status required.
+2. The fixture manifest, redaction validator, path-specific exercise mapping,
+   and automatic corpus enumeration are blocking checks.
+3. Suitable raw fixtures cross complete, selective, storage, Tauri, TypeScript,
+   and Reader boundaries, with intentional path differences declared.
+4. Scripted IMAP and SMTP harnesses cover framing, cancellation, TLS/STARTTLS,
+   failures, uncertainty, and a two-pass `MailService` persistence path via
+   internal injectable transport seams. Gmail duplicate-Sent `APPEND` skipping
+   is covered; public connector construction, the Tauri realtime event sink,
+   and generic-provider `APPEND` failure after SMTP acceptance remain future
+   integration scenarios.
+5. Mechanical Tauri command/event inventory and shared Rust/TypeScript payload
+   contracts are blocking checks.
+6. Deterministic locking, restart, late-completion, account-isolation, CLI
+   subprocess, cancellation, and bundled-sidecar checks are present.
+7. Fixed-seed properties are blocking source tests; bounded repetition and
+   coverage-candidate generation are manual dispatches. A ratchet activates
+   only after a reviewed baseline exists.
+8. Disabled manual provider-smoke configuration infrastructure is present.
+   Enabling credentials, connecting to a provider, or scheduling it remains a
+   separately approved change.
 9. Keep native WebKit and installed-upgrade verification in the supervised
    Apple-Silicon acceptance and release process.
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -296,20 +296,33 @@ scope:
   generative fuzz pass; a future target must check in its seed corpus and
   resource budget before it is described as one.
 - the provider dispatch is protected by both the explicit boolean input and
-  environment secret. It validates the secret JSON contract without printing
-  it or opening a network connection. A successful dispatch means only that
-  the provider harness configuration is well-formed, not that a live provider
-  succeeded. Connecting a `MailService` harness to a provider remains a
-  separately approved operation. `DAKIA_PROVIDER_SMOKE_CONFIG` uses version
-  `1` and contains
+  the `provider-smoke` environment secret. It validates the secret JSON
+  contract without printing it, then runs the checked-in
+  `dakia-provider-smoke` binary. That binary creates a fresh temporary SQLite
+  store, persists a temporary account, persists the password only to that
+  temporary store,
+  calls the public production `MailService::imap_auth_probe` path, and removes
+  the temporary state on every exit. That probe is limited to authenticated
+  `CAPABILITY`, `LIST`, read-only `EXAMINE INBOX`, and constant-size
+  `STATUS INBOX (UIDVALIDITY UIDNEXT)`; it fetches no message content, headers,
+  flags, or UID list, and does not request remote mailbox mutation.
+  It then runs the public production SMTP probe through the configured
+  implicit-TLS or STARTTLS/auth path and requires `QUIT` before `MAIL`, `RCPT`,
+  or `DATA`. The complete binary has a 45-second timeout; the SMTP probe has a
+  20-second deadline. A successful dispatch is live, bounded evidence of
+  authenticated read-neutral IMAP access plus SMTP auth/QUIT, not a send,
+  mailbox-write, OAuth, or broad provider-compatibility pass. The protected
+  environment still must be deliberately configured before it can run.
+  `DAKIA_PROVIDER_SMOKE_CONFIG` uses version `1` and contains
   a provider label, account email, IMAP and SMTP endpoints (`host`, integer
   `port`, and `tls` or `starttls` security), plus exactly one credential field
-  (`password`, `accessToken`, `refreshToken`, or `clientSecret`). Keep the JSON
-  solely in the protected environment secret; do not commit an example with a
-  real address or value.
+  (`password` or `appPassword`). OAuth/token fields are rejected rather than
+  guessing a token refresh flow. Keep the JSON solely in the protected
+  environment secret; do not commit an example with a real address or value.
 
-Apple-Silicon native verification and the entire release flow stay local. CI
-never receives signing, notarization, OAuth, R2, or production mailbox secrets.
+Apple-Silicon native verification and the entire release flow stay local.
+Outside the explicitly protected provider-smoke environment, CI never receives
+signing, notarization, OAuth, R2, or production mailbox secrets.
 
 ### Coverage ratchet without per-PR duplication
 
@@ -354,9 +367,12 @@ substitute for those gates.
 7. Fixed-seed properties are blocking source tests; bounded repetition and
    coverage-candidate generation are manual dispatches. A ratchet activates
    only after a reviewed baseline exists.
-8. Disabled manual provider-smoke configuration infrastructure is present.
-   Enabling credentials, connecting to a provider, or scheduling it remains a
-   separately approved change.
+8. The dispatch-only provider smoke harness is checked in. It is bounded to a
+   fresh temporary SQLite store, a read-neutral public `MailService` IMAP
+   authentication/discovery probe with no message fetch, and SMTP
+   TLS/STARTTLS authentication followed by `QUIT`; it cannot send a message.
+   Its protected credentials must still be enabled and its hosted result
+   recorded separately; scheduling it remains unapproved.
 9. Keep native WebKit and installed-upgrade verification in the supervised
    Apple-Silicon acceptance and release process.
 

--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,0 +1,313 @@
+# Testing and Fixture Strategy
+
+Status: implementation plan
+
+Baseline reviewed: `origin/main` at `0a3182e` on 2026-07-30
+
+This document defines how Dakia should prevent repeats of production issues
+without returning to slow, expensive GitHub Actions. It is a plan, not a claim
+that the described harnesses, workflows, or gates already exist.
+
+## Goals
+
+- Catch failures at the user-visible and durable production boundaries rather
+  than only testing parser helpers or mocked components.
+- Turn every confirmed production defect into a faithful, redacted regression
+  fixture and a test that fails on the broken implementation.
+- Keep automatic pull-request validation fast and inexpensive.
+- Keep signing, notarization, packaging, publication, live-provider checks, and
+  native Apple-Silicon acceptance outside ordinary pull-request CI.
+- Report skipped, unavailable, or environment-blocked validation accurately;
+  none of those states counts as a pass.
+
+## Current baseline and lessons
+
+Latest `main` already contains a substantial regression foundation:
+
+- 13 checked-in raw `.eml` fixtures and four realistic HTML fixtures;
+- MIME limits for raw message size, aggregate headers, part count, and nesting;
+- complete, catalogue, and header parse-path tests;
+- storage/restart, attachment-presentation, body-cache, fetch-claim, realtime,
+  Reader, and HTML disclosure tests;
+- typed message-content failures that distinguish retryable failures from
+  deterministic MIME resource-limit failures.
+
+The recent issue-driven changes show the remaining systemic weaknesses:
+
+- Provider-specific MIME can behave differently in the complete parser and the
+  selective IMAP `BODYSTRUCTURE`/section-fetch path.
+- Correct parser output can still diverge from persisted data, Tauri
+  serialization, frontend decoding, Reader state, or WebKit rendering.
+- Cache, refresh, reply provenance, flags, moves, deletion, and account removal
+  have important asynchronous orderings that ordinary happy-path tests miss.
+- Current IMAP/SMTP tests mostly construct commands and responses; they do not
+  exercise real socket framing, TLS/STARTTLS, cancellation, reconnect, delivery
+  uncertainty, or the complete provider-to-UI event path.
+- The comprehensive local verification script is not an automatic merge gate.
+  A test that is never run cannot prevent a regression.
+
+The old plan item "create a MIME corpus" is therefore complete enough to be
+replaced by corpus governance and cross-path conformance. The highest-value new
+work is efficient CI enforcement, fixture-path parity, scripted protocols,
+state-machine testing, and bidirectional Tauri contracts.
+
+## Regression contract for production defects
+
+A production defect is not complete until its fix includes all applicable
+items below:
+
+1. Capture the smallest faithful redacted input. Preserve provider nesting,
+   attributes, whitespace, sibling order, line endings, malformed structures,
+   and other details that contributed to the failure.
+2. Exercise the production selection and event path. Do not stop at a private
+   helper if the failure can occur during candidate discovery, persistence,
+   serialization, event delivery, rendering, or state cleanup.
+3. Assert the user-visible or durable result: visible content, disclosure
+   state, attachment presentation, stored rows, emitted event, retry behavior,
+   or remote command outcome.
+4. Add adjacent adversarial variants: empty, malformed, nested, adjacent,
+   ambiguous, multiple-candidate, and must-remain-untouched cases.
+5. Add restart and deterministic concurrency coverage when stale work can
+   outlive the request or mutate durable state.
+6. Prove sensitivity for the actual defect by running the regression against
+   the broken revision or a representative boundary mutation.
+7. Record the fixture and focused verification command in the pull request.
+8. Include the test in an automatic or explicitly required local gate. A
+   skipped or unexecuted test is not evidence.
+
+## Test architecture
+
+### Fixture manifest and governance
+
+Create one machine-readable manifest covering realistic `.eml` and HTML
+fixtures. Each entry contains:
+
+- a stable ID and repository path;
+- a checksum when exact malformed bytes matter;
+- synthetic or faithfully redacted provenance;
+- the issue or regression it protects;
+- provider shape without claiming live-provider compatibility;
+- expected body, HTML, snippet, attachment, error, and resource-limit semantics;
+- applicable publication/fetch paths;
+- redaction reviewer, review date, and permitted test domains.
+
+The validator must fail for unmanifested files, missing files, duplicate IDs,
+checksum drift, prohibited addresses/domains, credential-like values, or a
+manifest entry not exercised by a test. Automated scanning supplements, but
+does not replace, human redaction review.
+
+### Multi-path message conformance
+
+Every suitable raw fixture should run through:
+
+1. complete RFC822 parsing;
+2. catalogue and header parsing;
+3. partial preview;
+4. selective IMAP `BODYSTRUCTURE` and section fetching;
+5. file-backed SQLite persistence and reopen;
+6. the production Tauri `MessageContent` serialization shape;
+7. TypeScript decoding and Reader/HtmlMessage semantic assertions.
+
+For paths expected to be equivalent, compare normalized body text, HTML,
+snippet, attachment identity/presentation, and error category. Unsupported or
+intentionally different paths must declare the expected difference explicitly.
+Malformed/resource-limit fixtures must assert stable typed failures rather than
+only "does not panic."
+
+### Scripted IMAP and SMTP
+
+Build reusable local TLS and STARTTLS servers with ordered expectations,
+dynamic IMAP tags, exact transcripts, fault injection, and short test-specific
+deadlines. Drive public `MailService` sync, send, and realtime operations
+through temporary SQLite and a test event sink.
+
+The blocking scenario set should include:
+
+- fragmented and coalesced tagged/untagged responses and literals;
+- literals associated with the wrong UID or BODY section;
+- unsolicited responses, `BYE`, EOF, timeout, and cancellation;
+- IDLE renewal/reconnect and mailbox-scoped UIDVALIDITY changes;
+- Gmail labels, missing SPECIAL-USE, and unusual namespace/delimiter behavior;
+- read-neutral selective fetches and bounded literal/transcript allocation;
+- TLS, STARTTLS, and authentication rejection;
+- SMTP recipient rejection, timeout before/after DATA, uncertain delivery,
+  APPEND failure, COPYUID behavior, and duplicate-Sent prevention;
+- Inbox versus Sent event semantics, remote flag/deletion reconciliation,
+  restart recovery, and account isolation.
+
+Protocol tests assert both the exact conversation and final SQLite/event state.
+
+### State, persistence, and process boundaries
+
+Use deterministic scheduling or explicit barriers to cover interleavings among
+message selection, expand/reply/forward, fetch, cache warming, star/unstar,
+read/unread, move, delete, account removal, quiet refresh, and restart. A stale
+completion must never resurrect a message, attachment, flag, or cache entry.
+
+Add:
+
+- independent Store connections contending on one database;
+- bounded busy handling and injected write failures;
+- interruption immediately before and after transactional checkpoints;
+- repeated reopen after interrupted migration/rebuild/cache work;
+- corrupt-row isolation and whole-database corruption behavior;
+- CLI subprocess tests with isolated state, stdout/stderr schemas, exit codes,
+  cancellation, restart persistence, and bundled-sidecar parity.
+
+### Tauri command and event contracts
+
+Maintain a mechanical inventory of:
+
+- frontend production invokes;
+- Rust registered handlers;
+- native emitted events;
+- frontend and compose-window listeners.
+
+Fail when the sets diverge. Shared payload fixtures must be decoded by both
+Rust and TypeScript. Test exact names, top-level argument keys, camel/snake
+casing, UUID/cursor shapes, missing/null fields, channels, cleanup, remounts,
+late events, and sanitized error envelopes. Demo-only APIs are excluded from
+the production inventory explicitly.
+
+### Property, fuzz, and native layers
+
+- Run fixed-seed property tests in the ordinary source suite for multipart
+  trees, MIME parameters, IMAP framing, CID rewriting, quoted-history markers,
+  filenames, thread graphs, and state interleavings.
+- Run longer fuzzing only manually or in a separately approved schedule. Every
+  discovered failure becomes a checked-in blocking seed or fixture.
+- Use representative mutation/sensitivity evidence for high-risk boundaries;
+  do not require an expensive mutation run for every generated case.
+- Use native Apple-Silicon WebKit verification only for layout, iframe sizing,
+  focus, external links, remote-content policy, and repeated disclosure
+  transitions that jsdom cannot prove.
+
+## Cost-effective GitHub Actions
+
+### Hard constraints
+
+- Ordinary pull requests must not use macOS runners.
+- Ordinary pull requests must not package the app, build release artifacts,
+  sign, notarize, publish, run live-provider tests, download translation
+  models, or prepare release-only ONNX/classifier assets.
+- Do not run a platform matrix.
+- Do not run the same full suite in multiple jobs.
+- Cancel superseded runs on the same pull request.
+- Target a warm-cache automatic run below 10 Linux billable minutes and an
+  estimated hosted-runner cost below USD 0.25 per pull request.
+- If the rolling median exceeds the time or cost target, optimize or narrow the
+  automatic lane before adding more required work.
+
+### Required automatic lane
+
+Use one change-classification job and at most one Linux test job.
+
+The classifier derives scope from the merge-base diff:
+
+- `docs-only`: documentation/metadata validation only;
+- `frontend`: formatting, typecheck, and relevant Vitest suites;
+- `rust-core`: formatting/Clippy for changed packages and relevant Rust suites;
+- `mail-boundary`: full core mail/storage/protocol fixtures plus Reader/API
+  contract suites;
+- `tauri-boundary`: Linux-compilable Tauri command/event contract tests;
+- `release-only`: release-script tests without building an app.
+
+Shared types, API contracts, fixture manifests, lockfiles, test configuration,
+or scope-classifier changes promote the run to the broader applicable scope.
+The classifier itself has table-driven tests so path mistakes cannot silently
+skip validation.
+
+Workflow efficiency requirements:
+
+- use `concurrency` with `cancel-in-progress: true`;
+- use shallow checkout and Git LFS only when the selected scope needs an LFS
+  fixture;
+- restore npm and Cargo caches keyed by lockfiles, runner, architecture, and
+  toolchain;
+- use `npm ci --ignore-scripts` where compatible with the selected frontend
+  checks;
+- do not call `setup:worktree` in automatic CI because it combines dependency,
+  LFS, ONNX, and CLI preparation that most scopes do not need;
+- keep build/test output concise and upload reports only on failure or when
+  needed for the coverage baseline;
+- pin action revisions and toolchain versions.
+
+The single required status reports each applicable scope as passed, skipped due
+to an inapplicable diff, or failed. A skip caused by missing infrastructure or
+an environment error must fail the required status rather than appear green.
+
+### Local and manually dispatched lanes
+
+`npm run verify:local` remains the authoritative full source gate before merge
+for high-risk mail, storage, Tauri, native, and release changes. Pull requests
+record its result and focused sensitivity evidence.
+
+Manually dispatched GitHub workflows may provide reproducible remote evidence
+for:
+
+- the full Linux source suite;
+- coverage generation;
+- longer fuzzing;
+- credentialed provider smoke tests.
+
+They are disabled by default, have explicit job timeouts, and require a manual
+reason/input. No scheduled workflow is enabled without separate approval and a
+measured cost estimate.
+
+Apple-Silicon native verification and the entire release flow stay local. CI
+never receives signing, notarization, OAuth, R2, or production mailbox secrets.
+
+### Coverage ratchet without per-PR duplication
+
+Do not calculate full coverage on every pull request; it recompiles and reruns
+most of the suite for little additional defect-detection value.
+
+Instead:
+
+1. Pin Rust and frontend coverage tools and normalize exact covered/uncovered
+   line, function, and branch counts per package.
+2. Generate candidate baselines locally or with a manual Linux dispatch.
+3. Require three repeat green runs before committing a baseline.
+4. Compare the baseline during explicitly requested coverage runs and before a
+   release, not during every ordinary pull request.
+5. Review baseline changes as intentional diffs; never let the workflow under
+   test update its own baseline.
+6. Exclude generated/demo/fixture code explicitly, but never exclude protocol,
+   parser, storage, bridge, Reader, realtime, or CLI production code.
+
+Semantic fixture inventory and contract completeness remain blocking on every
+relevant pull request; coverage is a periodic non-regression guard, not a
+substitute for those gates.
+
+## Delivery sequence
+
+1. Add the tested change classifier and minimal Linux workflow. Measure three
+   representative runs before making it required.
+2. Add the fixture manifest, redaction validator, ownership, and automatic
+   corpus enumeration.
+3. Make existing raw fixtures equivalent across complete, selective, storage,
+   Tauri, and Reader paths.
+4. Add the scripted IMAP/SMTP harness and provider capability profiles.
+5. Enforce bidirectional Tauri command/event contracts.
+6. Add deterministic concurrency, locking, restart, and CLI subprocess tests.
+7. Add fixed-seed properties, then manual fuzzing and the periodic coverage
+   ratchet.
+8. Add disabled manual provider-smoke infrastructure. Enabling credentials or
+   scheduling it is a separately approved change.
+9. Keep native WebKit and installed-upgrade verification in the supervised
+   Apple-Silicon acceptance and release process.
+
+## Activation and cost review
+
+Creating workflow files does not automatically authorize:
+
+- enabling branch-protection requirements;
+- enabling scheduled workflows;
+- adding repository or environment secrets;
+- running credentialed provider tests;
+- using paid macOS or larger runners.
+
+Each requires separate approval after the workflow's measured duration and
+estimated monthly cost are reported. The first implementation should remain
+non-required until three representative pull requests demonstrate that the
+automatic lane stays within the documented budget.

--- a/docs/updater-release.md
+++ b/docs/updater-release.md
@@ -68,7 +68,10 @@ npm run release:publish -- vX.Y.Z "$PWD/release-assets/vX.Y.Z"
 `verify:local` runs the repository's Rust and frontend checks without producing
 a redundant packaged app. `release:build` builds the Apple Silicon app, signs
 and verifies it, notarizes and staples it, rebuilds and verifies the DMG, then
-creates and Tauri-signs the final updater archive.
+creates the final updater archive. The extracted archive must pass the same
+Apple-Silicon app and isolated bundled-CLI artifact checks before the archive is
+Tauri-signed. This is artifact acceptance, not an installed-client
+update/relaunch test.
 
 `release:publish` verifies the final DMG, refuses to overwrite versioned R2
 objects, uploads the immutable DMG/archive/signature, and anonymously downloads

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dakia",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dakia",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "dependencies": {
         "@browsermt/bergamot-translator": "^0.4.9",
         "@mantine/core": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "release:build": "./scripts/build-local-macos-release.sh",
     "release:publish": "./scripts/publish-local-production-release.sh",
     "test:updater-manifest": "node --test scripts/updater-manifest.node-test.mjs",
+    "test:change-classifier": "node --test scripts/change-classifier.node-test.mjs",
     "test:release-scripts": "node --test scripts/*.node-test.mjs",
     "audit:dependencies": "./scripts/audit-dependencies.sh",
     "audit:dependencies:npm": "./scripts/audit-dependencies.sh --npm",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dakia",
   "private": true,
-  "version": "0.3.0",
+  "version": "0.3.1",
   "type": "module",
   "scripts": {
     "dev": "./scripts/dev.sh",

--- a/scripts/bundle-cli.sh
+++ b/scripts/bundle-cli.sh
@@ -42,3 +42,10 @@ destination="$repo_root/apps/desktop/src-tauri/binaries/dakia-$target"
 mkdir -p "$(dirname "$destination")"
 cp "$repo_root/target/$target/$cargo_profile/dakia" "$destination"
 chmod 755 "$destination"
+
+if [ "$platform" = "macos" ] || [ "$platform" = "darwin" ]; then
+  # The sidecar lives in Contents/MacOS in a packaged app and next to the
+  # src-tauri framework directory during development. Its ONNX Runtime load
+  # command uses @rpath, so give both layouts the same relative lookup path.
+  install_name_tool -add_rpath "@executable_path/../Frameworks" "$destination"
+fi

--- a/scripts/change-classifier.mjs
+++ b/scripts/change-classifier.mjs
@@ -1,0 +1,255 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync } from "node:fs";
+
+const ACTIVE_SCOPES = [
+  "frontend",
+  "rust-core",
+  "mail-boundary",
+  "tauri-boundary",
+  "release-only",
+];
+
+const DOCS_OR_METADATA = [
+  /^docs\//,
+  /^README\.md$/,
+  /^CONTRIBUTING\.md$/,
+  /^SECURITY\.md$/,
+  /^CODE_OF_CONDUCT\.md$/,
+  /^\.github\/(?:CODEOWNERS|dependabot\.yml|pull_request_template\.md|ISSUE_TEMPLATE\/)/,
+];
+
+const MAIL_CORE =
+  /^crates\/dakia-core\/(?:src\/(?:mail|storage|provider|mime_budget|classification|flowed|oauth|ai)\.rs|testdata\/|tests\/)/;
+const MAIL_FRONTEND =
+  /^apps\/desktop\/src\/(?:api(?:MessageContent)?|types|App|components\/(?:HtmlMessage|Reader))(?:\.test)?\.(?:ts|tsx)$/;
+
+function matches(path, patterns) {
+  return patterns.some((pattern) => pattern.test(path));
+}
+
+function allActiveScopes() {
+  return Object.fromEntries(ACTIVE_SCOPES.map((scope) => [scope, true]));
+}
+
+/**
+ * Classify repository-relative paths into validation scopes. This deliberately
+ * promotes unknown or shared changes instead of risking an under-tested PR.
+ */
+export function classifyPaths(paths) {
+  const normalizedPaths = [
+    ...new Set(paths.map((path) => path.replaceAll("\\", "/"))),
+  ].sort();
+  const docsOnly = normalizedPaths.every((path) =>
+    matches(path, DOCS_OR_METADATA),
+  );
+  const scopes = Object.fromEntries(
+    ACTIVE_SCOPES.map((scope) => [scope, false]),
+  );
+  let requiresLfs = false;
+
+  if (docsOnly) {
+    return {
+      changedPaths: normalizedPaths,
+      docsOnly: true,
+      scopes,
+      requiresLfs,
+    };
+  }
+
+  for (const path of normalizedPaths) {
+    if (
+      path === "Cargo.toml" ||
+      path === "Cargo.lock" ||
+      path === "package.json" ||
+      path === "package-lock.json" ||
+      path === "vitest.config.ts" ||
+      path === "apps/desktop/tsconfig.json" ||
+      path === "apps/desktop/vite.config.ts" ||
+      path.startsWith(".github/workflows/") ||
+      path === "scripts/change-classifier.mjs" ||
+      path === "scripts/change-classifier.node-test.mjs"
+    ) {
+      Object.assign(scopes, allActiveScopes());
+      continue;
+    }
+
+    if (path.startsWith("apps/desktop/src/")) {
+      scopes.frontend = true;
+      if (
+        path === "apps/desktop/src/api.ts" ||
+        path === "apps/desktop/src/nativeWindows.ts" ||
+        path === "apps/desktop/src/composeWindow.ts" ||
+        path === "apps/desktop/src/types.ts"
+      ) {
+        scopes["tauri-boundary"] = true;
+      }
+      if (
+        MAIL_FRONTEND.test(path) ||
+        path.startsWith("apps/desktop/src/test/fixtures/")
+      ) {
+        scopes["mail-boundary"] = true;
+      }
+      continue;
+    }
+
+    if (path.startsWith("crates/dakia-core/")) {
+      scopes["rust-core"] = true;
+      if (MAIL_CORE.test(path)) {
+        scopes["mail-boundary"] = true;
+      }
+      continue;
+    }
+
+    if (path.startsWith("crates/dakia-cli/")) {
+      scopes["rust-core"] = true;
+      continue;
+    }
+
+    if (path.startsWith("apps/desktop/testdata/tauri-contract")) {
+      // These fixtures are consumed on both sides of the invoke/event boundary:
+      // TypeScript asserts frontend decoding while Rust asserts serialized
+      // command and event payloads.
+      scopes.frontend = true;
+      scopes["tauri-boundary"] = true;
+      continue;
+    }
+
+    if (path.startsWith("apps/desktop/src-tauri/")) {
+      scopes["rust-core"] = true;
+      scopes["tauri-boundary"] = true;
+      if (
+        path.startsWith("apps/desktop/src-tauri/resources/email-classifier-v2/")
+      ) {
+        scopes["mail-boundary"] = true;
+        scopes["release-only"] = true;
+      }
+      if (/\/tauri(?:\.install)?\.conf\.json$/.test(path)) {
+        scopes["release-only"] = true;
+      }
+      continue;
+    }
+
+    if (path.startsWith("apps/desktop/")) {
+      scopes.frontend = true;
+      continue;
+    }
+
+    if (path.startsWith("scripts/validate-realistic-fixtures.")) {
+      scopes["mail-boundary"] = true;
+      continue;
+    }
+
+    if (path.startsWith("scripts/tauri-contract-inventory.")) {
+      scopes["tauri-boundary"] = true;
+      continue;
+    }
+
+    if (path.startsWith("scripts/") || path.startsWith("docs/releases/")) {
+      scopes["release-only"] = true;
+      continue;
+    }
+
+    // A new top-level area has no established cheap validation contract yet.
+    // Exercise every automatic scope until one is deliberately added above.
+    Object.assign(scopes, allActiveScopes());
+  }
+
+  // Ordinary PR validation must never prepare the release-only ONNX model.
+  // Model-runtime tests remain in the authoritative local gate.
+  requiresLfs = false;
+
+  return {
+    changedPaths: normalizedPaths,
+    docsOnly: false,
+    scopes,
+    requiresLfs,
+  };
+}
+
+function git(cwd, args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+/**
+ * Resolve changed files against the true merge base rather than the current
+ * base branch tip, which can include unrelated changes made after branching.
+ */
+export function changedPathsFromMergeBase({
+  base,
+  head = "HEAD",
+  cwd = process.cwd(),
+}) {
+  if (!base) {
+    throw new Error("A base revision is required (pass --base <revision>)");
+  }
+  const mergeBase = git(cwd, ["merge-base", base, head]);
+  const output = execFileSync(
+    "git",
+    ["diff", "--name-only", "-z", mergeBase, head],
+    {
+      cwd,
+      encoding: "utf8",
+    },
+  );
+  const changedPaths = output.split("\0").filter(Boolean);
+  return { mergeBase, changedPaths };
+}
+
+function parseArguments(argv) {
+  const options = { head: "HEAD", githubOutput: false, json: false };
+  for (let index = 0; index < argv.length; index += 1) {
+    const argument = argv[index];
+    if (argument === "--base" || argument === "--head") {
+      const value = argv[index + 1];
+      if (!value) throw new Error(`${argument} requires a revision`);
+      options[argument.slice(2)] = value;
+      index += 1;
+    } else if (argument === "--github-output") {
+      options.githubOutput = true;
+    } else if (argument === "--json") {
+      options.json = true;
+    } else {
+      throw new Error(`Unknown argument: ${argument}`);
+    }
+  }
+  return options;
+}
+
+function writeGithubOutput(result) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) throw new Error("--github-output requires GITHUB_OUTPUT");
+  const entries = [
+    ["docs_only", result.docsOnly],
+    ["requires_lfs", result.requiresLfs],
+    ...ACTIVE_SCOPES.map((scope) => [
+      scope.replaceAll("-", "_"),
+      result.scopes[scope],
+    ]),
+  ];
+  appendFileSync(
+    outputPath,
+    `${entries.map(([key, value]) => `${key}=${value}`).join("\n")}\n`,
+  );
+}
+
+function main() {
+  const options = parseArguments(process.argv.slice(2));
+  const { mergeBase, changedPaths } = changedPathsFromMergeBase(options);
+  const result = {
+    ...classifyPaths(changedPaths),
+    base: options.base,
+    head: options.head,
+    mergeBase,
+  };
+  if (options.githubOutput) writeGithubOutput(result);
+  process.stdout.write(`${JSON.stringify(result)}\n`);
+}
+
+if (import.meta.url === new URL(process.argv[1], "file:").href) {
+  try {
+    main();
+  } catch (error) {
+    process.stderr.write(`change classifier failed: ${error.message}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -194,6 +194,11 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
     [...workflow.matchAll(/^  ([a-z][a-z0-9-]+):$/gm)].map((match) => match[1]),
     ["classify", "validate"],
   );
+  assert.match(
+    workflow,
+    /validate:\n\s+name: Validate applicable scopes[\s\S]*?timeout-minutes: 20/,
+    "the cold-cache activation run must have time to populate the shared Cargo cache",
+  );
   assert.doesNotMatch(workflow, /runs-on:\s*macos/i);
   assert.doesNotMatch(workflow, /setup:worktree/);
   assert.doesNotMatch(workflow, /git lfs (?:pull|fetch)/);

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -206,6 +206,11 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
     /--localstorage-file/,
     "Node 20 rejects --localstorage-file in NODE_OPTIONS on hosted runners",
   );
+  assert.match(
+    workflow,
+    /rustup toolchain install 1\.82\.0 --profile minimal --component rustfmt --component clippy/,
+    "rustup requires one --component flag per requested component",
+  );
   for (const action of workflow.matchAll(/uses:\s*[^@\s]+@([^\s#]+)/g)) {
     assert.match(action[1], /^[a-f0-9]{40}$/, `unpinned action: ${action[0]}`);
   }

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -208,7 +208,7 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
   );
   assert.match(
     workflow,
-    /rustup toolchain install 1\.82\.0 --profile minimal --component rustfmt --component clippy/,
+    /rustup toolchain install 1\.89\.0 --profile minimal --component rustfmt --component clippy/,
     "rustup requires one --component flag per requested component",
   );
   for (const action of workflow.matchAll(/uses:\s*[^@\s]+@([^\s#]+)/g)) {

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -201,6 +201,11 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
     workflow,
     /release:(?:build|publish)|notari[sz]|codesign|live-provider/i,
   );
+  assert.doesNotMatch(
+    workflow,
+    /--localstorage-file/,
+    "Node 20 rejects --localstorage-file in NODE_OPTIONS on hosted runners",
+  );
   for (const action of workflow.matchAll(/uses:\s*[^@\s]+@([^\s#]+)/g)) {
     assert.match(action[1], /^[a-f0-9]{40}$/, `unpinned action: ${action[0]}`);
   }

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -1,0 +1,224 @@
+import assert from "node:assert/strict";
+import { execFileSync, spawnSync } from "node:child_process";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  changedPathsFromMergeBase,
+  classifyPaths,
+} from "./change-classifier.mjs";
+
+const root = new URL("..", import.meta.url).pathname;
+const classifier = join(root, "scripts", "change-classifier.mjs");
+const scopeNames = [
+  "frontend",
+  "rust-core",
+  "mail-boundary",
+  "tauri-boundary",
+  "release-only",
+];
+
+function git(cwd, ...args) {
+  return execFileSync("git", args, { cwd, encoding: "utf8" }).trim();
+}
+
+function commit(cwd, message) {
+  git(cwd, "add", ".");
+  git(cwd, "commit", "-qm", message);
+}
+
+test("classifies representative paths and promotes shared or unknown paths", () => {
+  const cases = [
+    {
+      name: "documentation is docs-only",
+      paths: ["README.md", "docs/testing-strategy.md", ".github/CODEOWNERS"],
+      expected: { docsOnly: true, activeScopes: [] },
+    },
+    {
+      name: "reader changes cover frontend and mail boundaries",
+      paths: ["apps/desktop/src/components/Reader.test.tsx"],
+      expected: { activeScopes: ["frontend", "mail-boundary"] },
+    },
+    {
+      name: "core MIME fixtures cover rust and mail boundaries",
+      paths: ["crates/dakia-core/testdata/mime/provider-shape.eml"],
+      expected: { activeScopes: ["rust-core", "mail-boundary"] },
+    },
+    {
+      name: "fixture validator changes exercise the mail boundary",
+      paths: ["scripts/validate-realistic-fixtures.node-test.mjs"],
+      expected: { activeScopes: ["mail-boundary"] },
+    },
+    {
+      name: "Tauri inventory changes exercise the Tauri boundary",
+      paths: ["scripts/tauri-contract-inventory.mjs"],
+      expected: { activeScopes: ["tauri-boundary"] },
+    },
+    {
+      name: "shared Tauri contract fixtures exercise both consumers",
+      paths: ["apps/desktop/testdata/tauri-contracts/high-risk.json"],
+      expected: { activeScopes: ["frontend", "tauri-boundary"] },
+    },
+    {
+      name: "frontend invoke sources cannot bypass Tauri inventory",
+      paths: ["apps/desktop/src/api.ts"],
+      expected: {
+        activeScopes: ["frontend", "mail-boundary", "tauri-boundary"],
+      },
+    },
+    {
+      name: "Tauri origin inventory exercises both consumers",
+      paths: ["apps/desktop/testdata/tauri-contract-origins.json"],
+      expected: { activeScopes: ["frontend", "tauri-boundary"] },
+    },
+    {
+      name: "tauri configuration includes release validation",
+      paths: ["apps/desktop/src-tauri/tauri.conf.json"],
+      expected: {
+        activeScopes: ["rust-core", "tauri-boundary", "release-only"],
+      },
+    },
+    {
+      name: "classifier changes cannot narrow the required lane",
+      paths: ["scripts/change-classifier.mjs"],
+      expected: { activeScopes: scopeNames },
+    },
+    {
+      name: "unknown paths fail safe to every automatic scope",
+      paths: ["new-top-level-area/input.txt"],
+      expected: { activeScopes: scopeNames },
+    },
+  ];
+
+  for (const { name, paths, expected } of cases) {
+    const result = classifyPaths(paths);
+    assert.equal(result.docsOnly, expected.docsOnly ?? false, name);
+    assert.deepEqual(
+      result.scopes,
+      Object.fromEntries(
+        scopeNames.map((scope) => [
+          scope,
+          expected.activeScopes.includes(scope),
+        ]),
+      ),
+      name,
+    );
+  }
+
+  const lfsResult = classifyPaths([
+    "apps/desktop/src-tauri/resources/email-classifier-v2/model.onnx",
+  ]);
+  assert.equal(lfsResult.requiresLfs, false);
+  assert.equal(lfsResult.scopes["mail-boundary"], true);
+  assert.equal(
+    classifyPaths(["crates/dakia-cli/src/main.rs"]).requiresLfs,
+    false,
+  );
+});
+
+test("uses the merge base rather than unrelated commits on the base branch", () => {
+  const directory = mkdtempSync(join(tmpdir(), "dakia-change-classifier-"));
+  try {
+    git(directory, "init", "-q");
+    git(directory, "config", "user.email", "tests@example.invalid");
+    git(directory, "config", "user.name", "Dakia test");
+    writeFileSync(join(directory, "README.md"), "initial\n");
+    commit(directory, "initial");
+    git(directory, "branch", "-M", "main");
+    git(directory, "checkout", "-qb", "topic");
+    writeFileSync(join(directory, "README.md"), "topic documentation\n");
+    commit(directory, "topic docs");
+    git(directory, "checkout", "-q", "main");
+    writeFileSync(join(directory, "Cargo.toml"), "[workspace]\n");
+    commit(directory, "base rust change");
+
+    const diff = changedPathsFromMergeBase({
+      base: "main",
+      head: "topic",
+      cwd: directory,
+    });
+    assert.deepEqual(diff.changedPaths, ["README.md"]);
+    assert.equal(classifyPaths(diff.changedPaths).docsOnly, true);
+
+    const result = spawnSync(
+      process.execPath,
+      [classifier, "--base", "main", "--head", "topic", "--json"],
+      {
+        cwd: directory,
+        encoding: "utf8",
+      },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.deepEqual(JSON.parse(result.stdout).changedPaths, ["README.md"]);
+
+    const githubOutput = join(directory, "github-output.txt");
+    const outputResult = spawnSync(
+      process.execPath,
+      [classifier, "--base", "main", "--head", "topic", "--github-output"],
+      {
+        cwd: directory,
+        encoding: "utf8",
+        env: { ...process.env, GITHUB_OUTPUT: githubOutput },
+      },
+    );
+    assert.equal(outputResult.status, 0, outputResult.stderr);
+    assert.match(readFileSync(githubOutput, "utf8"), /^docs_only=true$/m);
+    assert.match(readFileSync(githubOutput, "utf8"), /^frontend=false$/m);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("requires a GitHub output file when asked to publish workflow outputs", () => {
+  const result = spawnSync(
+    process.execPath,
+    [classifier, "--base", "HEAD", "--github-output"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: { ...process.env, GITHUB_OUTPUT: "" },
+    },
+  );
+  assert.notEqual(result.status, 0);
+  assert.match(result.stderr, /requires GITHUB_OUTPUT/);
+});
+
+test("ordinary pull-request workflow preserves the cost and release boundaries", () => {
+  const workflow = readFileSync(
+    join(root, ".github/workflows/pull-request-validation.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /cancel-in-progress: true/);
+  assert.deepEqual(
+    [...workflow.matchAll(/^  ([a-z][a-z0-9-]+):$/gm)].map((match) => match[1]),
+    ["classify", "validate"],
+  );
+  assert.doesNotMatch(workflow, /runs-on:\s*macos/i);
+  assert.doesNotMatch(workflow, /setup:worktree/);
+  assert.doesNotMatch(workflow, /git lfs (?:pull|fetch)/);
+  assert.doesNotMatch(
+    workflow,
+    /release:(?:build|publish)|notari[sz]|codesign|live-provider/i,
+  );
+  for (const action of workflow.matchAll(/uses:\s*[^@\s]+@([^\s#]+)/g)) {
+    assert.match(action[1], /^[a-f0-9]{40}$/, `unpinned action: ${action[0]}`);
+  }
+  assert.match(
+    workflow,
+    /npm run bundle:cli:dev\s+cargo clippy -p dakia-desktop[\s\S]*cargo test -p dakia-desktop\s/,
+  );
+  assert.match(
+    workflow,
+    /id: frontend[\s\S]*npm run test[\s\S]*node --test scripts\/tauri-contract-inventory\.node-test\.mjs[\s\S]*node scripts\/tauri-contract-inventory\.mjs/,
+  );
+  const tauriStep = workflow.match(
+    /id: tauri_boundary[\s\S]*?(?=\n      - id:|\n      - name: Report selected scopes)/,
+  )?.[0];
+  assert.ok(tauriStep, "expected a Tauri boundary step");
+  assert.doesNotMatch(tauriStep, /tauri-contract-inventory/);
+  assert.doesNotMatch(
+    workflow,
+    /cargo test -p dakia-desktop tauri_contracts_tests/,
+  );
+});

--- a/scripts/coverage-ratchet.mjs
+++ b/scripts/coverage-ratchet.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function metric(found = 0, hit = 0) {
+  return { found, hit };
+}
+
+function addMetric(target, source) {
+  target.found += source.found;
+  target.hit += source.hit;
+}
+
+/**
+ * Parse the portable subset of LCOV produced by cargo-llvm-cov and Vitest.
+ * We deliberately count distinct lines/branches/functions per source file so
+ * repeated tracefile records cannot inflate a candidate's result.
+ */
+export function summarizeLcov(source) {
+  const files = new Map();
+  let current;
+
+  function file() {
+    if (!current) fail("LCOV record is missing an SF source-file entry");
+    if (!files.has(current)) {
+      files.set(current, {
+        lines: new Map(),
+        branches: new Map(),
+        functions: new Map(),
+      });
+    }
+    return files.get(current);
+  }
+
+  for (const line of source.split(/\r?\n/)) {
+    if (line.startsWith("SF:")) {
+      current = line.slice(3);
+      continue;
+    }
+    if (line === "end_of_record") {
+      current = undefined;
+      continue;
+    }
+    if (line.startsWith("DA:")) {
+      const [lineNumber, hits] = line.slice(3).split(",", 2);
+      const key = lineNumber;
+      const count = Number(hits);
+      if (!Number.isInteger(Number(lineNumber)) || !Number.isFinite(count)) {
+        fail(`Invalid DA record: ${line}`);
+      }
+      const existing = file().lines.get(key) ?? 0;
+      file().lines.set(key, Math.max(existing, count));
+      continue;
+    }
+    if (line.startsWith("BRDA:")) {
+      const [lineNumber, block, branch, hits] = line.slice(5).split(",", 4);
+      const key = `${lineNumber}:${block}:${branch}`;
+      const count = hits === "-" ? 0 : Number(hits);
+      if (!Number.isFinite(count)) fail(`Invalid BRDA record: ${line}`);
+      const existing = file().branches.get(key) ?? 0;
+      file().branches.set(key, Math.max(existing, count));
+      continue;
+    }
+    if (line.startsWith("FNDA:")) {
+      const separator = line.indexOf(",", 5);
+      if (separator === -1) fail(`Invalid FNDA record: ${line}`);
+      const count = Number(line.slice(5, separator));
+      const name = line.slice(separator + 1);
+      if (!name || !Number.isFinite(count))
+        fail(`Invalid FNDA record: ${line}`);
+      const existing = file().functions.get(name) ?? 0;
+      file().functions.set(name, Math.max(existing, count));
+    }
+  }
+
+  const summary = {
+    lines: metric(),
+    branches: metric(),
+    functions: metric(),
+  };
+  for (const record of files.values()) {
+    for (const hits of record.lines.values()) {
+      addMetric(summary.lines, metric(1, hits > 0 ? 1 : 0));
+    }
+    for (const hits of record.branches.values()) {
+      addMetric(summary.branches, metric(1, hits > 0 ? 1 : 0));
+    }
+    for (const hits of record.functions.values()) {
+      addMetric(summary.functions, metric(1, hits > 0 ? 1 : 0));
+    }
+  }
+  return summary;
+}
+
+function assertSummary(summary, label) {
+  for (const kind of ["lines", "branches", "functions"]) {
+    const value = summary?.[kind];
+    if (
+      !value ||
+      !Number.isInteger(value.found) ||
+      !Number.isInteger(value.hit) ||
+      value.found < 0 ||
+      value.hit < 0 ||
+      value.hit > value.found
+    ) {
+      fail(`${label} has an invalid ${kind} metric`);
+    }
+  }
+}
+
+export function compareCoverage(candidate, baseline) {
+  const failures = [];
+  for (const component of Object.keys(baseline.components)) {
+    const next = candidate.components[component];
+    if (!next) {
+      failures.push(`${component} is absent from the candidate`);
+      continue;
+    }
+    for (const kind of ["lines", "branches", "functions"]) {
+      const oldMetric = baseline.components[component][kind];
+      const nextMetric = next[kind];
+      // Cross multiplication avoids rounding a tiny regression into a pass.
+      if (nextMetric.hit * oldMetric.found < oldMetric.hit * nextMetric.found) {
+        failures.push(
+          `${component} ${kind} regressed: ${nextMetric.hit}/${nextMetric.found} < ${oldMetric.hit}/${oldMetric.found}`,
+        );
+      }
+    }
+  }
+  return failures;
+}
+
+function usage() {
+  return [
+    "Usage: node scripts/coverage-ratchet.mjs --rust-lcov PATH --frontend-lcov PATH --output PATH [--baseline PATH]",
+    "The script never writes a baseline. A missing --baseline produces a candidate JSON for review.",
+  ].join("\n");
+}
+
+export function parseArgs(args) {
+  const options = {};
+  for (let index = 0; index < args.length; index += 1) {
+    const argument = args[index];
+    if (argument === "--help") return { help: true };
+    if (
+      !["--rust-lcov", "--frontend-lcov", "--output", "--baseline"].includes(
+        argument,
+      )
+    ) {
+      fail(`Unknown option: ${argument}\n${usage()}`);
+    }
+    const value = args[index + 1];
+    if (!value || value.startsWith("--"))
+      fail(`Missing value for ${argument}\n${usage()}`);
+    options[argument.slice(2).replace("-", "_")] = value;
+    index += 1;
+  }
+  for (const option of ["rust_lcov", "frontend_lcov", "output"]) {
+    if (!options[option])
+      fail(`Missing --${option.replace("_", "-")}\n${usage()}`);
+  }
+  return options;
+}
+
+function readLcov(path, label) {
+  const summary = summarizeLcov(readFileSync(path, "utf8"));
+  if (summary.lines.found === 0)
+    fail(`${label} coverage report contains no executable lines`);
+  return summary;
+}
+
+function main() {
+  const options = parseArgs(process.argv.slice(2));
+  if (options.help) {
+    console.log(usage());
+    return;
+  }
+  const candidate = {
+    version: 1,
+    components: {
+      rust: readLcov(options.rust_lcov, "Rust"),
+      frontend: readLcov(options.frontend_lcov, "Frontend"),
+    },
+  };
+  const output = resolve(options.output);
+  mkdirSync(dirname(output), { recursive: true });
+  writeFileSync(output, `${JSON.stringify(candidate, null, 2)}\n`);
+
+  if (!options.baseline) {
+    console.log(`Wrote coverage candidate without a baseline: ${output}`);
+    return;
+  }
+  const baseline = JSON.parse(readFileSync(options.baseline, "utf8"));
+  if (baseline.version !== 1 || !baseline.components)
+    fail("Unsupported coverage baseline version");
+  for (const [name, summary] of Object.entries(baseline.components)) {
+    assertSummary(summary, `baseline ${name}`);
+  }
+  const failures = compareCoverage(candidate, baseline);
+  if (failures.length > 0)
+    fail(`Coverage ratchet failed:\n- ${failures.join("\n- ")}`);
+  console.log(
+    `Coverage ratchet passed against ${options.baseline}; candidate: ${output}`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/local-release.node-test.mjs
+++ b/scripts/local-release.node-test.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -31,6 +32,8 @@ function createStaticAppFixture() {
   mkdirSync(licenses, { recursive: true });
   writeFileSync(join(app, "Contents", "MacOS", "dakia-desktop"), "fixture");
   chmodSync(join(app, "Contents", "MacOS", "dakia-desktop"), 0o755);
+  writeFileSync(join(app, "Contents", "MacOS", "dakia"), "fixture");
+  chmodSync(join(app, "Contents", "MacOS", "dakia"), 0o755);
   writeFileSync(
     join(app, "Contents", "Frameworks", "libonnxruntime.1.23.2.dylib"),
     "fixture",
@@ -67,6 +70,74 @@ function createStaticAppFixture() {
     );
   }
   return { fixtureRoot, app };
+}
+
+function writeExecutable(path, source) {
+  writeFileSync(path, source);
+  chmodSync(path, 0o755);
+}
+
+function createCliContractFixture({ invalidInputSucceeds = false } = {}) {
+  const fixture = createStaticAppFixture();
+  const { app } = fixture;
+  const macOS = join(app, "Contents", "MacOS");
+  const mockBin = join(fixture.fixtureRoot, "mock-bin");
+  mkdirSync(mockBin);
+  writeFileSync(
+    join(app, "Contents", "Info.plist"),
+    `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict><key>CFBundleShortVersionString</key><string>0.0.0</string></dict></plist>
+`,
+  );
+  writeExecutable(
+    join(macOS, "dakia-desktop"),
+    `#!/bin/sh
+set -eu
+test "\${DAKIA_RELEASE_SMOKE_TEST:-}" = 1
+test -n "\${DAKIA_RELEASE_SMOKE_DATA_DIR:-}"
+printf '%s\\n' DAKIA_RELEASE_SMOKE_TEST_OK
+`,
+  );
+  writeExecutable(
+    join(macOS, "dakia"),
+    `#!/bin/sh
+set -eu
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --data-dir) shift 2 ;;
+    --json) shift ;;
+    *) break ;;
+  esac
+done
+case "\${1:-}" in
+  --version) printf 'dakia 0.0.0\\n' ;;
+  --help)
+    printf '%s\\n' 'Search, read, and send mail from the terminal' 'Usage: dakia [OPTIONS] <COMMAND>'
+    ;;
+  not-a-command)
+    ${invalidInputSucceeds ? "exit 0" : 'printf "%s\\n" "error: unrecognized subcommand \'not-a-command\'" "" "For more information, try \'--help\'." >&2; exit 2'}
+    ;;
+  account)
+    test "\${2:-}" = list
+    printf '[]\\n'
+    ;;
+  *) exit 64 ;;
+esac
+`,
+  );
+  writeExecutable(join(mockBin, "lipo"), "#!/bin/sh\nprintf '%s\\n' arm64\n");
+  writeExecutable(
+    join(mockBin, "codesign"),
+    `#!/bin/sh
+case "$1" in
+  --verify) exit 0 ;;
+  -dv) printf '%s\\n' TeamIdentifier=fixture-team >&2 ;;
+  *) exit 64 ;;
+esac
+`,
+  );
+  return { ...fixture, mockBin };
 }
 
 test("local installer builds only an app without updater artifacts", () => {
@@ -159,6 +230,104 @@ test("static packaged-app verification rejects a missing Dakia MPL source notice
   } finally {
     rmSync(fixtureRoot, { recursive: true, force: true });
   }
+});
+
+test("static packaged-app verification rejects a missing CLI sidecar", () => {
+  const { fixtureRoot, app } = createStaticAppFixture();
+  try {
+    rmSync(join(app, "Contents", "MacOS", "dakia"));
+    const result = spawnSync(appVerifier, ["--static-only", app], {
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /Contents\/MacOS\/dakia/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("static packaged-app verification rejects a symlinked CLI sidecar", () => {
+  const { fixtureRoot, app } = createStaticAppFixture();
+  try {
+    const sidecar = join(app, "Contents", "MacOS", "dakia");
+    rmSync(sidecar);
+    symlinkSync("dakia-desktop", sidecar);
+    const result = spawnSync(appVerifier, ["--static-only", app], {
+      encoding: "utf8",
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /unsafe packaged Dakia executable/);
+  } finally {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  }
+});
+
+test("packaged-app verification declares an isolated CLI contract smoke", () => {
+  const verifier = readFileSync(appVerifier, "utf8");
+  assert.match(verifier, /lipo -archs "\$cli"/);
+  assert.match(verifier, /codesign --verify --strict --verbose=2 "\$cli"/);
+  assert.match(verifier, /TeamIdentifier/);
+  assert.match(verifier, /"\$cli" --data-dir "\$cli_contract_data" --version/);
+  assert.match(verifier, /"\$cli" --data-dir "\$cli_contract_data" --help/);
+  assert.match(
+    verifier,
+    /"\$cli" --data-dir "\$cli_contract_data" not-a-command/,
+  );
+  assert.match(verifier, /cli_invalid_status" -ne 2/);
+  assert.match(
+    verifier,
+    /parse-only commands unexpectedly created profile state/,
+  );
+  assert.match(
+    verifier,
+    /"\$cli" --data-dir "\$smoke_root\/cli-data" --json account list/,
+  );
+  assert.match(verifier, /CFBundleShortVersionString/);
+  assert.match(verifier, /JSON\.parse/);
+});
+
+test(
+  "packaged-app verification executes and rejects bundled CLI parse-contract drift",
+  { skip: process.platform !== "darwin" },
+  () => {
+    const goodFixture = createCliContractFixture();
+    const badFixture = createCliContractFixture({ invalidInputSucceeds: true });
+    const environmentFor = (mockBin) => ({
+      PATH: `${mockBin}:${process.env.PATH}`,
+    });
+    try {
+      const goodResult = spawnSync(appVerifier, [goodFixture.app], {
+        encoding: "utf8",
+        env: environmentFor(goodFixture.mockBin),
+      });
+      assert.equal(goodResult.status, 0, goodResult.stderr);
+      assert.match(goodResult.stdout, /startup smoke test passed/);
+
+      const badResult = spawnSync(appVerifier, [badFixture.app], {
+        encoding: "utf8",
+        env: environmentFor(badFixture.mockBin),
+      });
+      assert.notEqual(badResult.status, 0);
+      assert.match(
+        badResult.stderr,
+        /invalid-input contract was not rejected as expected/,
+      );
+    } finally {
+      rmSync(goodFixture.fixtureRoot, { recursive: true, force: true });
+      rmSync(badFixture.fixtureRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test("updater packaging executes the extracted signed app and CLI verifier", () => {
+  const packager = readFileSync(
+    join(root, "scripts", "package-macos-updater.sh"),
+    "utf8",
+  );
+  assert.match(
+    packager,
+    /verify-macos-release-app\.sh" "\$verify_dir\/Dakia\.app"/,
+  );
 });
 
 test("release environment preserves an explicitly injected Google OAuth secret", () => {

--- a/scripts/local-release.node-test.mjs
+++ b/scripts/local-release.node-test.mjs
@@ -19,6 +19,7 @@ const publisher = join(root, "scripts/publish-release-to-r2.sh");
 const releaseEnvironment = join(root, "scripts/local-release-env.sh");
 const appVerifier = join(root, "scripts/verify-macos-release-app.sh");
 const releaseBuilder = join(root, "scripts/build-local-macos-release.sh");
+const cliBundler = join(root, "scripts/bundle-cli.sh");
 function createStaticAppFixture() {
   const fixtureRoot = mkdtempSync(join(tmpdir(), "dakia-release-app-test-"));
   const app = join(fixtureRoot, "Dakia.app");
@@ -77,7 +78,10 @@ function writeExecutable(path, source) {
   chmodSync(path, 0o755);
 }
 
-function createCliContractFixture({ invalidInputSucceeds = false } = {}) {
+function createCliContractFixture({
+  invalidInputSucceeds = false,
+  missingFrameworkRpath = false,
+} = {}) {
   const fixture = createStaticAppFixture();
   const { app } = fixture;
   const macOS = join(app, "Contents", "MacOS");
@@ -135,6 +139,19 @@ case "$1" in
   -dv) printf '%s\\n' TeamIdentifier=fixture-team >&2 ;;
   *) exit 64 ;;
 esac
+`,
+  );
+  writeExecutable(
+    join(mockBin, "otool"),
+    missingFrameworkRpath
+      ? "#!/bin/sh\nexit 0\n"
+      : `#!/bin/sh
+cat <<'OUTPUT'
+Load command 1
+          cmd LC_RPATH
+      cmdsize 48
+         path @executable_path/../Frameworks (offset 12)
+OUTPUT
 `,
   );
   return { ...fixture, mockBin };
@@ -265,6 +282,7 @@ test("static packaged-app verification rejects a symlinked CLI sidecar", () => {
 test("packaged-app verification declares an isolated CLI contract smoke", () => {
   const verifier = readFileSync(appVerifier, "utf8");
   assert.match(verifier, /lipo -archs "\$cli"/);
+  assert.match(verifier, /@executable_path\/\.\.\/Frameworks/);
   assert.match(verifier, /codesign --verify --strict --verbose=2 "\$cli"/);
   assert.match(verifier, /TeamIdentifier/);
   assert.match(verifier, /"\$cli" --data-dir "\$cli_contract_data" --version/);
@@ -284,6 +302,14 @@ test("packaged-app verification declares an isolated CLI contract smoke", () => 
   );
   assert.match(verifier, /CFBundleShortVersionString/);
   assert.match(verifier, /JSON\.parse/);
+});
+
+test("macOS CLI bundling injects the packaged framework lookup path", () => {
+  const bundler = readFileSync(cliBundler, "utf8");
+  assert.match(
+    bundler,
+    /install_name_tool -add_rpath "@executable_path\/\.\.\/Frameworks"/,
+  );
 });
 
 test(
@@ -315,6 +341,27 @@ test(
     } finally {
       rmSync(goodFixture.fixtureRoot, { recursive: true, force: true });
       rmSync(badFixture.fixtureRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "packaged-app verification rejects a CLI without the framework rpath",
+  { skip: process.platform !== "darwin" },
+  () => {
+    const fixture = createCliContractFixture({ missingFrameworkRpath: true });
+    try {
+      const result = spawnSync(appVerifier, [fixture.app], {
+        encoding: "utf8",
+        env: { PATH: `${fixture.mockBin}:${process.env.PATH}` },
+      });
+      assert.notEqual(result.status, 0);
+      assert.match(
+        result.stderr,
+        /cannot resolve the bundled ONNX Runtime framework/,
+      );
+    } finally {
+      rmSync(fixture.fixtureRoot, { recursive: true, force: true });
     }
   },
 );

--- a/scripts/local-release.node-test.mjs
+++ b/scripts/local-release.node-test.mjs
@@ -5,6 +5,7 @@ import {
   mkdtempSync,
   mkdirSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -100,6 +101,9 @@ function createCliContractFixture({
 set -eu
 test "\${DAKIA_RELEASE_SMOKE_TEST:-}" = 1
 test -n "\${DAKIA_RELEASE_SMOKE_DATA_DIR:-}"
+if [ -n "\${DAKIA_TEST_LAUNCH_PATH_FILE:-}" ]; then
+  printf '%s' "$0" > "\$DAKIA_TEST_LAUNCH_PATH_FILE"
+fi
 printf '%s\\n' DAKIA_RELEASE_SMOKE_TEST_OK
 `,
   );
@@ -361,6 +365,35 @@ test(
         /cannot resolve the bundled ONNX Runtime framework/,
       );
     } finally {
+      rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "packaged-app verification canonicalizes symlinked temporary launch paths",
+  { skip: process.platform !== "darwin" },
+  () => {
+    const fixture = createCliContractFixture();
+    const aliasRoot = mkdtempSync(join(tmpdir(), "dakia-release-alias-"));
+    const alias = join(aliasRoot, "bundle");
+    const launchPath = join(aliasRoot, "launch-path.txt");
+    symlinkSync(fixture.fixtureRoot, alias);
+    try {
+      const result = spawnSync(appVerifier, [join(alias, "Dakia.app")], {
+        encoding: "utf8",
+        env: {
+          PATH: `${fixture.mockBin}:${process.env.PATH}`,
+          DAKIA_TEST_LAUNCH_PATH_FILE: launchPath,
+        },
+      });
+      assert.equal(result.status, 0, result.stderr);
+      assert.equal(
+        readFileSync(launchPath, "utf8"),
+        join(realpathSync(fixture.app), "Contents", "MacOS", "dakia-desktop"),
+      );
+    } finally {
+      rmSync(aliasRoot, { recursive: true, force: true });
       rmSync(fixture.fixtureRoot, { recursive: true, force: true });
     }
   },

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -1,0 +1,193 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { execFileSync, spawnSync } from "node:child_process";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import {
+  compareCoverage,
+  parseArgs,
+  summarizeLcov,
+} from "./coverage-ratchet.mjs";
+import { validateProviderSmokeContract } from "./provider-smoke-contract.mjs";
+
+const root = new URL("..", import.meta.url).pathname;
+
+const providerConfig = {
+  version: 1,
+  provider: "example-provider",
+  accountEmail: "smoke@example.invalid",
+  imap: { host: "imap.example.invalid", port: 993, security: "tls" },
+  smtp: { host: "smtp.example.invalid", port: 587, security: "starttls" },
+  credentials: { accessToken: "not-a-real-token" },
+};
+
+test("LCOV summaries deduplicate records and ratchet exact ratios", () => {
+  const summary = summarizeLcov(
+    [
+      "SF:src/a.rs",
+      "DA:1,1",
+      "DA:2,0",
+      "BRDA:1,0,0,1",
+      "BRDA:1,0,1,-",
+      "FNDA:1,first",
+      "FNDA:0,second",
+      "end_of_record",
+      "SF:src/a.rs",
+      "DA:1,2",
+      "end_of_record",
+    ].join("\n"),
+  );
+  assert.deepEqual(summary, {
+    lines: { found: 2, hit: 1 },
+    branches: { found: 2, hit: 1 },
+    functions: { found: 2, hit: 1 },
+  });
+  const candidate = { components: { rust: summary, frontend: summary } };
+  assert.deepEqual(compareCoverage(candidate, candidate), []);
+  assert.match(
+    compareCoverage(
+      {
+        components: {
+          rust: { ...summary, lines: { found: 2, hit: 0 } },
+          frontend: summary,
+        },
+      },
+      candidate,
+    ).join("\n"),
+    /rust lines regressed/,
+  );
+});
+
+test("coverage arguments require both implementation reports and an output path", () => {
+  assert.throws(() => parseArgs(["--rust-lcov", "rust.lcov"]), /frontend-lcov/);
+  assert.deepEqual(
+    parseArgs([
+      "--rust-lcov",
+      "rust.lcov",
+      "--frontend-lcov",
+      "frontend.lcov",
+      "--output",
+      "candidate.json",
+    ]),
+    {
+      rust_lcov: "rust.lcov",
+      frontend_lcov: "frontend.lcov",
+      output: "candidate.json",
+    },
+  );
+});
+
+test("coverage CLI emits a reviewable candidate and never creates a baseline", () => {
+  const directory = mkdtempSync(join(tmpdir(), "dakia-coverage-ratchet-"));
+  try {
+    const lcov = join(directory, "coverage.lcov");
+    const output = join(directory, "candidate.json");
+    writeFileSync(lcov, "SF:src/a.rs\nDA:1,1\nend_of_record\n");
+    execFileSync(
+      process.execPath,
+      [
+        "scripts/coverage-ratchet.mjs",
+        "--rust-lcov",
+        lcov,
+        "--frontend-lcov",
+        lcov,
+        "--output",
+        output,
+      ],
+      { cwd: root, stdio: "pipe" },
+    );
+    assert.deepEqual(
+      JSON.parse(readFileSync(output, "utf8")).components.rust.lines,
+      { found: 1, hit: 1 },
+    );
+    assert.equal(existsSync(join(directory, "baseline.json")), false);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+test("provider smoke contract validates secrets without exposing them or connecting", () => {
+  assert.deepEqual(validateProviderSmokeContract(providerConfig), {
+    version: 1,
+    provider: "example-provider",
+    accountEmail: "smoke@example.invalid",
+    imap: providerConfig.imap,
+    smtp: providerConfig.smtp,
+    credentialKind: "accessToken",
+  });
+  assert.throws(
+    () =>
+      validateProviderSmokeContract({
+        ...providerConfig,
+        credentials: { accessToken: "x", password: "y" },
+      }),
+    /exactly one/,
+  );
+  const secret = "must-not-appear-in-output";
+  const result = spawnSync(
+    process.execPath,
+    ["scripts/provider-smoke-contract.mjs"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PROVIDER_SMOKE_CONFIG: JSON.stringify({
+          ...providerConfig,
+          credentials: { accessToken: secret },
+        }),
+      },
+    },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(secret));
+  assert.doesNotMatch(result.stdout, /smoke@example\.invalid/);
+});
+
+test("manual workflow remains dispatch-only and runs bounded infrastructure", () => {
+  const workflow = readFileSync(
+    join(root, ".github/workflows/manual-validation.yml"),
+    "utf8",
+  );
+  assert.match(workflow, /^\s*workflow_dispatch:/m);
+  assert.doesNotMatch(workflow, /^\s*schedule:/m);
+  assert.match(
+    workflow,
+    /cargo install cargo-llvm-cov --version 0\.6\.13 --locked/,
+  );
+  assert.match(
+    workflow,
+    /git lfs pull --include='apps\/desktop\/src-tauri\/resources\/email-classifier-v2\/model\.onnx/,
+  );
+  assert.match(workflow, /run-fixed-seed-property-regressions\.sh 3/);
+  assert.match(workflow, /provider-smoke-contract\.mjs/);
+  assert.equal(
+    [...workflow.matchAll(/npm run bundle:cli:dev/g)].length,
+    2,
+    "full-source and coverage must prepare Tauri externalBin",
+  );
+});
+
+test("fixed-seed lane executes the property targets and exact MIME regression", () => {
+  const script = readFileSync(
+    join(root, "scripts/run-fixed-seed-property-regressions.sh"),
+    "utf8",
+  );
+  assert.match(script, /threadsProperties\.test\.ts/);
+  assert.match(script, /--test mail_boundary_properties/);
+  assert.match(
+    script,
+    /mail::tests::parses_the_checked_in_mime_regression_corpus/,
+  );
+  assert.doesNotMatch(
+    script,
+    /cargo test -p dakia-core parses_the_checked_in_mime_regression_corpus/,
+  );
+});

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -25,7 +25,7 @@ const providerConfig = {
   accountEmail: "smoke@example.invalid",
   imap: { host: "imap.example.invalid", port: 993, security: "tls" },
   smtp: { host: "smtp.example.invalid", port: 587, security: "starttls" },
-  credentials: { accessToken: "not-a-real-token" },
+  credentials: { appPassword: "not-a-real-app-password" },
 };
 
 test("LCOV summaries deduplicate records and ratchet exact ratios", () => {
@@ -120,15 +120,24 @@ test("provider smoke contract validates secrets without exposing them or connect
     accountEmail: "smoke@example.invalid",
     imap: providerConfig.imap,
     smtp: providerConfig.smtp,
-    credentialKind: "accessToken",
+    credentialKind: "appPassword",
   });
   assert.throws(
     () =>
       validateProviderSmokeContract({
         ...providerConfig,
-        credentials: { accessToken: "x", password: "y" },
+        credentials: { appPassword: "x", password: "y" },
       }),
     /exactly one/,
+  );
+  assert.throws(
+    () =>
+      validateProviderSmokeContract({
+        ...providerConfig,
+        credentials: { accessToken: "not-a-real-token" },
+      }),
+    /password or appPassword/,
+    "the live harness must reject OAuth-like credential fields instead of guessing a flow",
   );
   const secret = "must-not-appear-in-output";
   const result = spawnSync(
@@ -141,7 +150,7 @@ test("provider smoke contract validates secrets without exposing them or connect
         ...process.env,
         PROVIDER_SMOKE_CONFIG: JSON.stringify({
           ...providerConfig,
-          credentials: { accessToken: secret },
+          credentials: { appPassword: secret },
         }),
       },
     },
@@ -149,6 +158,21 @@ test("provider smoke contract validates secrets without exposing them or connect
   assert.equal(result.status, 0, result.stderr);
   assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(secret));
   assert.doesNotMatch(result.stdout, /smoke@example\.invalid/);
+  assert.doesNotMatch(result.stdout, /example-provider|imap\.example\.invalid|smtp\.example\.invalid/);
+
+  const rejected = spawnSync(process.execPath, ["scripts/provider-smoke-contract.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PROVIDER_SMOKE_CONFIG: JSON.stringify({
+        ...providerConfig,
+        credentials: { accessToken: secret },
+      }),
+    },
+  });
+  assert.notEqual(rejected.status, 0);
+  assert.doesNotMatch(`${rejected.stdout}${rejected.stderr}`, new RegExp(secret));
 });
 
 test("manual workflow remains dispatch-only and runs bounded infrastructure", () => {
@@ -168,6 +192,30 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   );
   assert.match(workflow, /run-fixed-seed-property-regressions\.sh 3/);
   assert.match(workflow, /provider-smoke-contract\.mjs/);
+  assert.match(workflow, /dakia-provider-smoke/);
+  assert.match(workflow, /RUSTUP_TOOLCHAIN=1\.82\.0/);
+  const providerJob = workflow.slice(workflow.indexOf("\n  provider-smoke:"));
+  assert.match(
+    providerJob,
+    /cargo build --locked -p dakia-cli --bin dakia-provider-smoke/,
+  );
+  assert.doesNotMatch(
+    providerJob,
+    /cargo run .*dakia-provider-smoke/,
+    "the protected execution step must run the prebuilt artifact, never compile with a secret in scope",
+  );
+  const buildIndex = providerJob.indexOf("cargo build --locked -p dakia-cli --bin dakia-provider-smoke");
+  const secretIndex = providerJob.indexOf("PROVIDER_SMOKE_CONFIG:");
+  assert.ok(buildIndex >= 0 && secretIndex > buildIndex);
+  assert.equal(
+    [...providerJob.matchAll(/PROVIDER_SMOKE_CONFIG:/g)].length,
+    1,
+    "the provider secret may be scoped only to the artifact execution step",
+  );
+  assert.match(
+    providerJob,
+    /run: \|\n\s+node scripts\/provider-smoke-contract\.mjs\n\s+target\/debug\/dakia-provider-smoke/,
+  );
   assert.equal(
     [...workflow.matchAll(/npm run bundle:cli:dev/g)].length,
     2,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -221,6 +221,11 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     2,
     "full-source and coverage must prepare Tauri externalBin",
   );
+  assert.doesNotMatch(
+    workflow,
+    /--localstorage-file/,
+    "Node 20 rejects --localstorage-file in NODE_OPTIONS on hosted runners",
+  );
 });
 
 test("fixed-seed lane executes the property targets and exact MIME regression", () => {

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -194,6 +194,11 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   assert.match(workflow, /provider-smoke-contract\.mjs/);
   assert.match(workflow, /dakia-provider-smoke/);
   assert.match(workflow, /RUSTUP_TOOLCHAIN=1\.82\.0/);
+  assert.match(
+    workflow,
+    /rustup toolchain install 1\.82\.0 --profile minimal --component rustfmt --component clippy/,
+    "rustup requires one --component flag per requested component",
+  );
   const providerJob = workflow.slice(workflow.indexOf("\n  provider-smoke:"));
   assert.match(
     providerJob,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -193,10 +193,10 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   assert.match(workflow, /run-fixed-seed-property-regressions\.sh 3/);
   assert.match(workflow, /provider-smoke-contract\.mjs/);
   assert.match(workflow, /dakia-provider-smoke/);
-  assert.match(workflow, /RUSTUP_TOOLCHAIN=1\.82\.0/);
+  assert.match(workflow, /RUSTUP_TOOLCHAIN=1\.89\.0/);
   assert.match(
     workflow,
-    /rustup toolchain install 1\.82\.0 --profile minimal --component rustfmt --component clippy/,
+    /rustup toolchain install 1\.89\.0 --profile minimal --component rustfmt --component clippy/,
     "rustup requires one --component flag per requested component",
   );
   const providerJob = workflow.slice(workflow.indexOf("\n  provider-smoke:"));

--- a/scripts/package-macos-updater.sh
+++ b/scripts/package-macos-updater.sh
@@ -104,6 +104,7 @@ tar -xzf "$archive" -C "$verify_dir"
 codesign --verify --deep --strict --verbose=2 "$verify_dir/Dakia.app"
 spctl --assess --type execute --verbose=2 "$verify_dir/Dakia.app"
 xcrun stapler validate "$verify_dir/Dakia.app"
+"$root_dir/scripts/verify-macos-release-app.sh" "$verify_dir/Dakia.app"
 
 (cd "$root_dir" && npm run tauri signer sign -- "$archive")
 

--- a/scripts/provider-smoke-contract.mjs
+++ b/scripts/provider-smoke-contract.mjs
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+const SECRET_KEYS = new Set([
+  "password",
+  "accessToken",
+  "refreshToken",
+  "clientSecret",
+]);
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function nonEmptyString(value, name) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    fail(`${name} must be a non-empty string`);
+  }
+  return value;
+}
+
+function endpoint(value, name) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail(`${name} must be an object`);
+  }
+  nonEmptyString(value.host, `${name}.host`);
+  if (!Number.isInteger(value.port) || value.port < 1 || value.port > 65535) {
+    fail(`${name}.port must be an integer from 1 to 65535`);
+  }
+  if (!["tls", "starttls"].includes(value.security)) {
+    fail(`${name}.security must be tls or starttls`);
+  }
+}
+
+/**
+ * Validate, but never connect with, the secret-backed provider smoke contract.
+ * The validated schema gives a future explicit harness a stable handoff without
+ * treating a credential/configuration check as a live-provider pass.
+ */
+export function validateProviderSmokeContract(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    fail("provider smoke configuration must be a JSON object");
+  }
+  if (value.version !== 1)
+    fail("provider smoke configuration version must be 1");
+  nonEmptyString(value.provider, "provider");
+  nonEmptyString(value.accountEmail, "accountEmail");
+  endpoint(value.imap, "imap");
+  endpoint(value.smtp, "smtp");
+  if (
+    !value.credentials ||
+    typeof value.credentials !== "object" ||
+    Array.isArray(value.credentials)
+  ) {
+    fail("credentials must be an object");
+  }
+  const credentialKeys = Object.keys(value.credentials);
+  if (credentialKeys.length !== 1 || !SECRET_KEYS.has(credentialKeys[0])) {
+    fail("credentials must contain exactly one supported secret field");
+  }
+  nonEmptyString(
+    value.credentials[credentialKeys[0]],
+    `credentials.${credentialKeys[0]}`,
+  );
+  return {
+    version: value.version,
+    provider: value.provider,
+    accountEmail: value.accountEmail,
+    imap: {
+      host: value.imap.host,
+      port: value.imap.port,
+      security: value.imap.security,
+    },
+    smtp: {
+      host: value.smtp.host,
+      port: value.smtp.port,
+      security: value.smtp.security,
+    },
+    credentialKind: credentialKeys[0],
+  };
+}
+
+function main() {
+  const raw = process.env.PROVIDER_SMOKE_CONFIG;
+  if (!raw) fail("PROVIDER_SMOKE_CONFIG is required");
+  let value;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    fail("PROVIDER_SMOKE_CONFIG must be valid JSON");
+  }
+  const contract = validateProviderSmokeContract(value);
+  console.log(
+    `Provider smoke contract validated for ${contract.provider}; no network connection was attempted.`,
+  );
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  try {
+    main();
+  } catch (error) {
+    // Deliberately never print the secret-backed JSON input.
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/provider-smoke-contract.mjs
+++ b/scripts/provider-smoke-contract.mjs
@@ -2,9 +2,7 @@
 
 const SECRET_KEYS = new Set([
   "password",
-  "accessToken",
-  "refreshToken",
-  "clientSecret",
+  "appPassword",
 ]);
 
 function fail(message) {
@@ -32,9 +30,10 @@ function endpoint(value, name) {
 }
 
 /**
- * Validate, but never connect with, the secret-backed provider smoke contract.
- * The validated schema gives a future explicit harness a stable handoff without
- * treating a credential/configuration check as a live-provider pass.
+ * Validate the secret-backed provider smoke contract before the Rust harness
+ * opens its single read-neutral IMAP session and SMTP auth/QUIT probe. OAuth
+ * values are deliberately rejected: this lane must not guess a refresh or
+ * token acquisition flow.
  */
 export function validateProviderSmokeContract(value) {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
@@ -55,7 +54,7 @@ export function validateProviderSmokeContract(value) {
   }
   const credentialKeys = Object.keys(value.credentials);
   if (credentialKeys.length !== 1 || !SECRET_KEYS.has(credentialKeys[0])) {
-    fail("credentials must contain exactly one supported secret field");
+    fail("credentials must contain exactly one password or appPassword field");
   }
   nonEmptyString(
     value.credentials[credentialKeys[0]],
@@ -89,9 +88,11 @@ function main() {
     fail("PROVIDER_SMOKE_CONFIG must be valid JSON");
   }
   const contract = validateProviderSmokeContract(value);
-  console.log(
-    `Provider smoke contract validated for ${contract.provider}; no network connection was attempted.`,
-  );
+  // Do not log account, endpoint, provider, or the secret-backed JSON. The
+  // workflow runs the separately compiled Rust harness immediately after this
+  // validation, so this is not presented as a live-provider pass by itself.
+  void contract;
+  console.log("Provider smoke configuration validated for the live harness.");
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {

--- a/scripts/run-fixed-seed-property-regressions.sh
+++ b/scripts/run-fixed-seed-property-regressions.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+iterations="${1:-3}"
+if ! [[ "$iterations" =~ ^[1-9][0-9]*$ ]] || (( iterations > 20 )); then
+  echo "Usage: $0 [iterations 1..20]" >&2
+  exit 2
+fi
+
+# This is intentionally a bounded deterministic corpus, not an unbounded
+# generative fuzzer. Any future fuzzer must add its target, seed corpus, and
+# resource budget before this lane can claim broader fuzz coverage.
+for ((iteration = 1; iteration <= iterations; iteration += 1)); do
+  echo "Fixed-seed property corpus iteration $iteration/$iterations"
+  cargo test -p dakia-core \
+    storage::tests::fixed_seed_thread_graphs_are_invariant_to_insert_and_chunk_order_across_accounts \
+    -- --exact --test-threads=1
+  npm run test -- apps/desktop/src/threadsProperties.test.ts --maxWorkers=1
+  cargo test -p dakia-core --test mail_boundary_properties -- --test-threads=1
+  cargo test -p dakia-core \
+    mail::tests::parses_the_checked_in_mime_regression_corpus \
+    -- --exact --test-threads=1
+done

--- a/scripts/tauri-contract-inventory.mjs
+++ b/scripts/tauri-contract-inventory.mjs
@@ -1,0 +1,797 @@
+#!/usr/bin/env node
+
+import { readFile, readdir } from "node:fs/promises";
+import { dirname, extname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SCRIPT_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const CONTRACT_PATH = "apps/desktop/testdata/tauri-contract-origins.json";
+const FRONTEND_ROOT = "apps/desktop/src";
+const RUST_ROOT = "apps/desktop/src-tauri/src";
+
+function isIdentifierStart(character) {
+  return /[A-Za-z_$]/.test(character);
+}
+
+function isIdentifierPart(character) {
+  return /[A-Za-z0-9_$]/.test(character);
+}
+
+function decodeQuoted(value, quote) {
+  let result = "";
+  for (let index = 1; index < value.length - 1; index += 1) {
+    const character = value[index];
+    if (character !== "\\") {
+      result += character;
+      continue;
+    }
+    index += 1;
+    const escaped = value[index];
+    if (escaped === undefined) break;
+    const simple = {
+      b: "\b",
+      f: "\f",
+      n: "\n",
+      r: "\r",
+      t: "\t",
+      v: "\v",
+      0: "\0",
+    };
+    if (simple[escaped] !== undefined) {
+      result += simple[escaped];
+    } else if (escaped === "x") {
+      const hex = value.slice(index + 1, index + 3);
+      result += String.fromCharCode(Number.parseInt(hex, 16));
+      index += 2;
+    } else if (escaped === "u" && value[index + 1] === "{") {
+      const end = value.indexOf("}", index + 2);
+      if (end === -1)
+        throw new Error(`Unterminated Unicode escape in ${value}`);
+      result += String.fromCodePoint(
+        Number.parseInt(value.slice(index + 2, end), 16),
+      );
+      index = end;
+    } else if (escaped === "u") {
+      const hex = value.slice(index + 1, index + 5);
+      result += String.fromCharCode(Number.parseInt(hex, 16));
+      index += 4;
+    } else {
+      // Command and event names are ASCII, but retaining an escaped quote or
+      // slash makes the lexer usable for adjacent parser tests too.
+      result += escaped;
+    }
+  }
+  return result;
+}
+
+/**
+ * A deliberately small lexer for the call shapes used at the IPC boundary.
+ * It skips comments and string bodies so a commented-out or quoted invoke can
+ * never become a contract entry. This is not a TypeScript or Rust parser.
+ */
+export function tokenize(source, language = "typescript") {
+  const tokens = [];
+  let index = 0;
+  while (index < source.length) {
+    const character = source[index];
+    const next = source[index + 1];
+    if (/\s/.test(character)) {
+      index += 1;
+      continue;
+    }
+    if (character === "/" && next === "/") {
+      index = source.indexOf("\n", index + 2);
+      if (index === -1) break;
+      continue;
+    }
+    if (character === "/" && next === "*") {
+      const end = source.indexOf("*/", index + 2);
+      if (end === -1) throw new Error("Unterminated block comment");
+      index = end + 2;
+      continue;
+    }
+    if (
+      language === "rust" &&
+      character === "'" &&
+      /[A-Za-z_]/.test(next ?? "")
+    ) {
+      let lifetimeEnd = index + 1;
+      while (isIdentifierPart(source[lifetimeEnd] ?? "")) lifetimeEnd += 1;
+      if (source[lifetimeEnd] !== "'") {
+        tokens.push({ type: "symbol", value: "'" });
+        index += 1;
+        continue;
+      }
+    }
+    if (character === "'" || character === '"' || character === "`") {
+      const quote = character;
+      const start = index;
+      let hasInterpolation = false;
+      index += 1;
+      while (index < source.length) {
+        if (source[index] === "\\") {
+          index += 2;
+          continue;
+        }
+        if (
+          quote === "`" &&
+          source[index] === "$" &&
+          source[index + 1] === "{"
+        ) {
+          hasInterpolation = true;
+        }
+        if (source[index] === quote) {
+          index += 1;
+          break;
+        }
+        index += 1;
+      }
+      if (source[index - 1] !== quote) {
+        throw new Error(`Unterminated ${quote} string at offset ${start}`);
+      }
+      const raw = source.slice(start, index);
+      tokens.push({
+        type: quote === "`" && hasInterpolation ? "template" : "string",
+        value: quote === "`" ? raw.slice(1, -1) : decodeQuoted(raw, quote),
+      });
+      continue;
+    }
+    // Rust raw strings, including r#"event"# and br"event".
+    const rawString = source.slice(index).match(/^(?:br|rb|r)(#+)?"/);
+    if (rawString) {
+      const hashes = rawString[1] ?? "";
+      const delimiter = `"${hashes}`;
+      const start = index + rawString[0].length;
+      const end = source.indexOf(delimiter, start);
+      if (end === -1) throw new Error("Unterminated Rust raw string");
+      tokens.push({ type: "string", value: source.slice(start, end) });
+      index = end + delimiter.length;
+      continue;
+    }
+    if (isIdentifierStart(character)) {
+      const start = index;
+      index += 1;
+      while (index < source.length && isIdentifierPart(source[index]))
+        index += 1;
+      tokens.push({ type: "identifier", value: source.slice(start, index) });
+      continue;
+    }
+    tokens.push({ type: "symbol", value: character });
+    index += 1;
+  }
+  return tokens;
+}
+
+function skipTypeArguments(tokens, index) {
+  if (tokens[index]?.value !== "<") return index;
+  let depth = 0;
+  for (; index < tokens.length; index += 1) {
+    if (tokens[index].value === "<") depth += 1;
+    if (tokens[index].value === ">") {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+  }
+  throw new Error("Unterminated generic type arguments");
+}
+
+function literalCalls(source, names, argumentIndex) {
+  const tokens = tokenize(source);
+  const values = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index].type !== "identifier" || !names.has(tokens[index].value))
+      continue;
+    let cursor = skipTypeArguments(tokens, index + 1);
+    if (tokens[cursor]?.value !== "(") continue;
+    for (let argument = 0; argument < argumentIndex; argument += 1) {
+      cursor += 1;
+      let depth = 0;
+      while (cursor < tokens.length) {
+        if (tokens[cursor].value === "(") depth += 1;
+        if (tokens[cursor].value === ")") depth -= 1;
+        if (tokens[cursor].value === "," && depth === 0) break;
+        cursor += 1;
+      }
+      if (tokens[cursor]?.value !== ",") {
+        throw new Error(
+          `${tokens[index].value} is missing argument ${argumentIndex + 1}`,
+        );
+      }
+    }
+    const event = tokens[cursor + 1];
+    if (event?.type !== "string") {
+      throw new Error(
+        `${tokens[index].value} must use a literal contract name`,
+      );
+    }
+    values.push(event.value);
+  }
+  return values;
+}
+
+function skipBalanced(tokens, index, opening, closing) {
+  if (tokens[index]?.value !== opening) {
+    throw new Error(`Expected ${opening}`);
+  }
+  let depth = 0;
+  for (; index < tokens.length; index += 1) {
+    if (tokens[index].value === opening) depth += 1;
+    if (tokens[index].value === closing) {
+      depth -= 1;
+      if (depth === 0) return index + 1;
+    }
+  }
+  throw new Error(`Unterminated ${opening}${closing} expression`);
+}
+
+function skipObjectValue(tokens, index) {
+  const closings = new Map([
+    ["(", ")"],
+    ["[", "]"],
+    ["{", "}"],
+  ]);
+  const stack = [];
+  for (; index < tokens.length; index += 1) {
+    const value = tokens[index].value;
+    if (closings.has(value)) {
+      stack.push(closings.get(value));
+      continue;
+    }
+    if (stack.length && value === stack.at(-1)) {
+      stack.pop();
+      continue;
+    }
+    if (!stack.length && [",", "}"].includes(value)) return index;
+  }
+  throw new Error("Unterminated frontend invoke request object");
+}
+
+function isSpread(tokens, index) {
+  return (
+    tokens[index]?.value === "." &&
+    tokens[index + 1]?.value === "." &&
+    tokens[index + 2]?.value === "."
+  );
+}
+
+function frontendRequestObjectKeys(tokens, index, command) {
+  if (tokens[index]?.value !== "{") throw new Error("Expected request object");
+  const keys = [];
+  let cursor = index + 1;
+  while (tokens[cursor]?.value !== "}") {
+    if (!tokens[cursor]) {
+      throw new Error(
+        `invoke(${JSON.stringify(command)}) has an unterminated request object`,
+      );
+    }
+    if (isSpread(tokens, cursor)) {
+      throw new Error(
+        `invoke(${JSON.stringify(command)}) request object must not use spread properties`,
+      );
+    }
+    const property = tokens[cursor];
+    if (!["identifier", "string"].includes(property.type)) {
+      throw new Error(
+        `invoke(${JSON.stringify(command)}) request object must use static top-level keys`,
+      );
+    }
+    const key = property.value;
+    cursor += 1;
+    if (tokens[cursor]?.value === ":") {
+      cursor = skipObjectValue(tokens, cursor + 1);
+    } else if (property.type !== "identifier") {
+      throw new Error(
+        `invoke(${JSON.stringify(command)}) request object has an invalid property`,
+      );
+    }
+    keys.push(key);
+    if (tokens[cursor]?.value === ",") {
+      cursor += 1;
+      continue;
+    }
+    if (tokens[cursor]?.value !== "}") {
+      throw new Error(
+        `invoke(${JSON.stringify(command)}) request object must use static top-level keys`,
+      );
+    }
+  }
+  return { keys: sortedSet(keys), end: cursor + 1 };
+}
+
+/**
+ * Returns every frontend invocation with its statically knowable top-level
+ * request keys. Tauri deserializes command parameters directly from this
+ * object, so an opaque argument or spread would make the inventory unsound.
+ */
+export function extractFrontendInvokeRequests(source) {
+  const tokens = tokenize(source);
+  const requests = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index].type !== "identifier" || tokens[index].value !== "invoke")
+      continue;
+    let cursor = skipTypeArguments(tokens, index + 1);
+    if (tokens[cursor]?.value !== "(") continue;
+    const command = tokens[cursor + 1];
+    if (command?.type !== "string") {
+      throw new Error("invoke must use a literal contract name");
+    }
+    cursor += 2;
+    if (tokens[cursor]?.value === ")") {
+      requests.push({ command: command.value, keys: [] });
+      continue;
+    }
+    if (tokens[cursor]?.value !== ",") {
+      throw new Error(`invoke(${JSON.stringify(command.value)}) is malformed`);
+    }
+    cursor += 1;
+    if (tokens[cursor]?.value !== "{") {
+      throw new Error(
+        `invoke(${JSON.stringify(command.value)}) request arguments must be a static object literal`,
+      );
+    }
+    const request = frontendRequestObjectKeys(tokens, cursor, command.value);
+    if (![",", ")"].includes(tokens[request.end]?.value)) {
+      throw new Error(`invoke(${JSON.stringify(command.value)}) is malformed`);
+    }
+    requests.push({ command: command.value, keys: request.keys });
+  }
+  return requests;
+}
+
+export function extractFrontendInvokes(source) {
+  return extractFrontendInvokeRequests(source).map(({ command }) => command);
+}
+
+export function extractFrontendListeners(source) {
+  return literalCalls(source, new Set(["listen"]), 0);
+}
+
+export function extractFrontendEmitters(source) {
+  return literalCalls(source, new Set(["emitTo"]), 1);
+}
+
+export function extractGenerateHandlerCommands(source) {
+  const tokens = tokenize(source, "rust");
+  const commands = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index].value !== "generate_handler") continue;
+    if (tokens[index + 1]?.value !== "!" || tokens[index + 2]?.value !== "[")
+      continue;
+    let cursor = index + 3;
+    while (tokens[cursor]?.value !== "]") {
+      const command = tokens[cursor];
+      if (command?.type !== "identifier") {
+        throw new Error("generate_handler! must contain bare command names");
+      }
+      commands.push(command.value);
+      cursor += 1;
+      if (tokens[cursor]?.value === ",") cursor += 1;
+      else if (tokens[cursor]?.value !== "]") {
+        throw new Error("generate_handler! commands must be comma separated");
+      }
+    }
+  }
+  if (commands.length === 0)
+    throw new Error("No generate_handler! commands found");
+  return commands;
+}
+
+const TAURI_INJECTED_PARAMETER_TYPES = new Set([
+  "AppHandle",
+  "State",
+  "Window",
+  "WebviewWindow",
+  "Webview",
+  "Request",
+]);
+
+function commandAttributeEnd(tokens, index) {
+  if (
+    tokens[index]?.value !== "#" ||
+    tokens[index + 1]?.value !== "[" ||
+    tokens[index + 2]?.value !== "tauri" ||
+    tokens[index + 3]?.value !== ":" ||
+    tokens[index + 4]?.value !== ":" ||
+    tokens[index + 5]?.value !== "command"
+  ) {
+    return null;
+  }
+  return skipBalanced(tokens, index + 1, "[", "]");
+}
+
+function rustParameterIsInjected(typeTokens) {
+  const typeNames = typeTokens
+    .filter((token) => token.type === "identifier")
+    .map((token) => token.value);
+  // Channel is a Tauri IPC type, but unlike AppHandle/State/etc. it is sent by
+  // the frontend and therefore remains part of the request contract.
+  if (typeNames.includes("Channel")) return false;
+  return typeNames.some((name) => TAURI_INJECTED_PARAMETER_TYPES.has(name));
+}
+
+function rustCommandParameters(tokens, start, end, command) {
+  const parameters = [];
+  let cursor = start + 1;
+  while (cursor < end) {
+    if (tokens[cursor]?.value === ",") {
+      cursor += 1;
+      continue;
+    }
+    if (tokens[cursor]?.value === "mut") cursor += 1;
+    const name = tokens[cursor];
+    if (name?.type !== "identifier" || tokens[cursor + 1]?.value !== ":") {
+      throw new Error(
+        `#[tauri::command] ${command} must use named function parameters`,
+      );
+    }
+    cursor += 2;
+    const typeStart = cursor;
+    let genericDepth = 0;
+    let delimiterDepth = 0;
+    while (cursor < end) {
+      const value = tokens[cursor].value;
+      if (value === "<") genericDepth += 1;
+      else if (value === ">") genericDepth -= 1;
+      else if (["(", "[", "{"].includes(value)) delimiterDepth += 1;
+      else if ([")", "]", "}"].includes(value)) delimiterDepth -= 1;
+      if (value === "," && genericDepth === 0 && delimiterDepth === 0) break;
+      cursor += 1;
+    }
+    if (!rustParameterIsInjected(tokens.slice(typeStart, cursor))) {
+      parameters.push(snakeToCamel(name.value));
+    }
+  }
+  return parameters;
+}
+
+function snakeToCamel(name) {
+  return name.replace(/_([a-zA-Z0-9])/g, (_, character) =>
+    character.toUpperCase(),
+  );
+}
+
+/** Extract Tauri command request parameter names, expressed as JS keys. */
+export function extractRustCommandParameters(source) {
+  const tokens = tokenize(source, "rust");
+  const commands = {};
+  for (let index = 0; index < tokens.length; index += 1) {
+    let cursor = commandAttributeEnd(tokens, index);
+    if (cursor === null) continue;
+    // Attributes such as #[allow(...)] may sit between command and fn.
+    while (tokens[cursor]?.value === "#") {
+      if (tokens[cursor + 1]?.value !== "[") break;
+      cursor = skipBalanced(tokens, cursor + 1, "[", "]");
+    }
+    while (["pub", "async", "unsafe", "extern"].includes(tokens[cursor]?.value)) {
+      cursor += 1;
+      if (tokens[cursor - 1]?.value === "extern" && tokens[cursor]?.type === "string")
+        cursor += 1;
+    }
+    if (tokens[cursor]?.value !== "fn" || tokens[cursor + 1]?.type !== "identifier") {
+      throw new Error("#[tauri::command] must be followed by a function");
+    }
+    const command = tokens[cursor + 1].value;
+    cursor += 2;
+    while (tokens[cursor]?.value !== "(" && cursor < tokens.length) cursor += 1;
+    const end = skipBalanced(tokens, cursor, "(", ")") - 1;
+    if (Object.hasOwn(commands, command)) {
+      throw new Error(`Duplicate #[tauri::command] function ${command}`);
+    }
+    commands[command] = rustCommandParameters(tokens, cursor, end, command);
+  }
+  return commands;
+}
+
+function rustStringConstants(tokens) {
+  const constants = new Map();
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (
+      tokens[index].value !== "const" ||
+      tokens[index + 1]?.type !== "identifier"
+    )
+      continue;
+    const name = tokens[index + 1].value;
+    let cursor = index + 2;
+    while (cursor < tokens.length && tokens[cursor].value !== ";") {
+      if (
+        tokens[cursor].value === "=" &&
+        tokens[cursor + 1]?.type === "string"
+      ) {
+        constants.set(name, tokens[cursor + 1].value);
+        break;
+      }
+      cursor += 1;
+    }
+  }
+  return constants;
+}
+
+export function extractRustNativeEmits(source) {
+  const tokens = tokenize(source, "rust");
+  const constants = rustStringConstants(tokens);
+  const events = [];
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (!new Set(["emit", "emit_all", "emit_to"]).has(tokens[index].value))
+      continue;
+    if (tokens[index + 1]?.value !== "(") continue;
+    const event = tokens[index + 2];
+    if (event?.type === "string") {
+      events.push(event.value);
+    } else if (event?.type === "identifier" && constants.has(event.value)) {
+      events.push(constants.get(event.value));
+    } else {
+      throw new Error(
+        `${tokens[index].value} must use a literal or const event name`,
+      );
+    }
+  }
+  return events;
+}
+
+async function filesBelow(root, predicate) {
+  const files = [];
+  async function visit(directory) {
+    for (const entry of await readdir(directory, { withFileTypes: true })) {
+      const path = resolve(directory, entry.name);
+      if (entry.isDirectory()) await visit(path);
+      else if (predicate(path)) files.push(path);
+    }
+  }
+  await visit(root);
+  return files.sort();
+}
+
+function sortedSet(values) {
+  return [...new Set(values)].sort();
+}
+
+async function namesFromFiles(files, extractor, marker) {
+  const names = [];
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    // Avoid lexing unrelated TypeScript/TSX modules. Besides making the check
+    // cheap, this limits the mechanical lexer to the API syntax it owns.
+    if (!source.includes(marker)) continue;
+    names.push(...extractor(source));
+  }
+  return sortedSet(names);
+}
+
+async function frontendInvokeRequestsFromFiles(files) {
+  const requests = [];
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    if (!source.includes("invoke")) continue;
+    requests.push(...extractFrontendInvokeRequests(source));
+  }
+  return requests;
+}
+
+async function rustCommandParametersFromFiles(files) {
+  const commands = {};
+  for (const file of files) {
+    const source = await readFile(file, "utf8");
+    if (!source.includes("tauri::command")) continue;
+    for (const [name, parameters] of Object.entries(
+      extractRustCommandParameters(source),
+    )) {
+      if (Object.hasOwn(commands, name)) {
+        throw new Error(`Duplicate #[tauri::command] function ${name}`);
+      }
+      commands[name] = parameters;
+    }
+  }
+  return commands;
+}
+
+export async function inventoryRepository(repositoryRoot = SCRIPT_ROOT) {
+  const frontendDirectory = resolve(repositoryRoot, FRONTEND_ROOT);
+  const rustDirectory = resolve(repositoryRoot, RUST_ROOT);
+  const frontendFiles = await filesBelow(
+    frontendDirectory,
+    (path) =>
+      [".ts", ".tsx"].includes(extname(path)) &&
+      !/\.test\.tsx?$/.test(path) &&
+      !relative(frontendDirectory, path).split("/").includes("test"),
+  );
+  const rustFiles = await filesBelow(
+    rustDirectory,
+    (path) => extname(path) === ".rs",
+  );
+  const handlerSource = await readFile(
+    resolve(rustDirectory, "lib.rs"),
+    "utf8",
+  );
+  const frontendInvokeRequests = await frontendInvokeRequestsFromFiles(
+    frontendFiles,
+  );
+  return {
+    frontendInvokes: sortedSet(
+      frontendInvokeRequests.map(({ command }) => command),
+    ),
+    frontendInvokeRequests,
+    frontendListeners: await namesFromFiles(
+      frontendFiles,
+      extractFrontendListeners,
+      "listen",
+    ),
+    frontendEmitters: await namesFromFiles(
+      frontendFiles,
+      extractFrontendEmitters,
+      "emitTo",
+    ),
+    rustHandlers: sortedSet(extractGenerateHandlerCommands(handlerSource)),
+    rustCommandParameters: await rustCommandParametersFromFiles(rustFiles),
+    rustNativeEmits: await namesFromFiles(
+      rustFiles,
+      extractRustNativeEmits,
+      "emit",
+    ),
+  };
+}
+
+function difference(left, right) {
+  const rightNames = new Set(right);
+  return left.filter((name) => !rightNames.has(name));
+}
+
+function duplicates(values) {
+  return values.filter((value, index) => values.indexOf(value) !== index);
+}
+
+function expectExact(errors, label, actual, expected) {
+  const missing = difference(expected, actual);
+  const unexpected = difference(actual, expected);
+  if (missing.length) errors.push(`${label} missing: ${missing.join(", ")}`);
+  if (unexpected.length)
+    errors.push(`${label} unexpected: ${unexpected.join(", ")}`);
+}
+
+export function validateInventory(inventory, contract) {
+  const errors = [];
+  if (contract?.schemaVersion !== 1)
+    errors.push("contract schemaVersion must be 1");
+  const demoOnlyInvokes = contract?.demoOnlyInvokes;
+  const eventOrigins = contract?.eventOrigins;
+  if (!Array.isArray(demoOnlyInvokes))
+    errors.push("demoOnlyInvokes must be an array");
+  if (
+    !eventOrigins ||
+    typeof eventOrigins !== "object" ||
+    Array.isArray(eventOrigins)
+  ) {
+    errors.push("eventOrigins must be an object");
+  }
+  if (!Array.isArray(inventory.frontendInvokeRequests)) {
+    errors.push("frontendInvokeRequests must be an array");
+  }
+  if (
+    !inventory.rustCommandParameters ||
+    typeof inventory.rustCommandParameters !== "object" ||
+    Array.isArray(inventory.rustCommandParameters)
+  ) {
+    errors.push("rustCommandParameters must be an object");
+  }
+  if (errors.length) return errors;
+
+  if (duplicates(demoOnlyInvokes).length)
+    errors.push("demoOnlyInvokes contains duplicates");
+  for (const [event, origin] of Object.entries(eventOrigins)) {
+    if (!["native", "frontend", "demo-only"].includes(origin)) {
+      errors.push(`event ${event} has invalid origin ${String(origin)}`);
+    }
+  }
+  const frontendCommands = inventory.frontendInvokes.filter(
+    (name) => !demoOnlyInvokes.includes(name),
+  );
+  expectExact(
+    errors,
+    "frontend invokes vs Rust handlers",
+    frontendCommands,
+    inventory.rustHandlers,
+  );
+  for (const command of inventory.rustHandlers) {
+    if (!Object.hasOwn(inventory.rustCommandParameters, command)) {
+      errors.push(`registered Rust command ${command} has no parsed signature`);
+    }
+  }
+  for (const request of inventory.frontendInvokeRequests) {
+    if (demoOnlyInvokes.includes(request.command)) continue;
+    const parameters = inventory.rustCommandParameters[request.command];
+    if (!parameters) continue;
+    if (!Array.isArray(request.keys)) {
+      errors.push(
+        `frontend invoke request for ${request.command} must contain a keys array`,
+      );
+      continue;
+    }
+    expectExact(
+      errors,
+      `frontend invoke request keys for ${request.command}`,
+      request.keys,
+      parameters,
+    );
+  }
+  expectExact(
+    errors,
+    "declared demo-only invokes",
+    demoOnlyInvokes,
+    inventory.frontendInvokes.filter((name) => demoOnlyInvokes.includes(name)),
+  );
+
+  const knownEvents = Object.keys(eventOrigins).sort();
+  expectExact(
+    errors,
+    "frontend event classifications",
+    inventory.frontendListeners,
+    knownEvents,
+  );
+  const nativeEvents = knownEvents.filter(
+    (event) => eventOrigins[event] === "native",
+  );
+  const frontendEvents = knownEvents.filter(
+    (event) => eventOrigins[event] === "frontend",
+  );
+  const demoEvents = knownEvents.filter(
+    (event) => eventOrigins[event] === "demo-only",
+  );
+  expectExact(
+    errors,
+    "native emitted events vs native listeners",
+    inventory.rustNativeEmits,
+    nativeEvents,
+  );
+  expectExact(
+    errors,
+    "frontend emitted events vs frontend listeners",
+    inventory.frontendEmitters,
+    frontendEvents,
+  );
+  for (const event of demoEvents) {
+    if (
+      !inventory.frontendListeners.includes(event) &&
+      !inventory.frontendEmitters.includes(event)
+    ) {
+      errors.push(
+        `demo-only event ${event} is not present in frontend production source`,
+      );
+    }
+  }
+  return errors;
+}
+
+export function assertValidInventory(inventory, contract) {
+  const errors = validateInventory(inventory, contract);
+  if (errors.length)
+    throw new Error(
+      `Tauri contract drift:\n${errors.map((error) => `- ${error}`).join("\n")}`,
+    );
+}
+
+export async function readContract(repositoryRoot = SCRIPT_ROOT) {
+  return JSON.parse(
+    await readFile(resolve(repositoryRoot, CONTRACT_PATH), "utf8"),
+  );
+}
+
+async function main() {
+  const repositoryRoot = resolve(process.argv[2] ?? SCRIPT_ROOT);
+  const [inventory, contract] = await Promise.all([
+    inventoryRepository(repositoryRoot),
+    readContract(repositoryRoot),
+  ]);
+  assertValidInventory(inventory, contract);
+  process.stdout.write(
+    `Verified Tauri contracts: ${inventory.rustHandlers.length} commands, ${inventory.rustNativeEmits.length} native events, ${inventory.frontendEmitters.length} frontend events.\n`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  resolve(process.argv[1]) === fileURLToPath(import.meta.url)
+) {
+  main().catch((error) => {
+    process.stderr.write(`${error.stack ?? error}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/tauri-contract-inventory.node-test.mjs
+++ b/scripts/tauri-contract-inventory.node-test.mjs
@@ -1,0 +1,238 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  assertValidInventory,
+  extractFrontendEmitters,
+  extractFrontendInvokeRequests,
+  extractFrontendInvokes,
+  extractFrontendListeners,
+  extractGenerateHandlerCommands,
+  extractRustCommandParameters,
+  extractRustNativeEmits,
+  inventoryRepository,
+  readContract,
+  validateInventory,
+} from "./tauri-contract-inventory.mjs";
+
+test("parses production invokes while ignoring comments and quoted lookalikes", () => {
+  const source = `
+    // invoke("commented_out")
+    const note = 'invoke("quoted_out")';
+    invoke<Result<{ payload: Array<string> }>>("real_command", { payload: [] });
+    invoke("second_command");
+  `;
+  assert.deepEqual(extractFrontendInvokes(source), [
+    "real_command",
+    "second_command",
+  ]);
+});
+
+test("rejects dynamic frontend contract names instead of silently omitting them", () => {
+  assert.throws(
+    () => extractFrontendInvokes("invoke(`command-${suffix}`)"),
+    /must use a literal contract name/,
+  );
+  assert.throws(
+    () => extractFrontendListeners("listen(eventName, handler)"),
+    /must use a literal contract name/,
+  );
+});
+
+test("captures no-argument and static top-level frontend invoke request keys", () => {
+  const source = `
+    invoke("no_arguments");
+    invoke("hydrate_message", { messageId });
+    invoke("sync_account", {
+      accountId,
+      limit: full ? 250 : 50,
+      full,
+      onProgress: channel,
+    });
+  `;
+  assert.deepEqual(extractFrontendInvokeRequests(source), [
+    { command: "no_arguments", keys: [] },
+    { command: "hydrate_message", keys: ["messageId"] },
+    {
+      command: "sync_account",
+      keys: ["accountId", "full", "limit", "onProgress"],
+    },
+  ]);
+});
+
+test("rejects opaque, spread, and computed frontend invoke request keys", () => {
+  assert.throws(
+    () => extractFrontendInvokeRequests('invoke("command", request)'),
+    /must be a static object literal/,
+  );
+  assert.throws(
+    () => extractFrontendInvokeRequests('invoke("command", { ...request })'),
+    /must not use spread properties/,
+  );
+  assert.throws(
+    () => extractFrontendInvokeRequests('invoke("command", { [key]: value })'),
+    /must use static top-level keys/,
+  );
+});
+
+test("maps Rust command parameters to frontend keys and excludes injected parameters", () => {
+  const source = `
+    #[tauri::command]
+    async fn hydrate_message(
+      app: tauri::AppHandle,
+      state: State<'_, Arc<AppState>>,
+      message_id: String,
+    ) -> Result<(), String> { Ok(()) }
+
+    #[tauri::command]
+    async fn sync_account(
+      account_id: Uuid,
+      on_progress: Channel<SyncProgress>,
+      window: tauri::Window,
+    ) -> Result<(), String> { Ok(()) }
+  `;
+  assert.deepEqual(extractRustCommandParameters(source), {
+    hydrate_message: ["messageId"],
+    sync_account: ["accountId", "onProgress"],
+  });
+});
+
+test("parses Rust handler macros and native event constants", () => {
+  const source = `
+    const RECEIPT: &str = "dakia://receipt";
+    // app.emit("commented", value);
+    builder.invoke_handler(tauri::generate_handler![
+      first_command,
+      second_command,
+    ]);
+    app.emit(RECEIPT, value)?;
+    app.emit("mail-arrived", value)?;
+  `;
+  assert.deepEqual(extractGenerateHandlerCommands(source), [
+    "first_command",
+    "second_command",
+  ]);
+  assert.deepEqual(extractRustNativeEmits(source), [
+    "dakia://receipt",
+    "mail-arrived",
+  ]);
+});
+
+test("does not confuse Rust lifetimes with quoted event literals", () => {
+  const source = `
+    async fn command(state: State<'_, AppState>) {}
+    app.emit("lifetime-safe", payload)?;
+  `;
+  assert.deepEqual(extractRustNativeEmits(source), ["lifetime-safe"]);
+});
+
+test("parses frontend event listener and cross-window emitter argument positions", () => {
+  const source = `
+    listen<Event>("native-event", handler);
+    getCurrentWebview().listen("webview-event", handler);
+    emitTo("main", "frontend-event", payload);
+  `;
+  assert.deepEqual(extractFrontendListeners(source), [
+    "native-event",
+    "webview-event",
+  ]);
+  assert.deepEqual(extractFrontendEmitters(source), ["frontend-event"]);
+});
+
+test("reports command, origin, and event drift with demo-only exclusions explicit", () => {
+  const inventory = {
+    frontendInvokes: ["registered", "demo_command"],
+    frontendInvokeRequests: [
+      { command: "registered", keys: [] },
+      { command: "demo_command", keys: [] },
+    ],
+    rustHandlers: ["registered", "orphaned"],
+    rustCommandParameters: { registered: [], orphaned: [] },
+    frontendListeners: ["native-event", "frontend-event", "unclassified"],
+    frontendEmitters: ["frontend-event", "wrong-event"],
+    rustNativeEmits: ["native-event", "orphaned-event"],
+  };
+  const contract = {
+    schemaVersion: 1,
+    demoOnlyInvokes: ["demo_command"],
+    eventOrigins: {
+      "native-event": "native",
+      "frontend-event": "frontend",
+    },
+  };
+  const errors = validateInventory(inventory, contract);
+  assert.match(
+    errors.join("\n"),
+    /frontend invokes vs Rust handlers missing: orphaned/,
+  );
+  assert.match(
+    errors.join("\n"),
+    /frontend event classifications unexpected: unclassified/,
+  );
+  assert.match(
+    errors.join("\n"),
+    /native emitted events vs native listeners unexpected: orphaned-event/,
+  );
+  assert.match(
+    errors.join("\n"),
+    /frontend emitted events vs frontend listeners unexpected: wrong-event/,
+  );
+  assert.throws(
+    () => assertValidInventory(inventory, contract),
+    /Tauri contract drift/,
+  );
+});
+
+test("reports Rust handler parameter renames that command-name inventory misses", () => {
+  const rustCommandParameters = extractRustCommandParameters(`
+    #[tauri::command]
+    async fn hydrate_message(message: String) -> Result<(), String> { Ok(()) }
+
+    #[tauri::command]
+    async fn sync_account(account_id: Uuid, progress: Channel<SyncProgress>) -> Result<(), String> { Ok(()) }
+  `);
+  const inventory = {
+    frontendInvokes: ["hydrate_message", "sync_account"],
+    frontendInvokeRequests: [
+      { command: "hydrate_message", keys: ["messageId"] },
+      {
+        command: "sync_account",
+        keys: ["accountId", "onProgress"],
+      },
+    ],
+    rustHandlers: ["hydrate_message", "sync_account"],
+    rustCommandParameters,
+    frontendListeners: [],
+    frontendEmitters: [],
+    rustNativeEmits: [],
+  };
+  const contract = {
+    schemaVersion: 1,
+    demoOnlyInvokes: [],
+    eventOrigins: {},
+  };
+  const errors = validateInventory(inventory, contract).join("\n");
+  assert.match(
+    errors,
+    /frontend invoke request keys for hydrate_message missing: message/,
+  );
+  assert.match(
+    errors,
+    /frontend invoke request keys for hydrate_message unexpected: messageId/,
+  );
+  assert.match(
+    errors,
+    /frontend invoke request keys for sync_account missing: progress/,
+  );
+  assert.match(
+    errors,
+    /frontend invoke request keys for sync_account unexpected: onProgress/,
+  );
+});
+
+test("the checked-in production Tauri inventory is synchronized", async () => {
+  const [inventory, contract] = await Promise.all([
+    inventoryRepository(),
+    readContract(),
+  ]);
+  assert.deepEqual(validateInventory(inventory, contract), []);
+});

--- a/scripts/validate-realistic-fixtures.mjs
+++ b/scripts/validate-realistic-fixtures.mjs
@@ -1,0 +1,666 @@
+#!/usr/bin/env node
+
+import { createHash } from "node:crypto";
+import { existsSync, lstatSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, extname, join, relative, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const repositoryRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const manifestPath = "testdata/realistic-fixtures.manifest.json";
+const fixtureRoots = [
+  { path: "crates/dakia-core/testdata/mime", extension: ".eml" },
+  { path: "crates/dakia-core/tests/fixtures", extension: ".eml" },
+  { path: "apps/desktop/src/test/fixtures", extension: ".html" },
+];
+const expectedSemantics = [
+  "body",
+  "html",
+  "snippet",
+  "attachments",
+  "error",
+  "resourceLimit",
+];
+const applicablePaths = new Set([
+  "complete-rfc822",
+  "catalogue",
+  "header",
+  "partial-preview",
+  "storage-round-trip",
+  "selective-bodystructure",
+  "inline-image-resolution",
+  "reader-render",
+  "html-document",
+  "reader-disclosure",
+  "tauri-message-content",
+  "typescript-decoding",
+]);
+const exerciseDomainPaths = new Map([
+  ["rust.mail.parse-paths", ["complete-rfc822", "catalogue", "header"]],
+  [
+    "rust.mail.selective-bodystructure",
+    ["selective-bodystructure", "storage-round-trip"],
+  ],
+  ["rust.mail.inline-images", ["complete-rfc822", "inline-image-resolution"]],
+  ["rust.mail.partial-preview", ["partial-preview"]],
+  ["rust.tauri.message-content", ["tauri-message-content"]],
+  ["typescript.tauri-decoding", ["typescript-decoding"]],
+  ["frontend.html-message", ["html-document", "reader-disclosure"]],
+  ["frontend.reader", ["reader-render", "reader-disclosure"]],
+]);
+const prohibitedDomains = [
+  "gmail.com",
+  "googlemail.com",
+  "outlook.com",
+  "hotmail.com",
+  "live.com",
+  "yahoo.com",
+  "icloud.com",
+  "me.com",
+  "mac.com",
+  "linkedin.com",
+  "swedbank.ee",
+  "freshdesk.com",
+];
+const credentialPatterns = [
+  /-----BEGIN(?: [A-Z]+)? PRIVATE KEY-----/i,
+  /\b(?:api[-_ ]?key|access[-_ ]?token|client[-_ ]?secret|password)\b\s*[:=]\s*[^\s<]{8,}/i,
+  /\bauthorization\s*:\s*bearer\s+[A-Za-z0-9._~-]{12,}/i,
+  /\bAKIA[0-9A-Z]{16}\b/,
+];
+
+function addError(errors, message) {
+  errors.push(message);
+}
+
+function isPlainObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isSafeRelativePath(value) {
+  return (
+    typeof value === "string" &&
+    value.length > 0 &&
+    !value.startsWith("/") &&
+    !value.includes("\\") &&
+    value
+      .split("/")
+      .every((part) => part !== "" && part !== "." && part !== "..")
+  );
+}
+
+function domainIsWithin(domain, parent) {
+  return domain === parent || domain.endsWith(`.${parent}`);
+}
+
+function isValidDomain(value) {
+  return (
+    typeof value === "string" &&
+    /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?(?:\.[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?)+$/i.test(
+      value,
+    )
+  );
+}
+
+function listedFixtureFiles(root) {
+  const files = [];
+  for (const fixtureRoot of fixtureRoots) {
+    const directory = resolve(root, fixtureRoot.path);
+    if (!existsSync(directory)) {
+      continue;
+    }
+    const visit = (current) => {
+      for (const entry of readdirSync(current, { withFileTypes: true })) {
+        const path = join(current, entry.name);
+        if (entry.isDirectory()) {
+          visit(path);
+        } else if (
+          entry.isFile() &&
+          extname(entry.name) === fixtureRoot.extension
+        ) {
+          files.push(relative(root, path).replaceAll("\\", "/"));
+        }
+      }
+    };
+    visit(directory);
+  }
+  return files.sort();
+}
+
+function fixtureRootForPath(path) {
+  return fixtureRoots.find(
+    (fixtureRoot) =>
+      path.startsWith(`${fixtureRoot.path}/`) &&
+      extname(path) === fixtureRoot.extension,
+  );
+}
+
+function extractFixtureDomains(contents) {
+  const domains = new Set();
+  for (const match of contents.matchAll(
+    /[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\.[A-Za-z]{2,})/g,
+  )) {
+    domains.add(match[1].toLowerCase());
+  }
+  // Scan every absolute endpoint, including RFC headers such as
+  // List-Unsubscribe and plain-text links, not only HTML attributes.
+  for (const match of contents.matchAll(
+    /(?:https?:)?\/\/([A-Za-z0-9.-]+\.[A-Za-z]{2,})(?::\d+)?/gi,
+  )) {
+    domains.add(match[1].replace(/:\d+$/, "").toLowerCase());
+  }
+  return domains;
+}
+
+function decodedInspectionSurfaces(contents) {
+  const surfaces = [contents];
+  const transferEncoding =
+    /^content-transfer-encoding:\s*(base64|quoted-printable)[^\r\n]*$/gim;
+  for (const match of contents.matchAll(transferEncoding)) {
+    const bodyStartMatch = /\r?\n\r?\n/g;
+    bodyStartMatch.lastIndex = match.index + match[0].length;
+    const separator = bodyStartMatch.exec(contents);
+    if (!separator) continue;
+    const bodyStart = separator.index + separator[0].length;
+    const nextBoundary = contents.slice(bodyStart).search(/\r?\n--[^\r\n]+/);
+    const body = contents.slice(
+      bodyStart,
+      nextBoundary < 0 ? contents.length : bodyStart + nextBoundary,
+    );
+    if (Buffer.byteLength(body) > 2 * 1024 * 1024) continue;
+    if (match[1].toLowerCase() === "base64") {
+      const compact = body.replace(/\s/g, "");
+      if (compact.length >= 8 && /^[A-Za-z0-9+/]*={0,2}$/.test(compact)) {
+        surfaces.push(Buffer.from(compact, "base64").toString("utf8"));
+      }
+    } else {
+      surfaces.push(
+        body
+          .replace(/=\r?\n/g, "")
+          .replace(/=([A-Fa-f0-9]{2})/g, (_, hex) =>
+            String.fromCharCode(Number.parseInt(hex, 16)),
+          ),
+      );
+    }
+  }
+  return surfaces;
+}
+
+function declaredTestBody(source, exerciseId) {
+  const escaped = exerciseId.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const declarations = [
+    new RegExp(
+      `#\\[(?:tokio::)?test\\]\\s*(?:async\\s+)?fn\\s+${escaped}\\s*\\(`,
+    ),
+    new RegExp(`(?:it|test)\\s*\\(\\s*["'\`]${escaped}["'\`]`),
+  ];
+  const start = declarations
+    .map((pattern) => source.search(pattern))
+    .find((index) => index >= 0);
+  if (start === undefined) return null;
+  const remainder = source.slice(start + 1);
+  const nextOffsets = [
+    remainder.search(/\n\s*#\[(?:tokio::)?test\]/),
+    remainder.search(/\n\s*(?:it|test)\s*\(/),
+  ].filter((index) => index >= 0);
+  const end = nextOffsets.length
+    ? start + 1 + Math.min(...nextOffsets)
+    : source.length;
+  return source.slice(start, end);
+}
+
+function withoutComments(source) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// A receipt cannot be an unused binding or `void fixture`: either form can
+// satisfy a name-based audit while never reaching the code under test.
+function identifierHasNonTrivialUse(source, identifier) {
+  const escaped = escapeRegExp(identifier);
+  const withoutNoops = source
+    .replace(new RegExp(`\\bvoid\\s+${escaped}\\s*;?`, "g"), "")
+    .replace(
+      new RegExp(
+        `\\b(?:const|let|var)\\s+[A-Za-z_$][A-Za-z0-9_$]*\\s*=\\s*${escaped}\\s*;`,
+        "g",
+      ),
+      "",
+    );
+  return new RegExp(`\\b${escaped}\\b`).test(withoutNoops);
+}
+
+function bindingBefore(source, index) {
+  const start = Math.max(
+    source.lastIndexOf(";", index),
+    source.lastIndexOf("{", index),
+    source.lastIndexOf("}", index),
+  );
+  return source
+    .slice(start + 1, index)
+    .match(
+      /(?:^|\n)\s*(?:let(?:\s+mut)?|const|var)\s+([A-Za-z_$][A-Za-z0-9_$]*)\b[^=]*=\s*[\s\S]*$/,
+    )?.[1];
+}
+
+function loaderResultIsConsumed(body, match) {
+  const before = body.slice(0, match.index);
+  const after = body.slice(match.index + match[0].length);
+  if (/\bvoid\s*$/.test(before) || /^\s*;/.test(after)) return false;
+  const binding = bindingBefore(body, match.index);
+  if (!binding) return true;
+  const escaped = escapeRegExp(binding);
+  const meaningfulAfter = after.replace(
+    new RegExp(`\\bvoid\\s+${escaped}\\s*;?`, "g"),
+    "",
+  );
+  return new RegExp(`\\b${escaped}\\b`).test(meaningfulAfter);
+}
+
+function directLoaderExercisesFixture(body, fixtureName) {
+  const escapedName = escapeRegExp(fixtureName);
+  const loader = new RegExp(
+    `(?:mime_corpus\\s*|include_(?:str|bytes)!\\s*)\\([^)]*["'\\x60][^"'\\x60]*${escapedName}(?:\\.(?:eml|html))?["'\\x60]`,
+    "g",
+  );
+  return [...body.matchAll(loader)].some((match) =>
+    loaderResultIsConsumed(body, match),
+  );
+}
+
+function enumeratedLoaderExercisesFixture(body, fixtureName) {
+  const casesContainFixture = body.includes(`"${fixtureName}"`);
+  if (!casesContainFixture) return false;
+  const loader = /mime_corpus\s*\(\s*name\s*\)/g;
+  return [...body.matchAll(loader)].some((match) => {
+    const before = body.slice(0, match.index);
+    if (/\bvoid\s*$/.test(before)) return false;
+    const binding = before.match(
+      /\b(?:let|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*$/,
+    )?.[1];
+    return (
+      binding === undefined ||
+      identifierHasNonTrivialUse(
+        body.slice(match.index + match[0].length),
+        binding,
+      )
+    );
+  });
+}
+
+function importedFixtureIdentifier(source, fixtureName) {
+  const escapedName = escapeRegExp(fixtureName);
+  const match = source.match(
+    new RegExp(
+      `\\bimport\\s+([A-Za-z_$][A-Za-z0-9_$]*)\\s+from\\s+["'\\x60][^"'\\x60]*${escapedName}\\.(?:eml|html)(?:\\?[^"'\\x60]*)?["'\\x60]`,
+    ),
+  );
+  return match?.[1] ?? null;
+}
+
+function hasSharedContractReceipt(source, body, fixtureName) {
+  const contractImport = source.match(
+    /\bimport\s+([A-Za-z_$][A-Za-z0-9_$]*)\s+from\s+["'`][^"'`]*testdata\/tauri-contracts\/high-risk\.json["'`]/,
+  )?.[1];
+  const contractBinding = body.match(
+    /\blet\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*fixture\s*\(\s*\)/,
+  )?.[1];
+  return (
+    ((contractImport !== undefined &&
+      identifierHasNonTrivialUse(body, contractImport)) ||
+      (source.includes("tauri-contracts/high-risk.json") &&
+        contractBinding !== undefined &&
+        identifierHasNonTrivialUse(
+          body.slice(body.indexOf(contractBinding) + contractBinding.length),
+          contractBinding,
+        ))) &&
+    body.includes("realisticFixtureIds") &&
+    body.includes("providerSignature") &&
+    new RegExp(`["'\\x60]${escapeRegExp(fixtureName)}["'\\x60]`).test(body)
+  );
+}
+
+function testBodyExercisesFixture(source, testBody, fixtureName) {
+  const body = withoutComments(testBody);
+  const importedIdentifier = importedFixtureIdentifier(source, fixtureName);
+  // Kept local while the legacy recognition expressions below are removed in
+  // the next change; their results are deliberately no longer accepted.
+  const fixtureIdentifier = fixtureName;
+  const escapedName = fixtureName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedIdentifier = fixtureIdentifier.replace(
+    /[.*+?^${}()|[\]\\]/g,
+    "\\$&",
+  );
+  const directLoader = new RegExp(
+    `(?:mime_corpus|include_(?:str|bytes)!)\\s*\\([^)]*["'\`][^"'\`]*${escapedName}(?:\\.(?:eml|html))?["'\`]`,
+  );
+  const enumeratedLoader = new RegExp(
+    `["'\`]${escapedName}["'\`][\\s\\S]*mime_corpus\\s*\\(\\s*name\\s*\\)`,
+  );
+  const importedFixture = new RegExp(`\\b${escapedIdentifier}\\b`);
+  const sharedContractReceipt =
+    body.includes("realisticFixtureIds") &&
+    body.includes("providerSignature") &&
+    new RegExp(`["'\`]${escapedName}["'\`]`).test(body);
+  return (
+    directLoaderExercisesFixture(body, fixtureName) ||
+    enumeratedLoaderExercisesFixture(body, fixtureName) ||
+    (importedIdentifier !== null &&
+      identifierHasNonTrivialUse(body, importedIdentifier)) ||
+    hasSharedContractReceipt(source, body, fixtureName)
+  );
+}
+
+function assertString(errors, value, label) {
+  if (typeof value !== "string" || value.trim() === "") {
+    addError(errors, `${label} must be a non-empty string.`);
+    return false;
+  }
+  return true;
+}
+
+function validateExercise(errors, root, fixture, exercise) {
+  const label = `Fixture ${fixture.id} exercise`;
+  if (!isPlainObject(exercise)) {
+    addError(errors, `${label} must be an object.`);
+    return;
+  }
+  if (!assertString(errors, exercise.domain, `${label}.domain`)) return;
+  const coveredPaths = exerciseDomainPaths.get(exercise.domain);
+  if (!coveredPaths) {
+    addError(errors, `${label}.domain is not a governed publication path.`);
+    return;
+  }
+  if (!assertString(errors, exercise.source, `${label}.source`)) return;
+  if (!assertString(errors, exercise.id, `${label}.id`)) return;
+  if (!isSafeRelativePath(exercise.source)) {
+    addError(
+      errors,
+      `${label}.source must be a safe repository-relative path.`,
+    );
+    return;
+  }
+  const sourcePath = resolve(root, exercise.source);
+  if (!sourcePath.startsWith(`${root}/`) || !existsSync(sourcePath)) {
+    addError(errors, `${label} source is missing: ${exercise.source}`);
+    return;
+  }
+  const source = readFileSync(sourcePath, "utf8");
+  const fixtureName = fixture.path
+    .slice(0, -extname(fixture.path).length)
+    .split("/")
+    .at(-1);
+  const testBody = declaredTestBody(source, exercise.id);
+  if (
+    !testBody ||
+    !testBodyExercisesFixture(source, testBody, fixtureName)
+  ) {
+    addError(
+      errors,
+      `Fixture ${fixture.id} is not exercised by declared ${exercise.domain}/${exercise.id}.`,
+    );
+    return;
+  }
+  return coveredPaths;
+}
+
+export function validateFixtureCorpus(root = repositoryRoot) {
+  const errors = [];
+  const absoluteRoot = resolve(root);
+  const absoluteManifest = resolve(absoluteRoot, manifestPath);
+  let manifest;
+  try {
+    manifest = JSON.parse(readFileSync(absoluteManifest, "utf8"));
+  } catch (error) {
+    throw new Error(
+      `Could not read realistic fixture manifest: ${error.message}`,
+    );
+  }
+  if (!isPlainObject(manifest)) {
+    throw new Error("Realistic fixture manifest must be a JSON object.");
+  }
+  if (manifest.schemaVersion !== 1) {
+    addError(errors, "Realistic fixture manifest schemaVersion must be 1.");
+  }
+  if (JSON.stringify(manifest.fixtureRoots) !== JSON.stringify(fixtureRoots)) {
+    addError(
+      errors,
+      "Realistic fixture manifest fixtureRoots must match the governed corpus roots.",
+    );
+  }
+  if (!Array.isArray(manifest.fixtures)) {
+    addError(errors, "Realistic fixture manifest fixtures must be an array.");
+  } else {
+    const ids = new Set();
+    const paths = new Set();
+    for (const fixture of manifest.fixtures) {
+      if (!isPlainObject(fixture)) {
+        addError(errors, "Fixture entries must be objects.");
+        continue;
+      }
+      if (!assertString(errors, fixture.id, "Fixture id")) continue;
+      if (ids.has(fixture.id))
+        addError(errors, `Duplicate fixture id: ${fixture.id}`);
+      ids.add(fixture.id);
+      if (!assertString(errors, fixture.path, `Fixture ${fixture.id} path`))
+        continue;
+      if (paths.has(fixture.path))
+        addError(errors, `Duplicate fixture path: ${fixture.path}`);
+      paths.add(fixture.path);
+      if (
+        !isSafeRelativePath(fixture.path) ||
+        !fixtureRootForPath(fixture.path)
+      ) {
+        addError(
+          errors,
+          `Fixture ${fixture.id} path is outside the governed corpus roots: ${fixture.path}`,
+        );
+        continue;
+      }
+      const absoluteFixture = resolve(absoluteRoot, fixture.path);
+      if (
+        !absoluteFixture.startsWith(`${absoluteRoot}/`) ||
+        !existsSync(absoluteFixture) ||
+        !lstatSync(absoluteFixture).isFile()
+      ) {
+        addError(
+          errors,
+          `Fixture ${fixture.id} file is missing: ${fixture.path}`,
+        );
+        continue;
+      }
+      if (
+        typeof fixture.sha256 !== "string" ||
+        !/^[a-f0-9]{64}$/.test(fixture.sha256)
+      ) {
+        addError(
+          errors,
+          `Fixture ${fixture.id} sha256 must be lowercase SHA-256 hex.`,
+        );
+      } else {
+        const actual = createHash("sha256")
+          .update(readFileSync(absoluteFixture))
+          .digest("hex");
+        if (actual !== fixture.sha256)
+          addError(
+            errors,
+            `Fixture ${fixture.id} checksum drift: expected ${fixture.sha256}, got ${actual}.`,
+          );
+      }
+      if (
+        !isPlainObject(fixture.provenance) ||
+        !["synthetic", "faithfully-redacted"].includes(
+          fixture.provenance.kind,
+        ) ||
+        !assertString(
+          errors,
+          fixture.provenance.detail,
+          `Fixture ${fixture.id} provenance.detail`,
+        )
+      ) {
+        addError(
+          errors,
+          `Fixture ${fixture.id} requires synthetic or faithfully-redacted provenance.`,
+        );
+      }
+      assertString(errors, fixture.issue, `Fixture ${fixture.id} issue`);
+      if (
+        !isPlainObject(fixture.provider) ||
+        !assertString(
+          errors,
+          fixture.provider.shape,
+          `Fixture ${fixture.id} provider.shape`,
+        ) ||
+        fixture.provider.liveProviderCompatible !== false
+      ) {
+        addError(
+          errors,
+          `Fixture ${fixture.id} provider must explicitly set liveProviderCompatible to false.`,
+        );
+      }
+      if (!isPlainObject(fixture.expected)) {
+        addError(errors, `Fixture ${fixture.id} requires expected semantics.`);
+      } else {
+        for (const field of expectedSemantics)
+          assertString(
+            errors,
+            fixture.expected[field],
+            `Fixture ${fixture.id} expected.${field}`,
+          );
+      }
+      if (
+        !Array.isArray(fixture.applicablePaths) ||
+        fixture.applicablePaths.length === 0 ||
+        fixture.applicablePaths.some((path) => !applicablePaths.has(path))
+      ) {
+        addError(errors, `Fixture ${fixture.id} has invalid applicablePaths.`);
+      }
+      const redaction = fixture.redaction;
+      if (
+        !isPlainObject(redaction) ||
+        !assertString(
+          errors,
+          redaction.reviewer,
+          `Fixture ${fixture.id} redaction.reviewer`,
+        ) ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(redaction.reviewedOn ?? "") ||
+        !Array.isArray(redaction.permittedDomains) ||
+        redaction.permittedDomains.length === 0
+      ) {
+        addError(
+          errors,
+          `Fixture ${fixture.id} requires reviewer, ISO review date, and permitted domains.`,
+        );
+      } else {
+        for (const domain of redaction.permittedDomains) {
+          if (
+            !isValidDomain(domain) ||
+            prohibitedDomains.some((prohibited) =>
+              domainIsWithin(domain, prohibited),
+            )
+          ) {
+            addError(
+              errors,
+              `Fixture ${fixture.id} has prohibited permitted domain: ${domain}`,
+            );
+          }
+        }
+      }
+      if (
+        !Array.isArray(fixture.exercisedBy) ||
+        fixture.exercisedBy.length === 0
+      ) {
+        addError(
+          errors,
+          `Fixture ${fixture.id} must declare at least one exercising test.`,
+        );
+      } else {
+        const exercisedPaths = new Set();
+        for (const exercise of fixture.exercisedBy) {
+          for (const path of validateExercise(
+            errors,
+            absoluteRoot,
+            fixture,
+            exercise,
+          ) ?? []) {
+            exercisedPaths.add(path);
+          }
+        }
+        for (const path of fixture.applicablePaths ?? []) {
+          if (!exercisedPaths.has(path)) {
+            addError(
+              errors,
+              `Fixture ${fixture.id} applicable path is not exercised: ${path}.`,
+            );
+          }
+        }
+      }
+      const contents = readFileSync(absoluteFixture, "utf8");
+      const inspectionSurfaces = decodedInspectionSurfaces(contents);
+      const permittedDomains = redaction?.permittedDomains ?? [];
+      for (const surface of inspectionSurfaces) {
+        for (const domain of extractFixtureDomains(surface)) {
+          if (
+            prohibitedDomains.some((prohibited) =>
+              domainIsWithin(domain, prohibited),
+            )
+          ) {
+            addError(
+              errors,
+              `Fixture ${fixture.id} contains prohibited live domain: ${domain}`,
+            );
+          } else if (
+            !permittedDomains.some(
+              (permitted) =>
+                isValidDomain(permitted) && domainIsWithin(domain, permitted),
+            )
+          ) {
+            addError(
+              errors,
+              `Fixture ${fixture.id} contains undeclared address or endpoint domain: ${domain}`,
+            );
+          }
+        }
+        for (const pattern of credentialPatterns) {
+          if (pattern.test(surface))
+            addError(
+              errors,
+              `Fixture ${fixture.id} contains credential-like material matching ${pattern}.`,
+            );
+        }
+      }
+    }
+    const manifested = [...paths].sort();
+    const actual = listedFixtureFiles(absoluteRoot);
+    for (const path of actual)
+      if (!paths.has(path))
+        addError(errors, `Unmanifested fixture file: ${path}`);
+    for (const path of manifested)
+      if (!actual.includes(path))
+        addError(errors, `Manifested fixture file is not enumerated: ${path}`);
+  }
+  if (errors.length > 0)
+    throw new Error(
+      `Realistic fixture manifest validation failed:\n- ${errors.join("\n- ")}`,
+    );
+  return {
+    fixtureCount: manifest.fixtures.length,
+    files: listedFixtureFiles(absoluteRoot),
+  };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    const result = validateFixtureCorpus();
+    process.stdout.write(
+      `Validated ${result.fixtureCount} realistic fixtures.\n`,
+    );
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/validate-realistic-fixtures.node-test.mjs
+++ b/scripts/validate-realistic-fixtures.node-test.mjs
@@ -1,0 +1,208 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, join } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+import { validateFixtureCorpus } from "./validate-realistic-fixtures.mjs";
+
+const repositoryRoot = join(dirname(fileURLToPath(import.meta.url)), "..");
+const copiedDirectories = [
+  "crates/dakia-core/testdata/mime",
+  "crates/dakia-core/tests/fixtures",
+  "apps/desktop/src/test/fixtures",
+];
+const copiedSources = [
+  "crates/dakia-core/src/mail.rs",
+  "apps/desktop/src-tauri/src/tauri_contracts_tests.rs",
+  "apps/desktop/src/components/HtmlMessage.test.tsx",
+  "apps/desktop/src/components/Reader.test.tsx",
+  "apps/desktop/src/tauriContracts.test.ts",
+];
+
+function copyCorpus() {
+  const root = mkdtempSync("/tmp/dakia-realistic-fixtures-");
+  for (const directory of copiedDirectories)
+    cpSync(join(repositoryRoot, directory), join(root, directory), {
+      recursive: true,
+    });
+  for (const source of copiedSources)
+    cpSync(join(repositoryRoot, source), join(root, source));
+  cpSync(
+    join(repositoryRoot, "testdata/realistic-fixtures.manifest.json"),
+    join(root, "testdata/realistic-fixtures.manifest.json"),
+  );
+  return root;
+}
+
+function withCorpus(run) {
+  const root = copyCorpus();
+  try {
+    return run(root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+function manifestAt(root) {
+  const path = join(root, "testdata/realistic-fixtures.manifest.json");
+  return [path, JSON.parse(readFileSync(path, "utf8"))];
+}
+
+test("validates the checked-in realistic mail fixture corpus", () => {
+  const result = validateFixtureCorpus(repositoryRoot);
+  assert.equal(result.fixtureCount, 17);
+  assert.equal(result.files.filter((path) => path.endsWith(".eml")).length, 13);
+  assert.equal(result.files.filter((path) => path.endsWith(".html")).length, 4);
+});
+
+test("rejects checksum drift and unmanifested fixtures", () =>
+  withCorpus((root) => {
+    const drifted = join(
+      root,
+      "crates/dakia-core/testdata/mime/charset-matrix.eml",
+    );
+    writeFileSync(drifted, `${readFileSync(drifted, "utf8")}\nDrift.`);
+    assert.throws(() => validateFixtureCorpus(root), /checksum drift/);
+
+    const extra = join(
+      root,
+      "crates/dakia-core/testdata/mime/unmanifested.eml",
+    );
+    writeFileSync(extra, "From: fixture@example.test\n\nfixture\n");
+    assert.throws(
+      () => validateFixtureCorpus(root),
+      /Unmanifested fixture file/,
+    );
+  }));
+
+test("rejects live domains, credential-like values, and non-exercising tests", () =>
+  withCorpus((root) => {
+    const [manifestPath, manifest] = manifestAt(root);
+    const fixture = manifest.fixtures.find(
+      (entry) => entry.id === "mime.charset-matrix",
+    );
+    const fixturePath = join(root, fixture.path);
+    const changed = `${readFileSync(fixturePath, "utf8")}\nAuthorization: Bearer abcdefghijklmnop\nFrom: person@gmail.com\n`;
+    writeFileSync(fixturePath, changed);
+    fixture.sha256 = createHash("sha256").update(changed).digest("hex");
+    fixture.exercisedBy[0].id = "missing fixture test";
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    assert.throws(
+      () => validateFixtureCorpus(root),
+      (error) => {
+        const message = String(error);
+        return (
+          /prohibited live domain: gmail\.com/.test(message) &&
+          /credential-like/.test(message) &&
+          /not exercised/.test(message)
+        );
+      },
+    );
+  }));
+
+test("scans header URLs and bounded decoded MIME bodies and requires a real test declaration", () =>
+  withCorpus((root) => {
+    const [manifestPath, manifest] = manifestAt(root);
+    const fixture = manifest.fixtures.find(
+      (entry) => entry.id === "mime.charset-matrix",
+    );
+    const fixturePath = join(root, fixture.path);
+    const secret = Buffer.from("password=production-secret", "utf8").toString(
+      "base64",
+    );
+    const changed = `${readFileSync(fixturePath, "utf8")}\nList-Unsubscribe: <https://gmail.com/private-user-token>\nContent-Transfer-Encoding: base64\n\n${secret}\n`;
+    writeFileSync(fixturePath, changed);
+    fixture.sha256 = createHash("sha256").update(changed).digest("hex");
+    fixture.exercisedBy[0].id = "parse_message";
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    assert.throws(
+      () => validateFixtureCorpus(root),
+      (error) => {
+        const message = String(error);
+        return (
+          /prohibited live domain: gmail\.com/.test(message) &&
+          /credential-like/.test(message) &&
+          /not exercised/.test(message)
+        );
+      },
+    );
+  }));
+
+test("rejects an applicable publication path without a path-specific exercise", () =>
+  withCorpus((root) => {
+    const [manifestPath, manifest] = manifestAt(root);
+    const fixture = manifest.fixtures.find(
+      (entry) => entry.id === "mime.truncated-multipart-lf",
+    );
+    fixture.exercisedBy = fixture.exercisedBy.filter(
+      (exercise) => exercise.domain !== "rust.mail.partial-preview",
+    );
+    writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+
+    assert.throws(
+      () => validateFixtureCorpus(root),
+      /applicable path is not exercised: partial-preview/,
+    );
+  }));
+
+test("does not accept a fixture basename that appears only in a test comment", () =>
+  withCorpus((root) => {
+    const sourcePath = join(root, "crates/dakia-core/src/mail.rs");
+    const source = readFileSync(sourcePath, "utf8").replace(
+      '("charset-matrix", true),',
+      '("charset-matrix-removed", true), // charset-matrix',
+    );
+    writeFileSync(sourcePath, source);
+
+    assert.throws(
+      () => validateFixtureCorpus(root),
+      /Fixture mime\.charset-matrix is not exercised/,
+    );
+  }));
+
+test("rejects a corpus case whose loader result is discarded or left unused", () =>
+  withCorpus((root) => {
+    const sourcePath = join(root, "crates/dakia-core/src/mail.rs");
+    const source = readFileSync(sourcePath, "utf8")
+      .replace(
+        "let raw = mime_corpus(name);",
+        "void mime_corpus(name); // this exercise is intentionally discarded",
+      )
+      .replace(
+        'let raw = include_str!("../tests/fixtures/provider-signature-inline.eml");',
+        'let unused = include_str!("../tests/fixtures/provider-signature-inline.eml");',
+      );
+    writeFileSync(sourcePath, source);
+
+    assert.throws(
+      () => validateFixtureCorpus(root),
+      /Fixture mime\.charset-matrix is not exercised[\s\S]*Fixture mime\.provider-signature-inline is not exercised/,
+    );
+  }));
+
+test("rejects a raw fixture import referenced only through void", () =>
+  withCorpus((root) => {
+    const sourcePath = join(
+      root,
+      "apps/desktop/src/components/HtmlMessage.test.tsx",
+    );
+    const source = readFileSync(sourcePath, "utf8").replace(
+      "html={freshdeskReplySection}",
+      "html={\"<p>replacement</p>\"}\n        {void freshdeskReplySection}",
+    );
+    writeFileSync(sourcePath, source);
+
+    assert.throws(
+      () => validateFixtureCorpus(root),
+      /Fixture html\.freshdesk-reply-section is not exercised/,
+    );
+  }));

--- a/scripts/verify-macos-release-app.sh
+++ b/scripts/verify-macos-release-app.sh
@@ -12,6 +12,15 @@ if [ -z "$app" ]; then
   echo "Usage: $0 [--static-only] /path/to/Dakia.app" >&2
   exit 2
 fi
+if [ ! -d "$app" ] || [ -L "$app" ]; then
+  echo "Missing or unsafe packaged Dakia app bundle: $app" >&2
+  exit 1
+fi
+# Tauri rejects a macOS executable path with any symlinked ancestor. Common
+# temporary roots such as /var and /tmp are symlinks to /private/...; launch
+# the verifier smoke through the physical bundle path so resource resolution
+# exercises the extracted app instead of falling back to Contents/MacOS.
+app=$(CDPATH= cd -- "$app" && pwd -P)
 
 executable="$app/Contents/MacOS/dakia-desktop"
 cli="$app/Contents/MacOS/dakia"

--- a/scripts/verify-macos-release-app.sh
+++ b/scripts/verify-macos-release-app.sh
@@ -106,6 +106,17 @@ if [ "$cli_archs" != "arm64" ]; then
   echo "Packaged Dakia CLI is not exactly Apple Silicon arm64: $cli_archs" >&2
   exit 1
 fi
+if ! otool -l "$cli" | awk '
+  $1 == "cmd" && $2 == "LC_RPATH" { in_rpath = 1; next }
+  in_rpath && $1 == "path" {
+    if ($2 == "@executable_path/../Frameworks") found = 1
+    in_rpath = 0
+  }
+  END { exit(found ? 0 : 1) }
+'; then
+  echo "Packaged Dakia CLI cannot resolve the bundled ONNX Runtime framework." >&2
+  exit 1
+fi
 codesign --verify --strict --verbose=2 "$cli"
 app_team=$(
   codesign -dv --verbose=4 "$app" 2>&1 |

--- a/scripts/verify-macos-release-app.sh
+++ b/scripts/verify-macos-release-app.sh
@@ -14,6 +14,7 @@ if [ -z "$app" ]; then
 fi
 
 executable="$app/Contents/MacOS/dakia-desktop"
+cli="$app/Contents/MacOS/dakia"
 runtime="$app/Contents/Frameworks/libonnxruntime.1.23.2.dylib"
 notice_policy=${DAKIA_RELEASE_NOTICE_POLICY:-current}
 
@@ -45,10 +46,12 @@ for packaged_resource in \
     exit 1
   fi
 done
-if [ ! -x "$executable" ]; then
-  echo "Missing packaged Dakia executable: $executable" >&2
-  exit 1
-fi
+for packaged_executable in "$executable" "$cli"; do
+  if [ ! -f "$packaged_executable" ] || [ -L "$packaged_executable" ] || [ ! -x "$packaged_executable" ]; then
+    echo "Missing or unsafe packaged Dakia executable: $packaged_executable" >&2
+    exit 1
+  fi
+done
 
 if [ "$notice_policy" = "current" ]; then
   for packaged_resource in \
@@ -98,10 +101,112 @@ if [ "$static_only" = true ]; then
   exit 0
 fi
 
+cli_archs=$(lipo -archs "$cli")
+if [ "$cli_archs" != "arm64" ]; then
+  echo "Packaged Dakia CLI is not exactly Apple Silicon arm64: $cli_archs" >&2
+  exit 1
+fi
+codesign --verify --strict --verbose=2 "$cli"
+app_team=$(
+  codesign -dv --verbose=4 "$app" 2>&1 |
+    sed -n 's/^TeamIdentifier=//p'
+)
+cli_team=$(
+  codesign -dv --verbose=4 "$cli" 2>&1 |
+    sed -n 's/^TeamIdentifier=//p'
+)
+if [ -z "$app_team" ] || [ "$cli_team" != "$app_team" ]; then
+  echo "Packaged Dakia CLI TeamIdentifier does not match the outer app." >&2
+  exit 1
+fi
+
+umask 077
 smoke_root=$(mktemp -d "${TMPDIR:-/tmp}/dakia-release-smoke.XXXXXX")
 output="$smoke_root/output.log"
 trap 'rm -rf "$smoke_root"' EXIT HUP INT TERM
 mkdir -p "$smoke_root/data"
+
+version=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist")
+cli_contract_data="$smoke_root/cli-parse-contract"
+cli_version_stdout="$smoke_root/cli-version.stdout"
+cli_version_stderr="$smoke_root/cli-version.stderr"
+if ! "$cli" --data-dir "$cli_contract_data" --version \
+  >"$cli_version_stdout" 2>"$cli_version_stderr"; then
+  echo "Packaged Dakia CLI version contract failed." >&2
+  cat "$cli_version_stderr" >&2
+  exit 1
+fi
+if [ -s "$cli_version_stderr" ]; then
+  echo "Packaged Dakia CLI version contract wrote unexpected stderr output." >&2
+  cat "$cli_version_stderr" >&2
+  exit 1
+fi
+cli_version=$(cat "$cli_version_stdout")
+if [ "$cli_version" != "dakia $version" ]; then
+  echo "Packaged Dakia CLI version does not match the app: $cli_version (expected dakia $version)" >&2
+  exit 1
+fi
+
+cli_help_stdout="$smoke_root/cli-help.stdout"
+cli_help_stderr="$smoke_root/cli-help.stderr"
+if ! "$cli" --data-dir "$cli_contract_data" --help \
+  >"$cli_help_stdout" 2>"$cli_help_stderr"; then
+  echo "Packaged Dakia CLI help contract failed." >&2
+  cat "$cli_help_stderr" >&2
+  exit 1
+fi
+if [ -s "$cli_help_stderr" ] || \
+  ! grep -Fq "Search, read, and send mail from the terminal" "$cli_help_stdout" || \
+  ! grep -Fq "Usage: dakia [OPTIONS] <COMMAND>" "$cli_help_stdout"; then
+  echo "Packaged Dakia CLI help contract returned an unexpected schema." >&2
+  cat "$cli_help_stderr" >&2
+  cat "$cli_help_stdout" >&2
+  exit 1
+fi
+
+cli_invalid_stdout="$smoke_root/cli-invalid.stdout"
+cli_invalid_stderr="$smoke_root/cli-invalid.stderr"
+if "$cli" --data-dir "$cli_contract_data" not-a-command \
+  >"$cli_invalid_stdout" 2>"$cli_invalid_stderr"; then
+  cli_invalid_status=0
+else
+  cli_invalid_status=$?
+fi
+if [ "$cli_invalid_status" -ne 2 ] || [ -s "$cli_invalid_stdout" ] || \
+  ! grep -Fq "error: unrecognized subcommand 'not-a-command'" "$cli_invalid_stderr" || \
+  ! grep -Fq "For more information, try '--help'." "$cli_invalid_stderr"; then
+  echo "Packaged Dakia CLI invalid-input contract was not rejected as expected." >&2
+  cat "$cli_invalid_stderr" >&2
+  cat "$cli_invalid_stdout" >&2
+  exit 1
+fi
+if [ -e "$cli_contract_data" ]; then
+  echo "Packaged Dakia CLI parse-only commands unexpectedly created profile state." >&2
+  exit 1
+fi
+
+cli_stdout="$smoke_root/cli-stdout.json"
+cli_stderr="$smoke_root/cli-stderr.log"
+if ! "$cli" --data-dir "$smoke_root/cli-data" --json account list \
+  >"$cli_stdout" 2>"$cli_stderr"; then
+  echo "Packaged Dakia CLI isolated account-list smoke failed." >&2
+  cat "$cli_stderr" >&2
+  exit 1
+fi
+if [ -s "$cli_stderr" ]; then
+  echo "Packaged Dakia CLI wrote unexpected stderr output." >&2
+  cat "$cli_stderr" >&2
+  exit 1
+fi
+if ! node -e '
+  const fs = require("node:fs");
+  const value = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+  if (!Array.isArray(value) || value.length !== 0) process.exit(1);
+' "$cli_stdout"; then
+  echo "Packaged Dakia CLI isolated account-list smoke returned an unexpected schema." >&2
+  cat "$cli_stdout" >&2
+  exit 1
+fi
 
 DAKIA_RELEASE_SMOKE_TEST=1 \
 DAKIA_RELEASE_SMOKE_DATA_DIR="$smoke_root/data" \

--- a/testdata/realistic-fixtures.manifest.json
+++ b/testdata/realistic-fixtures.manifest.json
@@ -1,0 +1,692 @@
+{
+  "schemaVersion": 1,
+  "fixtureRoots": [
+    { "path": "crates/dakia-core/testdata/mime", "extension": ".eml" },
+    { "path": "crates/dakia-core/tests/fixtures", "extension": ".eml" },
+    { "path": "apps/desktop/src/test/fixtures", "extension": ".html" }
+  ],
+  "fixtures": [
+    {
+      "id": "mime.alternative-mixed-asic-footer",
+      "path": "crates/dakia-core/testdata/mime/alternative-mixed-asic-footer.eml",
+      "sha256": "401b67ace5dc503443b661edd0eff361a6ca2afec684045e76d387dace18bfaf",
+      "provenance": {
+        "kind": "faithfully-redacted",
+        "detail": "Apple Mail-shaped multipart message with fictional names, addresses, and hosts."
+      },
+      "issue": "MIME corpus: retain selected HTML from an alternative/mixed Apple Mail message and its ASiC attachment.",
+      "provider": {
+        "shape": "Apple Mail multipart/alternative containing multipart/mixed",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep the plain fallback alongside the selected body.",
+        "html": "Select the inner HTML delivery and retain its footer markup.",
+        "snippet": "Derive a normal message snippet without treating the attachment as body content.",
+        "attachments": "Expose redacted-delivery.asice as one downloadable ASiC attachment.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["redacted.example"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        }
+      ]
+    },
+    {
+      "id": "mime.attached-message-rfc822",
+      "path": "crates/dakia-core/testdata/mime/attached-message-rfc822.eml",
+      "sha256": "a6d8cf9ff97a4612f3cacfb420c1efe00c9441721779d2fe5c09f6613c216304",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic nested message/rfc822 attachment."
+      },
+      "issue": "MIME corpus: keep an attached RFC822 message out of the outer message body.",
+      "provider": {
+        "shape": "multipart/mixed with message/rfc822 attachment",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Retain only the outer synthetic body.",
+        "html": "Do not promote the attached message HTML to outer HTML.",
+        "snippet": "Use outer-message content for preview semantics.",
+        "attachments": "Expose forwarded-message.eml as one message/rfc822 attachment with its nested bytes.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": [
+        "complete-rfc822",
+        "catalogue",
+        "header",
+        "storage-round-trip",
+        "selective-bodystructure"
+      ],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        },
+        {
+          "domain": "rust.mail.selective-bodystructure",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "realistic_selective_bodystructure_fixtures_match_complete_parser_and_starred_storage"
+        }
+      ]
+    },
+    {
+      "id": "mime.charset-matrix",
+      "path": "crates/dakia-core/testdata/mime/charset-matrix.eml",
+      "sha256": "3a254be99ee64bd5263d2feb90c96907a5f647ccc1b215a68dc50aaa6ae29414",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic alternatives covering supported and unsupported charsets."
+      },
+      "issue": "MIME corpus: decode supported text charsets without inventing unsupported text.",
+      "provider": {
+        "shape": "multipart/alternative charset matrix",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Decode supported alternatives, including the selected ISO-8859-2 text.",
+        "html": "No HTML body is expected.",
+        "snippet": "Use normal decoded-text preview semantics.",
+        "attachments": "No attachments are expected.",
+        "error": "Unsupported charset leaves that cannot be decoded stay errors rather than invented text.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        }
+      ]
+    },
+    {
+      "id": "mime.competing-nested-alternatives",
+      "path": "crates/dakia-core/testdata/mime/competing-nested-alternatives.eml",
+      "sha256": "9ff77dfb2ed340808df5d023a7154b7f58b8e2d6c2220c1208337c03dfce8596",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic nested alternatives with a CID image and named text attachment."
+      },
+      "issue": "MIME corpus: select nested alternative bodies without leaking attachment text.",
+      "provider": {
+        "shape": "multipart/mixed with alternative and related branches",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep Visible plain body and exclude redacted-notes attachment text.",
+        "html": "Select Visible HTML body with its CID reference.",
+        "snippet": "Use selected message-body content only.",
+        "attachments": "Expose redacted-notes.txt separately; retain the referenced inline image as inline content.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        }
+      ]
+    },
+    {
+      "id": "mime.disposition-type-name-matrix",
+      "path": "crates/dakia-core/testdata/mime/disposition-type-name-matrix.eml",
+      "sha256": "7543224472beabf8db55b40c183fcc33da21bf81e5eb8c7ab0a1a79b65087926",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic disposition, media-type, name, and Content-ID matrix."
+      },
+      "issue": "MIME corpus: distinguish unnamed inline text bodies from named and explicit attachments.",
+      "provider": {
+        "shape": "multipart/mixed disposition and filename matrix",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Use unnamed inline plain text as body content.",
+        "html": "Use unnamed inline HTML as body content.",
+        "snippet": "Use selected body content for preview semantics.",
+        "attachments": "Keep named inline text, unnamed PDF, inline image, and explicit unnamed attachment as attachments.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        }
+      ]
+    },
+    {
+      "id": "mime.filename-parameters-and-encodings",
+      "path": "crates/dakia-core/testdata/mime/filename-parameters-and-encodings.eml",
+      "sha256": "e0e71d12dbeec09ec8c833d7b98f363366963edf5d00641b893249fba97b7a0e",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic RFC 2231, RFC 2047, malformed, and hostile filename parameters."
+      },
+      "issue": "MIME corpus: normalize attachment filenames without path or bidi-control leakage.",
+      "provider": {
+        "shape": "multipart/mixed attachment filename matrix",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep the synthetic message body.",
+        "html": "No HTML body is expected.",
+        "snippet": "Use normal decoded-text preview semantics.",
+        "attachments": "Decode valid continued and encoded filenames, sanitize path separators and bidi controls, and preserve safe fallbacks.",
+        "error": "Malformed filename parameters must not cause a message parse failure.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        }
+      ]
+    },
+    {
+      "id": "mime.format-flowed-delsp",
+      "path": "crates/dakia-core/testdata/mime/format-flowed-delsp.eml",
+      "sha256": "4a82e24f2495f9fdf226c12136e02ed73aec6b90d7bb4312bed60874d95701a8",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic format=flowed text with delsp=yes and an HTML alternative."
+      },
+      "issue": "MIME corpus: honor format=flowed delsp semantics in message text.",
+      "provider": {
+        "shape": "multipart/alternative with flowed text",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Join flowed lines without adding the deleted soft space, including quoted lines.",
+        "html": "Retain the HTML alternative.",
+        "snippet": "Use selected decoded text for preview semantics.",
+        "attachments": "No attachments are expected.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": [
+        "complete-rfc822",
+        "catalogue",
+        "header",
+        "selective-bodystructure"
+      ],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        },
+        {
+          "domain": "rust.mail.selective-bodystructure",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "realistic_selective_bodystructure_fixtures_match_complete_parser_and_starred_storage"
+        }
+      ]
+    },
+    {
+      "id": "mime.invalid-transfer-encodings",
+      "path": "crates/dakia-core/testdata/mime/invalid-transfer-encodings.eml",
+      "sha256": "75d91f062a84cc04963c039f207e0b66850fb52a36b719ab65b7392a978853ec",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic invalid base64, quoted-printable, and transfer-encoding labels."
+      },
+      "issue": "MIME corpus: report undecodable transfer encodings deterministically.",
+      "provider": {
+        "shape": "multipart/mixed with invalid transfer encodings",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Do not invent a complete decoded body.",
+        "html": "No HTML body is expected.",
+        "snippet": "Catalogue preview remains caller-provided and header parsing remains available.",
+        "attachments": "No attachments are expected.",
+        "error": "Complete parsing must return the stable MIME content undecodable error.",
+        "resourceLimit": "No resource-limit error is expected; this is an encoding failure."
+      },
+      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        }
+      ]
+    },
+    {
+      "id": "mime.line-endings-cr-only",
+      "path": "crates/dakia-core/testdata/mime/line-endings-cr-only.eml",
+      "sha256": "cae08220ad6beeeaf3bf4de7f9284f6ec9b8fb9789da6016f6669510d96f3c0e",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic CR-only RFC822 input."
+      },
+      "issue": "MIME corpus: normalize CR-only line endings without changing parse semantics.",
+      "provider": {
+        "shape": "multipart/alternative with CR-only lines",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Decode the CR-only plain text body.",
+        "html": "Decode the CR-only HTML alternative.",
+        "snippet": "Use normal decoded-text preview semantics.",
+        "attachments": "No attachments are expected.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        }
+      ]
+    },
+    {
+      "id": "mime.linkedin-inline-content-id",
+      "path": "crates/dakia-core/testdata/mime/linkedin-inline-content-id.eml",
+      "sha256": "d302e38e64c864df1a91fc72d60c54945ff81cf93a8158f88d167bdc927c4437",
+      "provenance": {
+        "kind": "faithfully-redacted",
+        "detail": "Provider-shaped LinkedIn notification with fictional addresses and content."
+      },
+      "issue": "MIME corpus: Content-ID-bearing unnamed text alternatives remain message bodies.",
+      "provider": {
+        "shape": "LinkedIn-shaped multipart/alternative with text Content-ID headers",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Decode the folded redacted plain text as body content.",
+        "html": "Decode the folded redacted HTML as body content.",
+        "snippet": "Derive the snippet from the selected plain text.",
+        "attachments": "Do not create attachments for text-body and html-body Content-ID headers.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": [
+        "complete-rfc822",
+        "catalogue",
+        "header",
+        "selective-bodystructure"
+      ],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        },
+        {
+          "domain": "rust.mail.selective-bodystructure",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "realistic_selective_bodystructure_fixtures_match_complete_parser_and_starred_storage"
+        }
+      ]
+    },
+    {
+      "id": "mime.multipart-attachment-container",
+      "path": "crates/dakia-core/testdata/mime/multipart-attachment-container.eml",
+      "sha256": "01246fb8935fabc95c63339eb328e5762ceff9df7b1d3ff50f93986bec6d5b53",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic multipart attachment containing child text and a PDF."
+      },
+      "issue": "MIME corpus: keep children of a multipart attachment out of parent content.",
+      "provider": {
+        "shape": "multipart/mixed with attached multipart/mixed branch",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep Visible parent body and exclude Secret child text.",
+        "html": "No HTML body is expected.",
+        "snippet": "Use parent body preview semantics.",
+        "attachments": "Expose bundle.mime as one multipart/mixed attachment containing its child bytes.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": [
+        "complete-rfc822",
+        "catalogue",
+        "header",
+        "selective-bodystructure"
+      ],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        },
+        {
+          "domain": "rust.mail.selective-bodystructure",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "realistic_selective_bodystructure_fixtures_match_complete_parser_and_starred_storage"
+        }
+      ]
+    },
+    {
+      "id": "mime.truncated-multipart-lf",
+      "path": "crates/dakia-core/testdata/mime/truncated-multipart-lf.eml",
+      "sha256": "e9644bc93393af94322680b3751032350daf5bcdbb5d479ee574ebb0c9006094",
+      "provenance": {
+        "kind": "synthetic",
+        "detail": "Synthetic LF-only multipart input with deliberately missing closing bytes."
+      },
+      "issue": "MIME corpus: use a safe partial preview from a truncated multipart message.",
+      "provider": {
+        "shape": "truncated multipart/alternative with LF-only lines",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Accept the first complete text leaf without leaking transport syntax.",
+        "html": "The incomplete HTML leaf is not a complete HTML-body guarantee.",
+        "snippet": "Use the first decodable text leaf for a safe partial preview.",
+        "attachments": "No attachments are expected.",
+        "error": "No complete-parse error is expected for the current tolerant parser behavior.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": [
+        "complete-rfc822",
+        "catalogue",
+        "header",
+        "partial-preview"
+      ],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.parse-paths",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        },
+        {
+          "domain": "rust.mail.partial-preview",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "parses_the_checked_in_mime_regression_corpus"
+        }
+      ]
+    },
+    {
+      "id": "mime.provider-signature-inline",
+      "path": "crates/dakia-core/tests/fixtures/provider-signature-inline.eml",
+      "sha256": "2bf3c6cf6c1aefcf5103697405a6592df8760786e45e7b0d2ff3c9692055e4ce",
+      "provenance": {
+        "kind": "faithfully-redacted",
+        "detail": "Fictional provider-signature shape; no raw production RFC822 source or production identities remain."
+      },
+      "issue": "MIME corpus: resolve a referenced signature logo inline while preserving a PDF attachment.",
+      "provider": {
+        "shape": "provider-shaped multipart/mixed -> multipart/related HTML, CID image, and PDF",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Use the redacted HTML message body.",
+        "html": "Resolve the referenced CID logo to embedded content while retaining remote URLs when present.",
+        "snippet": "Use normal parsed-body preview semantics.",
+        "attachments": "Keep claim-documents.pdf downloadable and do not count the referenced signature logo as a user-facing attachment.",
+        "error": "No complete-parse error is expected.",
+        "resourceLimit": "No resource-limit error is expected for this bounded fixture."
+      },
+      "applicablePaths": [
+        "complete-rfc822",
+        "inline-image-resolution",
+        "selective-bodystructure",
+        "reader-render",
+        "tauri-message-content",
+        "typescript-decoding"
+      ],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "rust.mail.inline-images",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "redacted_provider_signature_logo_stays_embedded_while_pdf_is_downloadable"
+        },
+        {
+          "domain": "rust.mail.selective-bodystructure",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "realistic_selective_bodystructure_fixtures_match_complete_parser_and_starred_storage"
+        },
+        {
+          "domain": "rust.tauri.message-content",
+          "source": "apps/desktop/src-tauri/src/tauri_contracts_tests.rs",
+          "id": "provider_signature_inline_message_content_matches_the_shared_fixture"
+        },
+        {
+          "domain": "typescript.tauri-decoding",
+          "source": "apps/desktop/src/tauriContracts.test.ts",
+          "id": "decodes provider-signature-inline through the native MessageContent boundary"
+        },
+        {
+          "domain": "frontend.reader",
+          "source": "apps/desktop/src/components/Reader.test.tsx",
+          "id": "renders provider-signature-inline shared message content"
+        }
+      ]
+    },
+    {
+      "id": "html.apple-mail-reply-section",
+      "path": "apps/desktop/src/test/fixtures/apple-mail-reply-section.html",
+      "sha256": "215ceecc55f0c2bbefe182e3c9bbbafa20d051eeb193d43927cb98bc100e045d",
+      "provenance": {
+        "kind": "faithfully-redacted",
+        "detail": "Apple Mail-shaped reply section with fictional recipient data."
+      },
+      "issue": "HTML corpus: move Apple Mail quoted reply sections behind a native history disclosure.",
+      "provider": {
+        "shape": "Apple Mail messageReplySection and messageBodySection markup",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep the current reply visible.",
+        "html": "Sanitize current and quoted content into separate documents.",
+        "snippet": "Not applicable to standalone HTML rendering fixtures.",
+        "attachments": "Not applicable to standalone HTML rendering fixtures.",
+        "error": "No rendering error is expected.",
+        "resourceLimit": "No MIME resource-limit semantics apply to standalone HTML."
+      },
+      "applicablePaths": ["html-document", "reader-disclosure"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "frontend.html-message",
+          "source": "apps/desktop/src/components/HtmlMessage.test.tsx",
+          "id": "repeatedly toggles Apple Mail and Outlook history through the native control"
+        }
+      ]
+    },
+    {
+      "id": "html.freshdesk-reply-section",
+      "path": "apps/desktop/src/test/fixtures/freshdesk-reply-section.html",
+      "sha256": "6582749e9527dfe4856f00affd6d8b40a23b270913e2bf8bcd343e14cad4b497",
+      "provenance": {
+        "kind": "faithfully-redacted",
+        "detail": "Freshdesk-shaped nested quote chain with fictional customer and support addresses."
+      },
+      "issue": "HTML corpus: retain current Freshdesk content while isolating nested provider history.",
+      "provider": {
+        "shape": "Freshdesk quote and Gmail quote-container markup",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep the current support reply visible and quoted requests hidden initially.",
+        "html": "Sanitize current and nested quoted content into separate documents.",
+        "snippet": "Not applicable to standalone HTML rendering fixtures.",
+        "attachments": "Not applicable to standalone HTML rendering fixtures.",
+        "error": "No rendering error is expected.",
+        "resourceLimit": "No MIME resource-limit semantics apply to standalone HTML."
+      },
+      "applicablePaths": ["html-document", "reader-disclosure"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "frontend.html-message",
+          "source": "apps/desktop/src/components/HtmlMessage.test.tsx",
+          "id": "uses one native accessible disclosure and preserves isolated history through repeated toggles"
+        },
+        {
+          "domain": "frontend.reader",
+          "source": "apps/desktop/src/components/Reader.test.tsx",
+          "id": "collapses Freshdesk history in the latest message of a thread"
+        }
+      ]
+    },
+    {
+      "id": "html.outlook-word-reply-section",
+      "path": "apps/desktop/src/test/fixtures/outlook-word-reply-section.html",
+      "sha256": "e054a8896185cad31a9914e137863ca324a78ea5837ba41221da903322c2edd5",
+      "provenance": {
+        "kind": "faithfully-redacted",
+        "detail": "Outlook Word-generated reply markup using reserved example.com addresses."
+      },
+      "issue": "HTML corpus: identify Outlook Word reply history without moving authored current content.",
+      "provider": {
+        "shape": "Outlook Word HTML with MsoNormal and stacked reply headers",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep the current Estonian reply and authored footer visible.",
+        "html": "Move the quoted reply chain into a separately sanitized history document.",
+        "snippet": "Not applicable to standalone HTML rendering fixtures.",
+        "attachments": "Not applicable to standalone HTML rendering fixtures.",
+        "error": "No rendering error is expected.",
+        "resourceLimit": "No MIME resource-limit semantics apply to standalone HTML."
+      },
+      "applicablePaths": ["html-document", "reader-disclosure"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": [
+          "example.com",
+          "schemas.microsoft.com",
+          "www.w3.org"
+        ]
+      },
+      "exercisedBy": [
+        {
+          "domain": "frontend.html-message",
+          "source": "apps/desktop/src/components/HtmlMessage.test.tsx",
+          "id": "repeatedly toggles Apple Mail and Outlook history through the native control"
+        }
+      ]
+    },
+    {
+      "id": "html.swedbank-signature-layout",
+      "path": "apps/desktop/src/test/fixtures/swedbank-signature-layout.html",
+      "sha256": "f07b63e4e460e260ca819f4fd6e0913a5183c2fc57b564719ff990de85c9d2ad",
+      "provenance": {
+        "kind": "faithfully-redacted",
+        "detail": "Swedbank-shaped presentation table with fictional message copy and a reserved test asset host."
+      },
+      "issue": "HTML corpus: preserve branded signature structure while removing structurally empty spacer rows.",
+      "provider": {
+        "shape": "branded presentation-table signature layout",
+        "liveProviderCompatible": false
+      },
+      "expected": {
+        "body": "Keep the visible branded copy and signature text.",
+        "html": "Preserve authored brand colors and the logo while removing empty spacer rows.",
+        "snippet": "Not applicable to standalone HTML rendering fixtures.",
+        "attachments": "Not applicable to standalone HTML rendering fixtures.",
+        "error": "No rendering error is expected.",
+        "resourceLimit": "No MIME resource-limit semantics apply to standalone HTML."
+      },
+      "applicablePaths": ["html-document"],
+      "redaction": {
+        "reviewer": "Dakia maintainers",
+        "reviewedOn": "2026-07-30",
+        "permittedDomains": ["example.test"]
+      },
+      "exercisedBy": [
+        {
+          "domain": "frontend.html-message",
+          "source": "apps/desktop/src/components/HtmlMessage.test.tsx",
+          "id": "collapses the fixture's empty spacer rows without changing signature structure"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add scoped pull-request and manual validation workflows
- add realistic fixture governance, protocol/storage/CLI/Tauri contract coverage, and fixed-seed properties
- add coverage-candidate and read-neutral provider-smoke infrastructure
- harden duplicate-copy mutations, SMTP delivery uncertainty, and packaged release verification

## Verification
- `npm run verify:local`
- 260 core tests plus 5 boundary properties
- 77 Tauri tests, 17 CLI tests, 240 frontend tests, and 59 release/contract tests
- hosted final-candidate validation green on three runs: 11m36s cold, 5m03s warm, 4m05s warm
- warm median: 4m34s, below the 10-minute target
- `Validate applicable scopes` is now an Actions-owned strict required check on `main`

## Apple-Silicon release acceptance
- built v0.3.1 from clean commit `7517bcb`
- signed app, CLI sidecar, ONNX Runtime framework, DMG, and updater archive
- Apple notarization accepted the app and DMG; stapling and Gatekeeper assessment passed
- packaged CLI contracts and native startup passed from the app bundle, mounted DMG, and extracted updater archive
- release publication remains gated on merge, coverage-baseline approval, and provider evidence
- automated Intel Mac testing is intentionally waived by the owner and is not reported as a pass

## Remaining activation
- merge requires the repository's one-review rule or an explicitly authorized admin bypass
- after merge, run three hosted coverage candidates and commit the reviewed stable baseline
- configure `DAKIA_PROVIDER_SMOKE_CONFIG` in the protected `provider-smoke` environment using a dedicated test account, then record the credentialed read-neutral result
