### PR TITLE
Fix Google OAuth credentials in published builds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "dakia-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-desktop"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/DakiaMail/dakia-desktop"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4066,6 +4066,9 @@ pub fn run() {
                     }
                 }));
             if release_smoke_test {
+                oauth_client_id("gmail")?;
+                oauth_client_secret("gmail")?;
+                eprintln!("DAKIA_RELEASE_GOOGLE_OAUTH_CONFIG_OK");
                 eprintln!("DAKIA_RELEASE_SMOKE_TEST_OK");
                 app.handle().exit(0);
                 return Ok(());

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dakia",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "dev.dakia.mail",
   "build": {
     "beforeDevCommand": "npm run dev:desktop-web",

--- a/docs/publishing-macos-release.md
+++ b/docs/publishing-macos-release.md
@@ -27,17 +27,19 @@ The builder:
 
 1. assembles, Developer ID signs, and verifies the Apple Silicon app;
 2. verifies the packaged app and CLI executables, Apple-Silicon architecture,
-   matching Developer ID ownership/version, classifier resources, and legal
-   notices;
+   matching Developer ID ownership/version, classifier resources, legal
+   notices, and compiled Google OAuth configuration without runtime overrides;
 3. runs isolated packaged CLI and app startup checks on the release Mac;
 4. notarizes and staples the app;
 5. rebuilds, notarizes, staples, mounts, and verifies the DMG;
 6. archives that same final app, extracts and repeats the app/CLI acceptance
    checks on the archive contents, then signs the exact archive bytes for Tauri.
 
-The publisher uses immutable versioned R2 paths, anonymously verifies the
-published bytes, validates the updater manifest, and publishes `latest.json`
-only after all artifact checks pass.
+The publisher re-verifies the DMG, cryptographically verifies and extracts the
+updater archive, checks the archived app version and packaged-app acceptance,
+uses immutable versioned R2 paths, anonymously verifies the published bytes,
+validates the updater manifest, and publishes `latest.json` only after all
+artifact checks pass.
 
 After R2 publication is proven, create the signed source tag and a draft GitHub
 Release. Use `release-assets/vX.Y.Z/release-notes.md` as the release body and

--- a/docs/releases/v0.3.2.md
+++ b/docs/releases/v0.3.2.md
@@ -1,0 +1,21 @@
+# Dakia v0.3.2
+
+This patch release restores Google sign-in in published macOS builds.
+
+## Fixes
+
+- Google OAuth credentials are now compiled into the desktop library that
+  implements Gmail account setup. The previous release routed the credential
+  to the wrong Rust crate, so installed builds could not start Google OAuth.
+- Release builds now discard cached desktop-package artifacts before compiling
+  the credential-bearing code.
+- Packaged-app verification launches the finished app without OAuth environment
+  overrides and requires it to resolve its built-in Google OAuth configuration.
+  The same check runs for the signed app and the updater archive contents.
+- Publication now cryptographically verifies the updater archive signature,
+  extracts the app, and checks its packaged version before changing the public
+  updater feed.
+
+## Download
+
+Dakia v0.3.2 supports Apple Silicon Macs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dakia",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dakia",
-      "version": "0.3.1",
+      "version": "0.3.2",
       "dependencies": {
         "@browsermt/bergamot-translator": "^0.4.9",
         "@mantine/core": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dakia",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "scripts": {
     "dev": "./scripts/dev.sh",

--- a/scripts/build-local-macos-release.sh
+++ b/scripts/build-local-macos-release.sh
@@ -85,6 +85,11 @@ TAURI_ENV_ARCH=aarch64 \
 TAURI_ENV_PLATFORM=macos \
   npm run bundle:cli
 
+# Cargo cannot observe changes to the release-only secret file consumed by the
+# compiler wrapper. Rebuild the desktop package so the current credential is
+# always compiled into the artifact that the release verifier exercises.
+cargo clean -p dakia-desktop --target aarch64-apple-darwin
+
 ORT_LIB_LOCATION="$root_dir/apps/desktop/src-tauri/frameworks" \
 ORT_PREFER_DYNAMIC_LINK=1 \
   "$root_dir/node_modules/.bin/tauri" build \

--- a/scripts/local-release-env.sh
+++ b/scripts/local-release-env.sh
@@ -144,7 +144,7 @@ dakia_prepare_google_oauth_compiler_environment() {
     '    break' \
     '  fi' \
     'done' \
-    'if [[ "$crate_name" == "dakia_desktop" ]]; then' \
+    'if [[ "$crate_name" == "dakia_desktop_lib" ]]; then' \
     '  client_id="$(<"$DAKIA_RELEASE_GOOGLE_CLIENT_ID_FILE")"' \
     '  client_secret="$(<"$DAKIA_RELEASE_GOOGLE_CLIENT_SECRET_FILE")"' \
     '  if [[ -n "${DAKIA_RELEASE_GOOGLE_ORIGINAL_RUSTC_WRAPPER:-}" ]]; then' \

--- a/scripts/local-release.node-test.mjs
+++ b/scripts/local-release.node-test.mjs
@@ -82,6 +82,7 @@ function writeExecutable(path, source) {
 function createCliContractFixture({
   invalidInputSucceeds = false,
   missingFrameworkRpath = false,
+  missingOauthMarker = false,
 } = {}) {
   const fixture = createStaticAppFixture();
   const { app } = fixture;
@@ -101,9 +102,12 @@ function createCliContractFixture({
 set -eu
 test "\${DAKIA_RELEASE_SMOKE_TEST:-}" = 1
 test -n "\${DAKIA_RELEASE_SMOKE_DATA_DIR:-}"
+test -z "\${DAKIA_GOOGLE_CLIENT_ID:-}"
+test -z "\${DAKIA_GOOGLE_CLIENT_SECRET:-}"
 if [ -n "\${DAKIA_TEST_LAUNCH_PATH_FILE:-}" ]; then
   printf '%s' "$0" > "\$DAKIA_TEST_LAUNCH_PATH_FILE"
 fi
+${missingOauthMarker ? "" : "printf '%s\\\\n' DAKIA_RELEASE_GOOGLE_OAUTH_CONFIG_OK"}
 printf '%s\\n' DAKIA_RELEASE_SMOKE_TEST_OK
 `,
   );
@@ -194,6 +198,18 @@ test("release builder requires tracked human-readable release notes", () => {
   assert.doesNotMatch(script, /printf 'Dakia %s\\n'/);
 });
 
+test("release builder invalidates cached desktop credentials before Tauri compilation", () => {
+  const script = readFileSync(releaseBuilder, "utf8");
+  const cliBundle = script.indexOf("npm run bundle:cli");
+  const desktopClean = script.indexOf(
+    "cargo clean -p dakia-desktop --target aarch64-apple-darwin",
+  );
+  const tauriBuild = script.indexOf('"$root_dir/node_modules/.bin/tauri" build');
+  assert.ok(cliBundle >= 0);
+  assert.ok(desktopClean > cliBundle);
+  assert.ok(tauriBuild > desktopClean);
+});
+
 test("publisher rejects incomplete release assets before requiring publication credentials", () => {
   const result = spawnSync(publisher, ["v0.2.8", tmpdir()], {
     encoding: "utf8",
@@ -205,6 +221,13 @@ test("publisher rejects incomplete release assets before requiring publication c
 
 test("publisher resumes only when immutable public bytes match", () => {
   const script = readFileSync(publisher, "utf8");
+  assert.match(script, /verify-updater-signature\.mjs/);
+  assert.match(script, /tar -xzf "\$apple_update"/);
+  assert.match(
+    script,
+    /verify-macos-release-app\.sh" "\$updater_app"/,
+  );
+  assert.match(script, /Updater app version.*does not match/);
   assert.match(script, /aws s3api get-object/);
   assert.match(script, /cmp -s "\$source" "\$existing"/);
   assert.match(script, /aws s3api put-object/);
@@ -324,6 +347,8 @@ test(
     const badFixture = createCliContractFixture({ invalidInputSucceeds: true });
     const environmentFor = (mockBin) => ({
       PATH: `${mockBin}:${process.env.PATH}`,
+      DAKIA_GOOGLE_CLIENT_ID: "runtime-id-must-not-reach-release-smoke",
+      DAKIA_GOOGLE_CLIENT_SECRET: "runtime-secret-must-not-reach-release-smoke",
     });
     try {
       const goodResult = spawnSync(appVerifier, [goodFixture.app], {
@@ -332,6 +357,8 @@ test(
       });
       assert.equal(goodResult.status, 0, goodResult.stderr);
       assert.match(goodResult.stdout, /startup smoke test passed/);
+      assert.doesNotMatch(goodResult.stdout, /runtime-secret-must-not-reach/);
+      assert.doesNotMatch(goodResult.stderr, /runtime-secret-must-not-reach/);
 
       const badResult = spawnSync(appVerifier, [badFixture.app], {
         encoding: "utf8",
@@ -363,6 +390,27 @@ test(
       assert.match(
         result.stderr,
         /cannot resolve the bundled ONNX Runtime framework/,
+      );
+    } finally {
+      rmSync(fixture.fixtureRoot, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "packaged-app verification rejects a missing compiled Google OAuth marker",
+  { skip: process.platform !== "darwin" },
+  () => {
+    const fixture = createCliContractFixture({ missingOauthMarker: true });
+    try {
+      const result = spawnSync(appVerifier, [fixture.app], {
+        encoding: "utf8",
+        env: { PATH: `${fixture.mockBin}:${process.env.PATH}` },
+      });
+      assert.notEqual(result.status, 0);
+      assert.match(
+        result.stderr,
+        /missing its compiled Google OAuth configuration/,
       );
     } finally {
       rmSync(fixture.fixtureRoot, { recursive: true, force: true });
@@ -466,7 +514,7 @@ test("Google OAuth preflight keeps the secret out of curl arguments", () => {
   }
 });
 
-test("Google OAuth secret reaches only the Dakia Rust compiler invocation", () => {
+test("Google OAuth secret reaches the Rust library crate that implements OAuth", () => {
   const tempRoot = mkdtempSync(
     join(tmpdir(), "dakia-google-oauth-rustc-test-"),
   );
@@ -474,7 +522,7 @@ test("Google OAuth secret reaches only the Dakia Rust compiler invocation", () =
   const capturedEnvironment = join(tempRoot, "rustc-environment.txt");
   writeFileSync(
     rustcPath,
-    '#!/bin/sh\nprintf "%s|%s" "${DAKIA_GOOGLE_CLIENT_ID:-}" "${DAKIA_GOOGLE_CLIENT_SECRET:-}" > "$DAKIA_TEST_RUSTC_ENV"\n',
+    '#!/bin/sh\nprintf "%s|%s\\n" "${DAKIA_GOOGLE_CLIENT_ID:-}" "${DAKIA_GOOGLE_CLIENT_SECRET:-}" >> "$DAKIA_TEST_RUSTC_ENV"\n',
   );
   chmodSync(rustcPath, 0o755);
   try {
@@ -482,7 +530,7 @@ test("Google OAuth secret reaches only the Dakia Rust compiler invocation", () =
       "/bin/bash",
       [
         "-c",
-        'source "$1"; dakia_load_google_oauth_environment; dakia_prepare_google_oauth_compiler_environment; test -z "$(env | grep ^DAKIA_GOOGLE_CLIENT_)"; "$RUSTC_WRAPPER" "$2" --crate-type bin --crate-name dakia_desktop; dakia_clear_google_oauth_compiler_environment',
+        'source "$1"; dakia_load_google_oauth_environment; dakia_prepare_google_oauth_compiler_environment; test -z "$(env | grep ^DAKIA_GOOGLE_CLIENT_)"; "$RUSTC_WRAPPER" "$2" --crate-type rlib --crate-name dakia_desktop_lib; "$RUSTC_WRAPPER" "$2" --crate-type bin --crate-name dakia_desktop; "$RUSTC_WRAPPER" "$2" --crate-type rlib --crate-name third_party_dependency; dakia_clear_google_oauth_compiler_environment',
         "bash",
         releaseEnvironment,
         rustcPath,
@@ -500,8 +548,10 @@ test("Google OAuth secret reaches only the Dakia Rust compiler invocation", () =
     assert.equal(result.status, 0, result.stderr);
     assert.equal(
       readFileSync(capturedEnvironment, "utf8"),
-      "test-client|injected-secret",
+      "test-client|injected-secret\n|\n|\n",
     );
+    assert.doesNotMatch(result.stdout, /injected-secret/);
+    assert.doesNotMatch(result.stderr, /injected-secret/);
   } finally {
     rmSync(tempRoot, { recursive: true, force: true });
   }

--- a/scripts/publish-release-to-r2.sh
+++ b/scripts/publish-release-to-r2.sh
@@ -41,6 +41,25 @@ for artifact in \
 done
 
 "$root_dir/scripts/verify-macos-release-dmg.sh" "$apple_dmg"
+node "$root_dir/scripts/verify-updater-signature.mjs" \
+  "$apple_update" "$apple_signature" \
+  "$root_dir/apps/desktop/src-tauri/tauri.conf.json"
+
+updater_verify_dir="$work_dir/updater-archive"
+mkdir -p "$updater_verify_dir"
+tar -xzf "$apple_update" -C "$updater_verify_dir"
+updater_app="$updater_verify_dir/Dakia.app"
+if [[ ! -d "$updater_app" ]]; then
+  echo "Updater archive is missing Dakia.app." >&2
+  exit 1
+fi
+"$root_dir/scripts/verify-macos-release-app.sh" "$updater_app"
+updater_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' \
+  "$updater_app/Contents/Info.plist")"
+if [[ "$updater_version" != "$version" ]]; then
+  echo "Updater app version '$updater_version' does not match '$version'." >&2
+  exit 1
+fi
 
 release_prefix="macos/$tag"
 manifest_key="macos/latest/latest.json"

--- a/scripts/verify-macos-release-app.sh
+++ b/scripts/verify-macos-release-app.sh
@@ -228,10 +228,11 @@ if ! node -e '
   exit 1
 fi
 
-DAKIA_RELEASE_SMOKE_TEST=1 \
-DAKIA_RELEASE_SMOKE_DATA_DIR="$smoke_root/data" \
-RUST_BACKTRACE=1 \
-"$executable" >"$output" 2>&1 &
+env -u DAKIA_GOOGLE_CLIENT_ID -u DAKIA_GOOGLE_CLIENT_SECRET \
+  DAKIA_RELEASE_SMOKE_TEST=1 \
+  DAKIA_RELEASE_SMOKE_DATA_DIR="$smoke_root/data" \
+  RUST_BACKTRACE=1 \
+  "$executable" >"$output" 2>&1 &
 pid=$!
 
 seconds=0
@@ -259,6 +260,11 @@ if [ "$status" -ne 0 ]; then
 fi
 if ! grep -Fq "DAKIA_RELEASE_SMOKE_TEST_OK" "$output"; then
   echo "Packaged Dakia did not complete native startup initialization." >&2
+  cat "$output" >&2
+  exit 1
+fi
+if ! grep -Fq "DAKIA_RELEASE_GOOGLE_OAUTH_CONFIG_OK" "$output"; then
+  echo "Packaged Dakia is missing its compiled Google OAuth configuration." >&2
   cat "$output" >&2
   exit 1
 fi

--- a/scripts/verify-updater-signature.mjs
+++ b/scripts/verify-updater-signature.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+import { createHash, createPublicKey, verify } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { pathToFileURL } from "node:url";
+
+function decodeOuterBase64(value, label) {
+  if (typeof value !== "string" || !/^[A-Za-z0-9+/]+={0,2}$/.test(value.trim())) {
+    throw new Error(`${label} must be a base64 minisign value.`);
+  }
+  return Buffer.from(value.trim(), "base64").toString("utf8");
+}
+
+function decodeRecord(value, length, marker, label) {
+  const record = Buffer.from(value, "base64");
+  if (
+    record.length !== length ||
+    !record.subarray(0, 2).equals(Buffer.from(marker))
+  ) {
+    throw new Error(`Invalid ${label}.`);
+  }
+  return record;
+}
+
+export function verifyUpdaterSignature({ archive, signature, publicKey }) {
+  const publicLines = decodeOuterBase64(publicKey, "updater public key")
+    .trimEnd()
+    .split("\n");
+  if (publicLines.length !== 2 || !publicLines[0].startsWith("untrusted comment:")) {
+    throw new Error("Invalid updater public key.");
+  }
+  const publicRecord = decodeRecord(
+    publicLines[1],
+    42,
+    "Ed",
+    "updater public key",
+  );
+
+  const signatureLines = decodeOuterBase64(signature, "updater signature")
+    .trimEnd()
+    .split("\n");
+  if (
+    signatureLines.length !== 4 ||
+    !signatureLines[0].startsWith("untrusted comment:") ||
+    !signatureLines[2].startsWith("trusted comment: ")
+  ) {
+    throw new Error("Invalid updater signature.");
+  }
+  const signatureRecord = decodeRecord(
+    signatureLines[1],
+    74,
+    "ED",
+    "updater signature",
+  );
+  const globalSignature = Buffer.from(signatureLines[3], "base64");
+  if (globalSignature.length !== 64) {
+    throw new Error("Invalid updater signature.");
+  }
+  if (!publicRecord.subarray(2, 10).equals(signatureRecord.subarray(2, 10))) {
+    throw new Error("Updater signature key does not match the embedded public key.");
+  }
+
+  const spki = Buffer.concat([
+    Buffer.from("302a300506032b6570032100", "hex"),
+    publicRecord.subarray(10),
+  ]);
+  const key = createPublicKey({ key: spki, format: "der", type: "spki" });
+  const digest = createHash("blake2b512").update(archive).digest();
+  if (!verify(null, digest, key, signatureRecord.subarray(10))) {
+    throw new Error("Updater archive signature verification failed.");
+  }
+  const trustedComment = Buffer.from(signatureLines[2].slice(17));
+  const globalMessage = Buffer.concat([
+    signatureRecord.subarray(10),
+    trustedComment,
+  ]);
+  if (!verify(null, globalMessage, key, globalSignature)) {
+    throw new Error("Updater trusted-comment signature verification failed.");
+  }
+}
+
+async function main() {
+  const [archivePath, signaturePath, tauriConfigPath] = process.argv.slice(2);
+  if (!archivePath || !signaturePath || !tauriConfigPath) {
+    throw new Error(
+      "Usage: verify-updater-signature.mjs archive signature tauri.conf.json",
+    );
+  }
+  const [archive, signature, tauriConfig] = await Promise.all([
+    readFile(archivePath),
+    readFile(signaturePath, "utf8"),
+    readFile(tauriConfigPath, "utf8").then(JSON.parse),
+  ]);
+  verifyUpdaterSignature({
+    archive,
+    signature,
+    publicKey: tauriConfig?.plugins?.updater?.pubkey,
+  });
+  process.stdout.write(`Verified updater signature: ${archivePath}\n`);
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  main().catch((error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/scripts/verify-updater-signature.node-test.mjs
+++ b/scripts/verify-updater-signature.node-test.mjs
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import {
+  createHash,
+  generateKeyPairSync,
+  sign,
+} from "node:crypto";
+import test from "node:test";
+
+import { verifyUpdaterSignature } from "./verify-updater-signature.mjs";
+
+function updaterFixture() {
+  const { privateKey, publicKey } = generateKeyPairSync("ed25519");
+  const publicDer = publicKey.export({ format: "der", type: "spki" });
+  const keyId = Buffer.from("0123456789abcdef", "hex");
+  const archive = Buffer.from("signed Dakia updater archive fixture");
+  const archiveSignature = sign(
+    null,
+    createHash("blake2b512").update(archive).digest(),
+    privateKey,
+  );
+  const trustedComment = "timestamp:1785571200\tfile:Dakia-aarch64.app.tar.gz\tprehashed";
+  const globalSignature = sign(
+    null,
+    Buffer.concat([archiveSignature, Buffer.from(trustedComment)]),
+    privateKey,
+  );
+  const publicText = [
+    "untrusted comment: minisign public key fixture",
+    Buffer.concat([Buffer.from("Ed"), keyId, publicDer.subarray(-32)]).toString(
+      "base64",
+    ),
+  ].join("\n");
+  const signatureText = [
+    "untrusted comment: signature fixture",
+    Buffer.concat([Buffer.from("ED"), keyId, archiveSignature]).toString(
+      "base64",
+    ),
+    `trusted comment: ${trustedComment}`,
+    globalSignature.toString("base64"),
+  ].join("\n");
+  return {
+    archive,
+    publicKey: Buffer.from(publicText).toString("base64"),
+    signature: Buffer.from(signatureText).toString("base64"),
+  };
+}
+
+test("cryptographically verifies a Tauri minisign updater archive", () => {
+  assert.doesNotThrow(() => verifyUpdaterSignature(updaterFixture()));
+});
+
+test("rejects tampered updater bytes and trusted comments", () => {
+  const fixture = updaterFixture();
+  assert.throws(
+    () =>
+      verifyUpdaterSignature({
+        ...fixture,
+        archive: Buffer.from("tampered updater archive"),
+      }),
+    /archive signature verification failed/,
+  );
+
+  const decoded = Buffer.from(fixture.signature, "base64")
+    .toString("utf8")
+    .replace("timestamp:1785571200", "timestamp:1785571201");
+  assert.throws(
+    () =>
+      verifyUpdaterSignature({
+        ...fixture,
+        signature: Buffer.from(decoded).toString("base64"),
+      }),
+    /trusted-comment signature verification failed/,
+  );
+});


### PR DESCRIPTION
## Summary
- route the Google OAuth credential to the Rust library crate that implements OAuth
- make packaged release smoke tests prove compiled OAuth configuration without runtime overrides
- invalidate stale desktop build artifacts and cryptographically verify updater archives before publication
- prepare v0.3.2 release metadata and notes

## Verification
- npm run verify:local
- regression test fails when restored to the v0.3.1 crate-name routing
- 63 release-script tests, including updater signature tamper checks