### PR TITLE
Prioritize realtime cancellation coordination

### DIFF
--- a/apps/desktop/src-tauri/src/realtime.rs
+++ b/apps/desktop/src-tauri/src/realtime.rs
@@ -1016,6 +1016,10 @@ where
             break;
         }
         tokio::select! {
+            // Cancellation and a worker observing that cancellation can become
+            // ready together. Prefer the coordinator signal so the next loop
+            // cannot refill a newly vacant slot before recording the stop.
+            biased;
             changed = cancel.changed(), if !cancelled => {
                 cancelled = changed.is_err() || *cancel.borrow();
             }


### PR DESCRIPTION
## Summary

- use Tokio biased selection to record cancellation before a simultaneously completing worker
- preserve the existing bounded runner behavior while strengthening the no-post-cancellation-refill guarantee

## Evidence

Two successful same-SHA coverage runs produced identical denominators and frontend results but differed by one Rust covered line. LCOV comparison isolated the only hit/miss transition to the cancellation coordinator assignment in `realtime.rs`; workers and the coordinator observe the same watch update and could win randomized select order differently.

Validation passed:

- `cargo fmt --all -- --check`
- five cancellation-focused native tests
- `cargo clippy -p dakia-desktop --lib --tests -- -D warnings`

The final three-run coverage measurement will restart after this merges.