### PR TITLE
Stabilize concurrent coverage paths

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -984,6 +984,12 @@ describe("App read state", () => {
       () => new Promise(() => undefined),
     );
     let peopleSearches = 0;
+    let resolveRefreshedPeople:
+      | ((page: {
+          conversations: ReturnType<typeof groupMessages>;
+          nextCursor: null;
+        }) => void)
+      | undefined;
     const nextMessage = {
       ...mocks.message,
       id: "message-2",
@@ -1002,6 +1008,11 @@ describe("App read state", () => {
       }
       if (args[7] !== "people") return { conversations: [], nextCursor: null };
       peopleSearches += 1;
+      if (peopleSearches === 2) {
+        return new Promise((resolve) => {
+          resolveRefreshedPeople = resolve;
+        });
+      }
       return {
         conversations:
           peopleSearches === 1 ? groupMessages([mocks.message]) : [],
@@ -1021,6 +1032,14 @@ describe("App read state", () => {
     await waitFor(() =>
       expect(mocks.api.setRead).toHaveBeenCalledWith("message-1", true),
     );
+    await waitFor(() => expect(resolveRefreshedPeople).toBeTypeOf("function"));
+    await act(async () =>
+      resolveRefreshedPeople!({ conversations: [], nextCursor: null }),
+    );
+    expect(
+      screen.getByRole("heading", { name: "Unread thread" }),
+    ).toBeVisible();
+    expect(screen.getByRole("button", { name: "Quick reply" })).toBeEnabled();
     expect(
       within(document.querySelector(".mail-list-panel")!).getByText(
         "Unread thread",

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -3706,6 +3706,23 @@ mod tests {
     use super::*;
 
     #[test]
+    fn sqlite_contention_helpers_classify_synthetic_error_chains() {
+        assert!(is_sqlite_busy_message("database is locked"));
+        assert!(is_sqlite_busy_message("database is busy"));
+        assert!(!is_sqlite_busy_message("disk I/O error"));
+
+        let locked = anyhow!("database is locked").context("opening the store");
+        assert!(is_sqlite_busy(&locked));
+        assert!(!is_sqlite_busy(&anyhow!("disk I/O error")));
+
+        let migration_race = anyhow!("duplicate column name: indexed_at").context("migrating");
+        assert!(is_sqlite_migration_race(&migration_race));
+        assert!(!is_sqlite_migration_race(&anyhow!(
+            "no such column: indexed_at"
+        )));
+    }
+
+    #[test]
     fn parses_only_complete_canonical_message_id_lists() {
         assert_eq!(
             parse_message_ids(" <Root@Example.Test>\t<Reply@example.test> "),


### PR DESCRIPTION
## What changed

- make the Smart Inbox snapshot fallback an explicit user-visible regression state
- cover SQLite busy and migration-race predicates with deterministic synthetic error chains

## Why

Two green coverage runs on the same source SHA differed because React scheduling sometimes skipped the active-reader snapshot render, while SQLite contention could surface at either connection or migration time. Both are valid runtime paths, but their test coverage must not depend on scheduler timing.

## Impact

Production code is unchanged. Coverage measurement now deterministically exercises the Smart Inbox reader fallback and storage contention classification semantics.

## Validation

- App suite: 35/35 passed
- focused Smart Inbox V8 coverage: fallback line and both branches covered 10/10 runs
- storage contention helper regression passed with exact module-qualified filter
- TypeScript typecheck passed
- Rust clippy passed with warnings denied
- Rustfmt, Prettier, and diff checks passed