### PR TITLE
Add Gmail verification warning to account setup

### DIFF
--- a/apps/desktop/src/components/AccountSetup.test.tsx
+++ b/apps/desktop/src/components/AccountSetup.test.tsx
@@ -1,0 +1,104 @@
+import { MantineProvider } from "@mantine/core";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeAll, describe, expect, it, vi } from "vitest";
+import "../i18n";
+import type { Provider } from "../types";
+import { AccountSetup } from "./AccountSetup";
+
+const gmail: Provider = {
+  id: "gmail",
+  name: "Gmail",
+  domains: ["gmail.com", "googlemail.com"],
+  imap_host: "imap.gmail.com",
+  imap_port: 993,
+  imap_security: "tls",
+  smtp_host: "smtp.gmail.com",
+  smtp_port: 465,
+  smtp_security: "tls",
+  archive_mailbox: "[Gmail]/All Mail",
+  spam_mailbox: "[Gmail]/Spam",
+  oauth: true,
+  app_password_help: "https://support.google.com/accounts/answer/185833",
+};
+
+const fastmail: Provider = {
+  id: "fastmail",
+  name: "Fastmail",
+  domains: ["fastmail.com"],
+  imap_host: "imap.fastmail.com",
+  imap_port: 993,
+  imap_security: "tls",
+  smtp_host: "smtp.fastmail.com",
+  smtp_port: 465,
+  smtp_security: "tls",
+  archive_mailbox: "Archive",
+  spam_mailbox: "Spam",
+  oauth: false,
+};
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+describe("AccountSetup provider guidance", () => {
+  it("shows the temporary verification notice for detected Gmail accounts", () => {
+    render(
+      <MantineProvider>
+        <AccountSetup
+          providers={[gmail, fastmail]}
+          saving={false}
+          onSave={vi.fn()}
+          onOAuth={vi.fn()}
+        />
+      </MantineProvider>,
+    );
+
+    const email = screen.getByRole("textbox", { name: "Email address" });
+    fireEvent.change(email, { target: { value: "person@gmail.com" } });
+
+    expect(screen.getByRole("status")).toHaveTextContent(
+      "Dakia’s app is awaiting Google verification, so you may see an “unverified app” warning during sign-in. This should be resolved soon; use an app password in the meantime.",
+    );
+  });
+
+  it("follows a manual provider override instead of the email domain", async () => {
+    render(
+      <MantineProvider>
+        <AccountSetup
+          providers={[gmail, fastmail]}
+          saving={false}
+          onSave={vi.fn()}
+          onOAuth={vi.fn()}
+        />
+      </MantineProvider>,
+    );
+
+    const email = screen.getByRole("textbox", { name: "Email address" });
+    fireEvent.change(email, { target: { value: "person@gmail.com" } });
+
+    fireEvent.click(screen.getByRole("textbox", { name: "Provider" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Fastmail" }));
+
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("shows the notice when Gmail is chosen for a custom-domain account", async () => {
+    render(
+      <MantineProvider>
+        <AccountSetup
+          providers={[gmail, fastmail]}
+          saving={false}
+          onSave={vi.fn()}
+          onOAuth={vi.fn()}
+        />
+      </MantineProvider>,
+    );
+
+    const email = screen.getByRole("textbox", { name: "Email address" });
+    fireEvent.change(email, { target: { value: "person@company.example" } });
+    fireEvent.click(screen.getByRole("textbox", { name: "Provider" }));
+    fireEvent.click(await screen.findByRole("option", { name: "Gmail" }));
+
+    expect(screen.getByRole("status")).toBeVisible();
+  });
+});

--- a/apps/desktop/src/components/AccountSetup.tsx
+++ b/apps/desktop/src/components/AccountSetup.tsx
@@ -108,6 +108,11 @@ export function AccountSetup({ providers, saving, onSave, onOAuth }: Props) {
             }))}
             required
           />
+          {chosen?.id === "gmail" ? (
+            <Text role="status" size="xs" className="gmail-verification-notice">
+              {t("account.gmailVerificationNotice")}
+            </Text>
+          ) : null}
           {usesOAuth ? (
             <Text size="sm" c="dimmed">
               {t("account.browserHint")}

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -212,6 +212,8 @@ export const en = {
       appPasswordHelp: "How to create an app password for {{provider}}",
       browserHint:
         "Your provider will open in the browser. Dakia never sees your provider password.",
+      gmailVerificationNotice:
+        "Dakia’s app is awaiting Google verification, so you may see an “unverified app” warning during sign-in. This should be resolved soon; use an app password in the meantime.",
     },
     composer: {
       title: "New message",

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1799,6 +1799,14 @@ textarea {
   margin: 0 auto;
   padding: 22px 28px 30px;
 }
+.gmail-verification-notice {
+  padding: 8px 10px;
+  border: 1px solid var(--dakia-divider);
+  border-radius: 7px;
+  color: light-dark(#5f625f, #b8bfbb);
+  line-height: 1.45;
+  background: light-dark(#f5f1ea, #282c29);
+}
 .settings-tabs {
   min-height: 0;
   flex: 1;


### PR DESCRIPTION
## Summary

- Show a temporary Google verification warning when Gmail is selected.
- Support both detected Gmail domains and manual Gmail provider selection.
- Add styled guidance and regression coverage for provider overrides.

## Testing

- Added component tests covering detected Gmail accounts, manual provider overrides, and custom-domain Gmail selection.