### PR TITLE
Approve coverage ratchet baseline

### DIFF
--- a/docs/testing-strategy.md
+++ b/docs/testing-strategy.md
@@ -1,9 +1,10 @@
 # Testing and Fixture Strategy
 
-Status: activated deterministic source lanes implemented; connector/event-path
-gaps, external activation, and measured evidence pending
+Status: deterministic source lanes and required scoped pull-request validation
+activated; three-run coverage baseline approved; credentialed provider and
+release evidence pending
 
-Baseline reviewed: `origin/main` at `0a3182e` on 2026-07-30
+Baseline reviewed: `origin/main` at `fdb4d29` on 2026-07-31
 
 This document defines how Dakia prevents repeats of production issues without
 returning to slow, expensive GitHub Actions. The activated source-controlled
@@ -11,12 +12,12 @@ harnesses, workflows, fixture governance, and gates in the delivery state are
 implemented; the explicitly named integration gaps remain work rather than
 completed coverage.
 
-The following acceptance evidence deliberately remains external to this source
-change:
+Hosted pull-request validation is required on `main`. The reviewed coverage
+baseline was reproduced byte-for-byte by three sequential green manual runs
+(`30608458117`, `30608993770`, and `30609479746`) on `fdb4d29`.
 
-- making the pull-request validation status required and measuring three
-  representative hosted runs;
-- reviewing and committing a coverage baseline after three repeat green runs;
+The following acceptance evidence deliberately remains external:
+
 - enabling credentials for a live-provider smoke test;
 - Apple-Silicon WebKit acceptance when a change affects native layout or
   interaction; and

--- a/testdata/coverage/baseline.json
+++ b/testdata/coverage/baseline.json
@@ -1,0 +1,33 @@
+{
+  "version": 1,
+  "components": {
+    "rust": {
+      "lines": {
+        "found": 22295,
+        "hit": 17813
+      },
+      "branches": {
+        "found": 0,
+        "hit": 0
+      },
+      "functions": {
+        "found": 4677,
+        "hit": 2006
+      }
+    },
+    "frontend": {
+      "lines": {
+        "found": 2696,
+        "hit": 1964
+      },
+      "branches": {
+        "found": 2078,
+        "hit": 1352
+      },
+      "functions": {
+        "found": 969,
+        "hit": 581
+      }
+    }
+  }
+}


### PR DESCRIPTION
## What changed

- commit the reviewed Rust/frontend coverage baseline
- update the testing strategy with the required hosted-CI and three-run evidence

## Evidence

Three strictly sequential green coverage runs on exact source SHA `fdb4d29cebf89b3a38f00d7db7e783940ec81ab1` produced byte-identical candidate SHA-256 `8cc99d5b08a73af76be5e66307349250e3c06ab48eb880d8aa11e1a7e58aab1f`:

- `30608458117`
- `30608993770`
- `30609479746`

Each candidate recorded Rust 17,813/22,295 lines and 2,006/4,677 functions; frontend 1,964/2,696 lines, 1,352/2,078 branches, and 581/969 functions.

## Validation

- baseline is byte-identical to all three hosted candidates
- `coverage-ratchet.mjs` passed independently against all three downloaded LCOV artifact pairs
- manual-validation Node suite passed 6/6
- `git diff --check` passed