### PR TITLE
Stabilize Reader coverage regression

### DIFF
--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -960,15 +960,23 @@ describe("Reader unsubscribe action", () => {
     const latestMessage = await screen.findByRole("document", {
       name: "Latest Freshdesk reply",
     });
-    const currentSurface = latestMessage.shadowRoot
-      ?.firstElementChild as HTMLElement | null;
-    const currentDocument = currentSurface?.shadowRoot;
     const historyHost = latestMessage.querySelector<HTMLElement>(
       '[data-dakia-email-surface="history"]',
     );
-    const historySurface = historyHost?.shadowRoot
-      ?.firstElementChild as HTMLElement | null;
-    const historyDocument = historySurface?.shadowRoot;
+    const currentDocument = await waitFor(() => {
+      const currentSurface = latestMessage.shadowRoot
+        ?.firstElementChild as HTMLElement | null;
+      const document = currentSurface?.shadowRoot;
+      expect(document).toBeInstanceOf(ShadowRoot);
+      return document as ShadowRoot;
+    });
+    const historyDocument = await waitFor(() => {
+      const historySurface = historyHost?.shadowRoot
+        ?.firstElementChild as HTMLElement | null;
+      const document = historySurface?.shadowRoot;
+      expect(document).toBeInstanceOf(ShadowRoot);
+      return document as ShadowRoot;
+    });
     const historyButton = screen.getByRole("button", { name: "Show history" });
 
     expect(


### PR DESCRIPTION
## Summary

- wait for the production current-message shadow surface before asserting Freshdesk content
- wait for the production history shadow surface before exercising repeated expand/collapse transitions
- require actual `ShadowRoot` instances so `undefined` cannot false-pass the wait

## Evidence

Hosted coverage run 30602231365 exposed the race at `Reader.test.tsx:978`: the accessible outer document existed before its effect-installed shadow tree. The exact full frontend coverage command now passes all 240 tests, and the focused Freshdesk case passed ten consecutive coverage executions. Typecheck and diff checks pass.

This is a test synchronization fix; production behavior is unchanged.