### PR TITLE
Stabilize coverage baseline paths

### DIFF
--- a/apps/desktop/src-tauri/src/realtime.rs
+++ b/apps/desktop/src-tauri/src/realtime.rs
@@ -1125,8 +1125,8 @@ mod tests {
 
     fn tracked_watcher(running: Arc<AtomicUsize>) -> WatcherTask {
         let (cancel, mut receiver) = watch::channel(false);
+        running.fetch_add(1, Ordering::SeqCst);
         let handle = tauri::async_runtime::spawn(async move {
-            running.fetch_add(1, Ordering::SeqCst);
             wait_for_cancellation(&mut receiver).await;
             running.fetch_sub(1, Ordering::SeqCst);
         });
@@ -1661,13 +1661,7 @@ mod tests {
         first.await.unwrap();
         second.await.unwrap();
 
-        tokio::time::timeout(Duration::from_secs(1), async {
-            while running.load(Ordering::SeqCst) != 1 {
-                tokio::task::yield_now().await;
-            }
-        })
-        .await
-        .expect("exactly one replacement watcher should remain live");
+        assert_eq!(running.load(Ordering::SeqCst), 1);
         assert_eq!(tasks.lock().await.len(), 1);
 
         stop_watcher_task(tasks.lock().await.remove(&account_id)).await;

--- a/crates/dakia-core/src/classification.rs
+++ b/crates/dakia-core/src/classification.rs
@@ -362,6 +362,16 @@ mod tests {
     }
 
     #[test]
+    fn classifier_category_mapping_covers_every_model_output() {
+        assert_eq!(map_category(0), "notifications");
+        assert_eq!(map_category(1), "newsletters");
+        assert_eq!(map_category(2), "people");
+        assert_eq!(map_category(3), "newsletters");
+        assert_eq!(map_category(4), "notifications");
+        assert_eq!(map_category(5), "transactions");
+    }
+
+    #[test]
     fn email_text_preserves_the_sender_display_name() {
         let text = email_text(
             Some("Example App Store"),
@@ -500,6 +510,10 @@ mod tests {
 
         assert_eq!(
             apply_high_precision_signals("newsletters", &decision),
+            "notifications"
+        );
+        assert_eq!(
+            apply_high_precision_signals("people", "Automatically generated message header",),
             "notifications"
         );
     }


### PR DESCRIPTION
## What changed

- register test watcher liveness synchronously before the watcher task starts
- remove scheduler-dependent polling from the concurrent watcher regression
- cover every classifier model-output mapping deterministically
- cover the generic auto-generated notification override without depending on ONNX output

## Why

Hosted coverage runs on the same source SHA differed by a few hit lines because these tests depended on task scheduling and model predictions. That made a byte-identical coverage baseline impossible to approve.

## Impact

Production behavior is unchanged. The regression tests and coverage measurement now exercise the intended paths deterministically.

## Validation

- `cargo test -p dakia-core classification::tests -- --test-threads=1` (17 passed)
- exact watcher regression repeated 20 times (20/20 passed)
- `cargo clippy -p dakia-core -p dakia-desktop --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`