### PR TITLE
Open conversations in dedicated windows

### DIFF
--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -2,7 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "Default desktop permissions",
-  "windows": ["main", "compose-*", "settings", "account"],
+  "windows": ["main", "compose-*", "reader-*", "settings", "account"],
   "permissions": [
     "core:default",
     "core:webview:allow-create-webview-window",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -5,13 +5,14 @@ mod translation;
 mod tauri_contracts_tests;
 
 use base64::{engine::general_purpose::STANDARD, Engine};
-use dakia_core::storage::MessageContentFetchAcquire;
+use dakia_core::storage::{ConversationTarget, MessageContentFetchAcquire};
 use dakia_core::{
     ai::{AiConfig, AiProvider, AiService},
     mailbox_action_destination, provider, Account, AccountAuth, AccountDraft, Attachment,
-    CachedMessageContent, ComposeMessage, LocalEmailClassifier, MailConversationPage,
-    MailRebuildJob, MailService, MailSummary, MailboxAction, OAuthFlow, OAuthProviderConfig,
-    ProviderPreset, SearchQuery, Store, SyncProgress, SyncResult, UnsubscribeOutcome,
+    CachedMessageContent, ComposeMessage, LocalEmailClassifier, MailConversation,
+    MailConversationPage, MailRebuildJob, MailService, MailSummary, MailboxAction, OAuthFlow,
+    OAuthProviderConfig, ProviderPreset, SearchQuery, Store, SyncProgress, SyncResult,
+    UnsubscribeOutcome,
 };
 use secrecy::SecretString;
 use serde::Deserialize;
@@ -1012,8 +1013,61 @@ struct DesktopNotification {
     body: String,
     account_id: Option<String>,
     message_id: Option<String>,
+    thread_id: Option<String>,
+    rfc_message_id: Option<String>,
     count: usize,
     sound: Option<String>,
+}
+
+fn notification_has_reader_target(notification: &DesktopNotification) -> bool {
+    notification.count == 1
+        && notification
+            .account_id
+            .as_deref()
+            .is_some_and(|account_id| !account_id.trim().is_empty())
+        && [
+            notification.message_id.as_deref(),
+            notification.rfc_message_id.as_deref(),
+            notification.thread_id.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        .any(|value| !value.trim().is_empty())
+}
+
+#[cfg(test)]
+mod desktop_notification_tests {
+    use super::*;
+
+    #[test]
+    fn single_message_notifications_preserve_reader_locators_without_focusing_main() {
+        let notification = DesktopNotification {
+            title: "New message".into(),
+            body: "A reply arrived".into(),
+            account_id: Some("account-1".into()),
+            message_id: Some("account-1:INBOX:7".into()),
+            thread_id: Some("root@example.test".into()),
+            rfc_message_id: Some("<reply@example.test>".into()),
+            count: 1,
+            sound: None,
+        };
+        assert!(notification_has_reader_target(&notification));
+        let value = serde_json::to_value(notification).unwrap();
+        assert_eq!(value["threadId"], "root@example.test");
+        assert_eq!(value["rfcMessageId"], "<reply@example.test>");
+
+        let grouped = DesktopNotification {
+            title: "New messages".into(),
+            body: "Several messages arrived".into(),
+            account_id: Some("account-1".into()),
+            message_id: Some("account-1:INBOX:7".into()),
+            thread_id: Some("root@example.test".into()),
+            rfc_message_id: Some("<reply@example.test>".into()),
+            count: 2,
+            sound: None,
+        };
+        assert!(!notification_has_reader_target(&grouped));
+    }
 }
 
 #[derive(Deserialize)]
@@ -3113,6 +3167,18 @@ async fn search(
 }
 
 #[tauri::command]
+async fn conversation_for_target(
+    state: State<'_, Arc<AppState>>,
+    target: ConversationTarget,
+) -> Result<Option<MailConversation>, String> {
+    state
+        .store
+        .conversation_for_target(&target)
+        .await
+        .map_err(error)
+}
+
+#[tauri::command]
 async fn search_remote(
     state: State<'_, Arc<AppState>>,
     query: SearchQuery,
@@ -3890,9 +3956,11 @@ async fn send_desktop_notification(
                 if action == "__closed" {
                     return;
                 }
-                if let Some(window) = action_app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
+                if !notification_has_reader_target(&notification) {
+                    if let Some(window) = action_app.get_webview_window("main") {
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                    }
                 }
                 let _ = action_app.emit("notification-action", notification);
             });
@@ -4058,7 +4126,18 @@ pub fn run() {
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .on_menu_event(|app, event| {
-            let _ = app.emit("menu-action", event.id().as_ref());
+            let action = event.id().as_ref();
+            let message_action = matches!(action, "reply" | "forward" | "archive" | "spam");
+            let focused = message_action.then(|| {
+                app.webview_windows()
+                    .into_values()
+                    .find(|window| window.is_focused().unwrap_or(false))
+            });
+            if let Some(Some(window)) = focused {
+                let _ = window.emit("menu-action", action);
+            } else if let Some(main) = app.get_webview_window("main") {
+                let _ = main.emit("menu-action", action);
+            }
         })
         .on_window_event(move |window, event| match event {
             WindowEvent::DragDrop(DragDropEvent::Drop { paths, .. }) => {
@@ -4245,6 +4324,7 @@ pub fn run() {
             add_account,
             add_oauth_account,
             search,
+            conversation_for_target,
             search_remote,
             set_message_category,
             set_message_starred,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1019,6 +1019,7 @@ struct DesktopNotification {
     sound: Option<String>,
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn notification_has_reader_target(notification: &DesktopNotification) -> bool {
     notification.count == 1
         && notification

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -32,6 +32,10 @@ const mocks = vi.hoisted(() => {
   const desktopNotificationActionHandlers: Array<
     (extra: Record<string, unknown>) => void | Promise<void>
   > = [];
+  const readerMutationHandlers: Array<() => void> = [];
+  const readerFailureHandlers: Array<
+    (failure: { accountId: string }) => void | Promise<void>
+  > = [];
   const accountRemovedHandlers: Array<(event: { accountId: string }) => void> =
     [];
   const accountUpdatedHandlers: Array<(account: Account) => void> = [];
@@ -114,6 +118,7 @@ const mocks = vi.hoisted(() => {
     requestInitialNotificationAccess: vi.fn(async () => undefined),
     sendNewMailNotification: vi.fn(async () => false),
     openComposeWindow: vi.fn(),
+    openReaderWindow: vi.fn(async () => undefined),
     noopListener: vi.fn(async () => unlisten),
     onNativeMenuAction: vi.fn(async (handler: (action: string) => void) => {
       nativeMenuHandlers.push(handler);
@@ -137,6 +142,20 @@ const mocks = vi.hoisted(() => {
     nativeMenuHandlers,
     notificationActionHandlers,
     desktopNotificationActionHandlers,
+    readerMutationHandlers,
+    readerFailureHandlers,
+    onReaderWindowMutated: vi.fn(async (handler: () => void) => {
+      readerMutationHandlers.push(handler);
+      return unlisten;
+    }),
+    onReaderWindowFailed: vi.fn(
+      async (
+        handler: (failure: { accountId: string }) => void | Promise<void>,
+      ) => {
+        readerFailureHandlers.push(handler);
+        return unlisten;
+      },
+    ),
     onNotificationAction: vi.fn(
       async (
         handler: (extra: Record<string, unknown>) => void | Promise<void>,
@@ -184,6 +203,12 @@ vi.mock("./composeWindow", () => ({
   onComposeSent: mocks.noopListener,
   onOutboxChanged: mocks.noopListener,
   openComposeWindow: mocks.openComposeWindow,
+}));
+
+vi.mock("./readerWindow", () => ({
+  onReaderWindowFailed: mocks.onReaderWindowFailed,
+  onReaderWindowMutated: mocks.onReaderWindowMutated,
+  openReaderWindow: mocks.openReaderWindow,
 }));
 
 vi.mock("./nativeFeedback", () => ({
@@ -236,6 +261,9 @@ describe("App read state", () => {
     mocks.nativeMenuHandlers.length = 0;
     mocks.notificationActionHandlers.length = 0;
     mocks.desktopNotificationActionHandlers.length = 0;
+    mocks.readerMutationHandlers.length = 0;
+    mocks.readerFailureHandlers.length = 0;
+    mocks.openReaderWindow.mockClear();
     mocks.accountRemovedHandlers.length = 0;
     mocks.accountUpdatedHandlers.length = 0;
     localStorage.clear();
@@ -423,7 +451,29 @@ describe("App read state", () => {
     expect(mocks.api.content).not.toHaveBeenCalledWith(older.id);
   });
 
-  it("focuses the newest thread message when an older notification is opened", async () => {
+  it("opens a main-list thread in a dedicated window on double-click", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const row = await screen.findByText("Unread thread");
+    fireEvent.doubleClick(row.closest("button")!);
+
+    expect(mocks.openReaderWindow).toHaveBeenCalledWith({
+      target: {
+        accountId: mocks.account.id,
+        localMessageId: mocks.message.id,
+        rfcMessageId: undefined,
+        threadId: mocks.message.thread_id,
+        mailbox: "INBOX",
+      },
+      focusedMessageId: mocks.message.id,
+    });
+  });
+
+  it("opens a targeted notification in a dedicated conversation window", async () => {
     const older = {
       ...mocks.message,
       id: "message-notified",
@@ -431,23 +481,6 @@ describe("App read state", () => {
       received_at: "2026-07-19T09:00:00Z",
       snippet: "Notified preview",
     };
-    const latest = {
-      ...mocks.message,
-      id: "message-after-notification",
-      uid: 2,
-      received_at: "2026-07-19T10:00:00Z",
-      snippet: "Newest preview",
-      unsubscribe_kind: "one_click" as const,
-    };
-    mocks.api.search.mockResolvedValue({
-      conversations: groupMessages([latest, older]),
-      nextCursor: null,
-    });
-    mocks.api.content.mockImplementation(async (id: string) => ({
-      body_text: id === latest.id ? "Newest notification body" : "Older body",
-      attachments: [],
-    }));
-
     render(
       <MantineProvider>
         <App />
@@ -461,24 +494,119 @@ describe("App read state", () => {
       await mocks.notificationActionHandlers.at(-1)!({
         accountId: mocks.account.id,
         messageId: older.id,
+        rfcMessageId: "<notified@example.com>",
+        threadId: older.thread_id,
+        count: 1,
       });
     });
 
-    expect(await screen.findByText("Newest notification body")).toBeVisible();
-    expect(mocks.api.content).toHaveBeenCalledWith(latest.id);
-    expect(mocks.api.content).not.toHaveBeenCalledWith(older.id);
-    fireEvent.click(
-      screen
-        .getAllByRole("button", { name: "Star conversation" })
-        .find((element) => element.tagName === "BUTTON")!,
+    expect(mocks.openReaderWindow).toHaveBeenCalledWith({
+      target: {
+        accountId: mocks.account.id,
+        localMessageId: older.id,
+        rfcMessageId: "<notified@example.com>",
+        threadId: older.thread_id,
+        mailbox: "INBOX",
+      },
+      focusedMessageId: older.id,
+    });
+    expect(mocks.windowApi.show).not.toHaveBeenCalled();
+    expect(mocks.windowApi.setFocus).not.toHaveBeenCalled();
+  });
+
+  it("keeps grouped notifications in the main Inbox", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mocks.notificationActionHandlers).not.toHaveLength(0),
+    );
+    await act(async () => {
+      await mocks.notificationActionHandlers.at(-1)!({ count: 2 });
+    });
+
+    expect(mocks.openReaderWindow).not.toHaveBeenCalled();
+    expect(mocks.windowApi.show).toHaveBeenCalled();
+    expect(mocks.windowApi.setFocus).toHaveBeenCalled();
+    expect(mocks.api.search.mock.calls).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(["", [mocks.account.id], "INBOX"]),
+      ]),
+    );
+  });
+
+  it("falls back to the main Inbox when a notification reader cannot open", async () => {
+    mocks.openReaderWindow.mockRejectedValueOnce(new Error("window failed"));
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mocks.notificationActionHandlers).not.toHaveLength(0),
+    );
+    await act(async () => {
+      await mocks.notificationActionHandlers.at(-1)!({
+        accountId: mocks.account.id,
+        messageId: mocks.message.id,
+        threadId: mocks.message.thread_id,
+        count: 1,
+      });
+    });
+
+    expect(mocks.showNativeMessage).toHaveBeenCalled();
+    expect(mocks.windowApi.show).toHaveBeenCalled();
+    expect(mocks.windowApi.setFocus).toHaveBeenCalled();
+  });
+
+  it("returns a failed reader target to its account Inbox", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
     );
     await waitFor(() =>
-      expect(mocks.api.setStarred).toHaveBeenCalledWith(latest.id, true),
+      expect(mocks.readerFailureHandlers).not.toHaveLength(0),
     );
-    fireEvent.click(screen.getByRole("button", { name: "Unsubscribe" }));
+
+    await act(async () => {
+      await mocks.readerFailureHandlers.at(-1)!({
+        accountId: mocks.account.id,
+      });
+    });
+
+    expect(mocks.windowApi.show).toHaveBeenCalled();
+    expect(mocks.windowApi.setFocus).toHaveBeenCalled();
+    expect(mocks.api.search.mock.calls).toEqual(
+      expect.arrayContaining([
+        expect.arrayContaining(["", [mocks.account.id], "INBOX"]),
+      ]),
+    );
+  });
+
+  it("refreshes the main mailbox after a reader-window mutation", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
     await waitFor(() =>
-      expect(mocks.api.unsubscribe).toHaveBeenCalledWith(latest.id),
+      expect(mocks.readerMutationHandlers).not.toHaveLength(0),
     );
+    const searchesBefore = mocks.api.search.mock.calls.length;
+
+    act(() => mocks.readerMutationHandlers.at(-1)!());
+
+    await waitFor(() =>
+      expect(mocks.api.search.mock.calls.length).toBeGreaterThan(
+        searchesBefore,
+      ),
+    );
+    expect(mocks.api.starredCount).toHaveBeenCalled();
   });
 
   it("paints the first 100 conversations before classifying in the background", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -41,6 +41,12 @@ import {
   sendNewMailNotification,
 } from "./notifications";
 import {
+  onReaderWindowFailed,
+  onReaderWindowMutated,
+  openReaderWindow,
+  type ReaderWindowSeed,
+} from "./readerWindow";
+import {
   onAccountConnected,
   onAccountRemoved,
   onAccountUpdated,
@@ -1043,6 +1049,33 @@ export default function App() {
     let disposed = false;
     let dispose: () => void = () => undefined;
     const openNotification = async (extra: Record<string, unknown>) => {
+      const accountId =
+        typeof extra.accountId === "string" ? extra.accountId : undefined;
+      const messageId =
+        typeof extra.messageId === "string" ? extra.messageId : undefined;
+      const rfcMessageId =
+        typeof extra.rfcMessageId === "string" ? extra.rfcMessageId : undefined;
+      const threadId =
+        typeof extra.threadId === "string" ? extra.threadId : undefined;
+      const count = typeof extra.count === "number" ? extra.count : 0;
+      if (count === 1 && accountId && (messageId || rfcMessageId || threadId)) {
+        try {
+          await openReaderWindow({
+            target: {
+              accountId,
+              localMessageId: messageId,
+              rfcMessageId,
+              threadId,
+              mailbox: "INBOX",
+            },
+            focusedMessageId: messageId,
+          });
+          return;
+        } catch (error) {
+          showError(error);
+        }
+      }
+
       const currentWindow = getCurrentWindow();
       await currentWindow.show();
       await currentWindow.setFocus();
@@ -1051,10 +1084,6 @@ export default function App() {
       setSelected(new Set());
       setAiResult(undefined);
 
-      const accountId =
-        typeof extra.accountId === "string" ? extra.accountId : undefined;
-      const messageId =
-        typeof extra.messageId === "string" ? extra.messageId : undefined;
       const accountIds = accountId
         ? [accountId]
         : accounts.map((account) => account.id);
@@ -1065,14 +1094,8 @@ export default function App() {
       nextCursorRef.current = inbox.nextCursor;
       setHasMore(inbox.nextCursor !== null);
       setThreads(inbox.conversations);
-      const clickedThread = inbox.conversations.find((thread) =>
-        thread.messages.some((message) => message.id === messageId),
-      );
-      setActive(clickedThread?.latest);
-      setActiveThreadSnapshot(clickedThread);
-      if (clickedThread) {
-        void setThreadReadState(clickedThread, true, { silent: true });
-      }
+      setActive(undefined);
+      setActiveThreadSnapshot(undefined);
     };
     void Promise.all([
       onNotificationAction(openNotification).then((listener) =>
@@ -1089,6 +1112,44 @@ export default function App() {
       dispose();
     };
   }, [accounts]);
+
+  useEffect(() => {
+    let dispose: () => void = () => undefined;
+    let disposed = false;
+    void Promise.all([
+      onReaderWindowMutated(() => {
+        void loadMessages();
+        void refreshStarredCount(activeAccounts);
+      }),
+      onReaderWindowFailed(async ({ accountId }) => {
+        try {
+          const currentWindow = getCurrentWindow();
+          await currentWindow.show();
+          await currentWindow.setFocus();
+          setMailbox("INBOX");
+          setQuery("");
+          selectedAccountIdRef.current = accountId;
+          setSelectedAccountId(accountId);
+          setActive(undefined);
+          setActiveThreadSnapshot(undefined);
+          const inbox = await api.search("", [accountId], "INBOX");
+          setThreads(inbox.conversations);
+          nextCursorRef.current = inbox.nextCursor;
+          setHasMore(inbox.nextCursor !== null);
+        } catch (error) {
+          showError(error);
+        }
+      }),
+    ]).then((unlisteners) => {
+      const unlistenAll = () => unlisteners.forEach((unlisten) => unlisten());
+      if (disposed) unlistenAll();
+      else dispose = unlistenAll;
+    });
+    return () => {
+      disposed = true;
+      dispose();
+    };
+  }, [activeAccounts, loadMessages, refreshStarredCount]);
 
   const activeThread = useMemo(
     () =>
@@ -2190,6 +2251,20 @@ export default function App() {
           setActiveThreadSnapshot(thread);
           setAiResult(undefined);
           void setThreadReadState(thread, true, { silent: true });
+        }}
+        onDoubleOpen={(thread) => {
+          const focused = thread.latest;
+          const seed: ReaderWindowSeed = {
+            target: {
+              accountId: focused.account_id,
+              localMessageId: focused.id,
+              rfcMessageId: focused.message_id ?? undefined,
+              threadId: thread.threadId ?? focused.thread_id,
+              mailbox,
+            },
+            focusedMessageId: focused.id,
+          };
+          void openReaderWindow(seed).catch(showError);
         }}
         onSelect={select}
         onSync={() => void sync()}

--- a/apps/desktop/src/DesktopRoot.tsx
+++ b/apps/desktop/src/DesktopRoot.tsx
@@ -9,6 +9,7 @@ import "./i18n";
 import "./styles.css";
 import App from "./App";
 import { ComposeApp } from "./ComposeApp";
+import { ReaderWindowApp } from "./ReaderWindowApp";
 import { AccountWindowApp, SettingsWindowApp } from "./UtilityApps";
 
 const theme = createTheme({
@@ -45,6 +46,8 @@ export function DesktopRoot() {
   const content =
     view === "compose" ? (
       <ComposeApp />
+    ) : view === "reader" ? (
+      <ReaderWindowApp />
     ) : view === "settings" ? (
       <SettingsWindowApp />
     ) : view === "account" ? (

--- a/apps/desktop/src/ReaderWindowApp.test.tsx
+++ b/apps/desktop/src/ReaderWindowApp.test.tsx
@@ -1,0 +1,335 @@
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { MantineProvider } from "@mantine/core";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MailSummary, MailThread } from "./types";
+
+const mocks = vi.hoisted(() => ({
+  api: {
+    accounts: vi.fn(),
+    action: vi.fn(),
+    aiAvailable: vi.fn(),
+    content: vi.fn(),
+    conversationForTarget: vi.fn(),
+    setRead: vi.fn(),
+    setStarred: vi.fn(),
+    summarize: vi.fn(),
+    unsubscribe: vi.fn(),
+  },
+  closeReaderWindow: vi.fn(),
+  notifyReaderWindowMutated: vi.fn(),
+  notifyReaderWindowFailed: vi.fn(),
+  onReaderTarget: vi.fn(),
+  readReaderSeed: vi.fn(),
+  openComposeWindow: vi.fn(),
+  showNativeMessage: vi.fn(),
+  nativeMenuHandlers: [] as Array<(action: string) => void>,
+}));
+
+vi.mock("./api", () => ({ api: mocks.api }));
+vi.mock("./composeWindow", () => ({
+  openComposeWindow: mocks.openComposeWindow,
+}));
+vi.mock("./readerWindow", () => ({
+  closeReaderWindow: mocks.closeReaderWindow,
+  notifyReaderWindowMutated: mocks.notifyReaderWindowMutated,
+  notifyReaderWindowFailed: mocks.notifyReaderWindowFailed,
+  onReaderTarget: mocks.onReaderTarget,
+  readReaderSeed: mocks.readReaderSeed,
+}));
+vi.mock("./nativeFeedback", () => ({
+  showNativeMessage: mocks.showNativeMessage,
+}));
+vi.mock("./nativeWindows", () => ({
+  onNativeMenuAction: vi.fn(async (handler: (action: string) => void) => {
+    mocks.nativeMenuHandlers.push(handler);
+    return () => undefined;
+  }),
+}));
+vi.mock("./components/Reader", () => ({
+  Reader: ({
+    message,
+    messages,
+    onArchive,
+    onPermanentDelete,
+  }: {
+    message?: MailSummary;
+    messages?: MailSummary[];
+    onArchive: () => void;
+    onPermanentDelete: (message: MailSummary) => void;
+  }) => (
+    <div>
+      <span data-testid="focused-message">{message?.id}</span>
+      <span data-testid="conversation-count">{messages?.length}</span>
+      <button type="button" onClick={onArchive}>
+        Archive
+      </button>
+      <button
+        type="button"
+        onClick={() => message && onPermanentDelete(message)}
+      >
+        Permanently delete
+      </button>
+    </div>
+  ),
+}));
+
+const messages: MailSummary[] = [
+  {
+    id: "message-1",
+    account_id: "account-1",
+    mailbox: "INBOX",
+    uid: 1,
+    thread_id: "thread-1",
+    subject: "Project",
+    from_address: "mara@example.com",
+    to_addresses: "alex@example.com",
+    received_at: "2026-08-10T09:00:00Z",
+    snippet: "Earlier",
+    body_text: "Earlier",
+    is_read: true,
+    is_flagged: false,
+    has_attachments: false,
+  },
+  {
+    id: "message-2",
+    account_id: "account-1",
+    mailbox: "INBOX",
+    uid: 2,
+    thread_id: "thread-1",
+    subject: "Project",
+    from_address: "alex@example.com",
+    to_addresses: "mara@example.com",
+    received_at: "2026-08-10T10:00:00Z",
+    snippet: "Focused",
+    body_text: "Focused",
+    is_read: false,
+    is_flagged: false,
+    has_attachments: false,
+  },
+];
+
+const thread: MailThread = {
+  id: "account-1:thread-1",
+  accountId: "account-1",
+  threadId: "thread-1",
+  messages,
+  latest: messages[1],
+  unread: true,
+  hasAttachments: false,
+  participants: [],
+};
+
+describe("ReaderWindowApp", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.nativeMenuHandlers.length = 0;
+    mocks.readReaderSeed.mockReturnValue({
+      target: {
+        accountId: "account-1",
+        threadId: "thread-1",
+        localMessageId: "message-2",
+      },
+      focusedMessageId: "message-1",
+    });
+    mocks.api.accounts.mockResolvedValue([
+      { id: "account-1", email: "alex@example.com" },
+    ]);
+    mocks.api.conversationForTarget.mockResolvedValue(thread);
+    mocks.api.aiAvailable.mockResolvedValue(false);
+    mocks.api.action.mockResolvedValue(undefined);
+    mocks.api.setRead.mockResolvedValue(undefined);
+    mocks.onReaderTarget.mockResolvedValue(() => undefined);
+    mocks.notifyReaderWindowMutated.mockResolvedValue(undefined);
+  });
+
+  it("loads the whole target conversation while passing the focused message to Reader", async () => {
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+
+    expect(await screen.findByTestId("focused-message")).toHaveTextContent(
+      "message-1",
+    );
+    expect(screen.getByTestId("conversation-count")).toHaveTextContent("2");
+    expect(mocks.api.conversationForTarget).toHaveBeenCalledWith({
+      accountId: "account-1",
+      threadId: "thread-1",
+      localMessageId: "message-2",
+    });
+    await waitFor(() =>
+      expect(mocks.api.setRead).toHaveBeenCalledWith("message-2", true),
+    );
+    expect(mocks.notifyReaderWindowMutated).toHaveBeenCalledWith({
+      accountId: "account-1",
+      threadId: "thread-1",
+      messageIds: ["message-2"],
+      mutation: "read",
+    });
+  });
+
+  it("only closes after every mailbox action succeeds and refreshes main", async () => {
+    const remainingThread = {
+      ...thread,
+      messages: [messages[0]],
+      latest: messages[0],
+    };
+    mocks.api.conversationForTarget
+      .mockResolvedValueOnce(thread)
+      .mockResolvedValueOnce(remainingThread);
+    mocks.api.action.mockRejectedValueOnce(new Error("offline"));
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+    const archive = await screen.findByRole("button", { name: "Archive" });
+    await waitFor(() => expect(mocks.api.setRead).toHaveBeenCalled());
+    mocks.notifyReaderWindowMutated.mockClear();
+
+    fireEvent.click(archive);
+    await waitFor(() => expect(mocks.api.action).toHaveBeenCalledTimes(2));
+    expect(mocks.closeReaderWindow).not.toHaveBeenCalled();
+    expect(mocks.notifyReaderWindowMutated).toHaveBeenCalledWith({
+      accountId: "account-1",
+      threadId: "thread-1",
+      messageIds: ["message-2"],
+      mutation: "archive",
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId("conversation-count")).toHaveTextContent("1"),
+    );
+
+    mocks.api.action.mockResolvedValue(undefined);
+    mocks.notifyReaderWindowMutated.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "Archive" }));
+    await waitFor(() => expect(mocks.closeReaderWindow).toHaveBeenCalledOnce());
+    expect(mocks.api.action).toHaveBeenCalledTimes(3);
+    expect(mocks.notifyReaderWindowMutated).toHaveBeenCalledWith({
+      accountId: "account-1",
+      threadId: "thread-1",
+      messageIds: ["message-1"],
+      mutation: "archive",
+    });
+  });
+
+  it("routes a native archive command to the visible reader conversation", async () => {
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+    await screen.findByTestId("focused-message");
+    await waitFor(() =>
+      expect(mocks.nativeMenuHandlers.length).toBeGreaterThan(1),
+    );
+
+    act(() => mocks.nativeMenuHandlers.at(-1)?.("archive"));
+
+    await waitFor(() => expect(mocks.api.action).toHaveBeenCalledTimes(2));
+    expect(mocks.closeReaderWindow).toHaveBeenCalledOnce();
+  });
+
+  it("removes only the permanently deleted message and keeps the conversation open", async () => {
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+    await screen.findByTestId("focused-message");
+
+    fireEvent.click(screen.getByRole("button", { name: "Permanently delete" }));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("conversation-count")).toHaveTextContent("1"),
+    );
+    expect(mocks.api.action).toHaveBeenCalledWith(
+      "account-1",
+      "INBOX",
+      1,
+      "delete",
+    );
+    expect(mocks.notifyReaderWindowMutated).toHaveBeenCalledWith({
+      accountId: "account-1",
+      threadId: "thread-1",
+      messageIds: ["message-1"],
+      mutation: "delete",
+    });
+    expect(mocks.closeReaderWindow).not.toHaveBeenCalled();
+  });
+
+  it("returns an unresolved reader target to the main Inbox", async () => {
+    mocks.api.conversationForTarget.mockResolvedValueOnce(null);
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+
+    await waitFor(() =>
+      expect(mocks.notifyReaderWindowFailed).toHaveBeenCalledWith({
+        accountId: "account-1",
+      }),
+    );
+    expect(mocks.showNativeMessage).toHaveBeenCalled();
+    expect(mocks.closeReaderWindow).toHaveBeenCalled();
+  });
+
+  it("does not let a slower prior target overwrite a retargeted window", async () => {
+    let resolveFirst: (value: MailThread) => void = () => undefined;
+    const first = new Promise<MailThread>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const retargetedMessage = {
+      ...messages[1],
+      id: "message-retargeted",
+      thread_id: "thread-2",
+      subject: "Retargeted",
+    };
+    const retargetedThread = {
+      ...thread,
+      id: "account-1:thread-2",
+      threadId: "thread-2",
+      messages: [retargetedMessage],
+      latest: retargetedMessage,
+    };
+    mocks.api.conversationForTarget
+      .mockImplementationOnce(() => first)
+      .mockResolvedValueOnce(retargetedThread);
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+    await waitFor(() => expect(mocks.onReaderTarget).toHaveBeenCalled());
+    const retarget = mocks.onReaderTarget.mock.calls[0][0];
+
+    await act(async () => {
+      retarget({
+        target: { accountId: "account-1", threadId: "thread-2" },
+        focusedMessageId: retargetedMessage.id,
+      });
+    });
+    expect(await screen.findByTestId("focused-message")).toHaveTextContent(
+      retargetedMessage.id,
+    );
+
+    await act(async () => resolveFirst(thread));
+    expect(screen.getByTestId("focused-message")).toHaveTextContent(
+      retargetedMessage.id,
+    );
+  });
+});

--- a/apps/desktop/src/ReaderWindowApp.tsx
+++ b/apps/desktop/src/ReaderWindowApp.tsx
@@ -1,0 +1,560 @@
+import { Loader } from "@mantine/core";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { api } from "./api";
+import { openComposeWindow } from "./composeWindow";
+import { Reader } from "./components/Reader";
+import { AI_FEATURES_VISIBLE } from "./features";
+import { forwardBody, forwardSubject } from "./forward";
+import {
+  conversationActionMessages,
+  removeConcreteMessage,
+  type MailAction,
+} from "./mailActions";
+import { showNativeMessage } from "./nativeFeedback";
+import { onNativeMenuAction } from "./nativeWindows";
+import {
+  closeReaderWindow,
+  notifyReaderWindowMutated,
+  notifyReaderWindowFailed,
+  onReaderTarget,
+  readReaderSeed,
+  type ReaderWindowMutation,
+  type ReaderWindowSeed,
+} from "./readerWindow";
+import { replyRecipients } from "./recipients";
+import { formatReplyHistory } from "./replyHistory";
+import type { AiSettings, MailSummary, MailThread } from "./types";
+import { concreteThreadMessages } from "./threads";
+
+const defaultAi: AiSettings = {
+  provider: "ollama",
+  baseUrl: "http://127.0.0.1:11434/",
+  model: "qwen2.5:1.5b",
+  apiKey: "",
+  executable: "",
+  modelPath: "",
+};
+
+const readerApi = api;
+
+export function ReaderWindowApp() {
+  const { t } = useTranslation();
+  const [seed, setSeed] = useState<ReaderWindowSeed | undefined>(
+    readReaderSeed,
+  );
+  const [thread, setThread] = useState<MailThread>();
+  const [accountEmail, setAccountEmail] = useState<string>();
+  const [loading, setLoading] = useState(Boolean(seed));
+  const [actionBusy, setActionBusy] = useState(false);
+  const [unsubscribeLoading, setUnsubscribeLoading] = useState(false);
+  const [aiLoading, setAiLoading] = useState(false);
+  const [aiResult, setAiResult] = useState<string>();
+  const [aiConnected, setAiConnected] = useState(false);
+  const loadGeneration = useRef(0);
+  const translate = useRef(t);
+  translate.current = t;
+  const aiSettings = useMemo(() => readAiSettings(), []);
+
+  const loadThread = useCallback(async (nextSeed: ReaderWindowSeed) => {
+    const generation = ++loadGeneration.current;
+    setLoading(true);
+    setThread(undefined);
+    setAiResult(undefined);
+    try {
+      const [accounts, conversation] = await Promise.all([
+        readerApi.accounts(),
+        readerApi.conversationForTarget(nextSeed.target),
+      ]);
+      if (generation !== loadGeneration.current) return;
+      setAccountEmail(
+        accounts.find((account) => account.id === nextSeed.target.accountId)
+          ?.email,
+      );
+      setThread(conversation ?? undefined);
+      if (conversation) document.title = conversation.latest.subject || "Dakia";
+      if (!conversation) {
+        await showNativeMessage(
+          translate.current("errors.generic"),
+          translate.current("reader.emptyBody"),
+          "warning",
+        );
+        try {
+          await notifyReaderWindowFailed({
+            accountId: nextSeed.target.accountId,
+          });
+        } catch (error) {
+          showError(error);
+        } finally {
+          await closeReaderWindow();
+        }
+      } else {
+        const unread = concreteThreadMessages(conversation).filter(
+          (message) => !message.is_read,
+        );
+        if (unread.length) {
+          void Promise.allSettled(
+            unread.map((message) => readerApi.setRead(message.id, true)),
+          )
+            .then(async (results) => {
+              const succeeded = unread.filter(
+                (_message, index) => results[index].status === "fulfilled",
+              );
+              if (!succeeded.length) {
+                const failed = results.find(
+                  (result): result is PromiseRejectedResult =>
+                    result.status === "rejected",
+                );
+                if (failed) throw failed.reason;
+                return;
+              }
+              if (generation !== loadGeneration.current) return;
+              setThread((current) =>
+                current
+                  ? updateThread(current, (message) =>
+                      succeeded.some((item) => item.id === message.id)
+                        ? { ...message, is_read: true }
+                        : message,
+                    )
+                  : current,
+              );
+              await notifyReaderWindowMutated({
+                accountId: nextSeed.target.accountId,
+                threadId:
+                  conversation.threadId ?? conversation.latest.thread_id,
+                messageIds: succeeded.map((message) => message.id),
+                mutation: "read",
+              });
+              const failed = results.find(
+                (result): result is PromiseRejectedResult =>
+                  result.status === "rejected",
+              );
+              if (failed) throw failed.reason;
+            })
+            .catch(showError);
+        }
+      }
+    } catch (error) {
+      if (generation !== loadGeneration.current) return;
+      showError(error);
+      try {
+        await notifyReaderWindowFailed({
+          accountId: nextSeed.target.accountId,
+        });
+      } catch (notificationError) {
+        showError(notificationError);
+      } finally {
+        await closeReaderWindow();
+      }
+    } finally {
+      if (generation === loadGeneration.current) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    document.title = "Dakia";
+    if (seed) void loadThread(seed);
+  }, [loadThread, seed]);
+
+  useEffect(() => {
+    let dispose: () => void = () => undefined;
+    let disposed = false;
+    void onReaderTarget((nextSeed) => setSeed(nextSeed)).then((unlisten) => {
+      if (disposed) unlisten();
+      else dispose = unlisten;
+    });
+    return () => {
+      disposed = true;
+      loadGeneration.current += 1;
+      dispose();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!AI_FEATURES_VISIBLE) return;
+    let current = true;
+    void readerApi
+      .aiAvailable(aiSettings)
+      .then((available) => current && setAiConnected(available))
+      .catch(() => current && setAiConnected(false));
+    return () => {
+      current = false;
+    };
+  }, [aiSettings]);
+
+  const messages = thread?.messages ?? [];
+  const focusedMessage =
+    messages.find((message) => message.id === seed?.focusedMessageId) ??
+    messages.at(-1);
+
+  const notifyMutation = useCallback(
+    async (
+      mutation: ReaderWindowMutation["mutation"],
+      messageIds: string[],
+    ) => {
+      if (!seed) return;
+      await notifyReaderWindowMutated({
+        accountId: seed.target.accountId,
+        threadId: seed.target.threadId,
+        messageIds,
+        mutation,
+      });
+    },
+    [seed],
+  );
+
+  const applyMailboxAction = async (
+    mutation: Extract<
+      ReaderWindowMutation["mutation"],
+      "archive" | "spam" | "not_spam" | "trash"
+    >,
+  ) => {
+    if (actionBusy || !thread) return;
+    const actionTargets = conversationActionMessages(
+      thread,
+      seed?.target.mailbox ?? "INBOX",
+      mutation as MailAction,
+    );
+    if (!actionTargets.length) return;
+    setActionBusy(true);
+    try {
+      const results = await Promise.allSettled(
+        actionTargets.map((message) =>
+          readerApi.action(
+            message.account_id,
+            message.mailbox,
+            message.uid,
+            mutation,
+          ),
+        ),
+      );
+      const succeeded = actionTargets.filter(
+        (_message, index) => results[index].status === "fulfilled",
+      );
+      if (succeeded.length)
+        await notifyMutation(
+          mutation,
+          succeeded.map((message) => message.id),
+        );
+      const failed = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (failed) {
+        if (seed) {
+          const refreshed = await readerApi.conversationForTarget(seed.target);
+          setThread(refreshed ?? undefined);
+        }
+        throw failed.reason;
+      }
+      await closeReaderWindow();
+    } catch (error) {
+      showError(error);
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const toggleRead = async (read: boolean) => {
+    if (actionBusy) return;
+    if (!thread) return;
+    const changes = concreteThreadMessages(thread).filter(
+      (message) => message.is_read !== read,
+    );
+    if (!changes.length) return;
+    setActionBusy(true);
+    try {
+      const results = await Promise.allSettled(
+        changes.map((message) => readerApi.setRead(message.id, read)),
+      );
+      const succeeded = changes.filter(
+        (_message, index) => results[index].status === "fulfilled",
+      );
+      setThread((current) =>
+        current
+          ? updateThread(current, (message) =>
+              succeeded.some((change) => change.id === message.id)
+                ? { ...message, is_read: read }
+                : message,
+            )
+          : current,
+      );
+      if (succeeded.length)
+        await notifyMutation(
+          "read",
+          succeeded.map((message) => message.id),
+        );
+      const failed = results.find(
+        (result): result is PromiseRejectedResult =>
+          result.status === "rejected",
+      );
+      if (failed) throw failed.reason;
+    } catch (error) {
+      showError(error);
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const permanentlyDelete = async (message: MailSummary) => {
+    if (actionBusy || !thread) return;
+    setActionBusy(true);
+    try {
+      await readerApi.action(
+        message.account_id,
+        message.mailbox,
+        message.uid,
+        "delete",
+      );
+      const remaining = removeConcreteMessage(thread, message);
+      setThread(remaining);
+      await notifyMutation("delete", [message.id]);
+      if (!remaining) await closeReaderWindow();
+    } catch (error) {
+      showError(error);
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const toggleStar = async (message: MailSummary, starred: boolean) => {
+    if (actionBusy) return;
+    setActionBusy(true);
+    try {
+      const updated = await readerApi.setStarred(message.id, starred);
+      setThread((current) =>
+        current
+          ? updateThread(current, (item) =>
+              item.id === message.id
+                ? { ...item, ...updated, is_flagged: starred }
+                : item,
+            )
+          : current,
+      );
+      await notifyMutation("star", [message.id]);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setActionBusy(false);
+    }
+  };
+
+  const summarize = async () => {
+    if (aiLoading || !messages.length) return;
+    setAiLoading(true);
+    try {
+      setAiResult(
+        await readerApi.summarize(
+          aiSettings,
+          messages.map((message) => message.id),
+        ),
+      );
+    } catch (error) {
+      showError(error, t("ai.error"));
+    } finally {
+      setAiLoading(false);
+    }
+  };
+
+  const reply = async (message: MailSummary, replyAll = false) => {
+    const recipientMessage =
+      accountEmail &&
+      message.from_address.toLowerCase() === accountEmail.toLowerCase()
+        ? ([...messages]
+            .reverse()
+            .find(
+              (item) =>
+                item.from_address.toLowerCase() !== accountEmail.toLowerCase(),
+            ) ?? message)
+        : message;
+    const recipients = replyRecipients(
+      recipientMessage,
+      accountEmail,
+      replyAll,
+    );
+    if (!recipients) return;
+    try {
+      const content = await readerApi.content(message.id);
+      const history = formatReplyHistory({
+        message,
+        bodyText: content.body_text,
+        formatCitation: ({ date, sender }) =>
+          t("reader.replyCitation", { date, sender }),
+      });
+      const prefix = t("reader.replyPrefix");
+      openComposeWindow({
+        accountId: message.account_id,
+        to: recipients.to,
+        ...(recipients.cc ? { cc: recipients.cc } : {}),
+        subject: message.subject.toLowerCase().startsWith(prefix.toLowerCase())
+          ? message.subject
+          : `${prefix} ${message.subject}`,
+        body: history.body,
+        bodyHtml: history.bodyHtml,
+        inReplyTo: message.message_id ?? undefined,
+        references: [message.reference_ids, message.message_id]
+          .filter(Boolean)
+          .join(" "),
+        contextMessageIds: messages.map((item) => item.id),
+      });
+    } catch (error) {
+      showError(error, t("reader.replyErrorTitle"));
+    }
+  };
+
+  const forward = async (message: MailSummary) => {
+    try {
+      const content = await readerApi.content(message.id);
+      openComposeWindow({
+        accountId: message.account_id,
+        subject: forwardSubject(message.subject, t("reader.forwardPrefix")),
+        body: forwardBody(message, content, {
+          originalMessage: t("reader.originalMessage"),
+          from: t("composer.from"),
+          date: t("reader.date"),
+          subject: t("composer.subject"),
+          to: t("composer.to"),
+        }),
+        forwardMessageId: content.attachments.some(
+          (attachment) => attachment.presentation !== "embedded",
+        )
+          ? message.id
+          : undefined,
+        contextMessageIds: [message.id],
+      });
+    } catch (error) {
+      showError(error, t("reader.forwardErrorTitle"));
+    }
+  };
+
+  const unsubscribe = async (message: MailSummary) => {
+    if (unsubscribeLoading) return;
+    setUnsubscribeLoading(true);
+    try {
+      await readerApi.unsubscribe(message.id);
+      await notifyMutation("unsubscribe", [message.id]);
+    } catch (error) {
+      showError(error);
+    } finally {
+      setUnsubscribeLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    let dispose: () => void = () => undefined;
+    let disposed = false;
+    void onNativeMenuAction((action) => {
+      if (!focusedMessage) return;
+      switch (action) {
+        case "reply":
+          void reply(focusedMessage);
+          break;
+        case "forward":
+          void forward(focusedMessage);
+          break;
+        case "archive":
+          void applyMailboxAction("archive");
+          break;
+        case "spam":
+          void applyMailboxAction(
+            focusedMessage.mailbox.split("::", 1)[0] === "Spam"
+              ? "not_spam"
+              : "spam",
+          );
+          break;
+      }
+    }).then((unlisten) => {
+      if (disposed) unlisten();
+      else dispose = unlisten;
+    });
+    return () => {
+      disposed = true;
+      dispose();
+    };
+  }, [focusedMessage, thread, actionBusy]);
+
+  if (loading)
+    return (
+      <main className="reader-window reader-window-loading">
+        <div className="reader-window-titlebar" data-tauri-drag-region />
+        <Loader size="sm" />
+      </main>
+    );
+
+  return (
+    <div className="reader-window">
+      <div className="reader-window-titlebar" data-tauri-drag-region />
+      <Reader
+        message={focusedMessage}
+        messages={messages}
+        focusedMessageId={focusedMessage?.id}
+        accountEmail={accountEmail}
+        aiResult={aiResult}
+        aiLoading={aiLoading}
+        aiConnected={aiConnected}
+        actionsDisabled={actionBusy}
+        onArchive={() => void applyMailboxAction("archive")}
+        onSpam={() =>
+          void applyMailboxAction(
+            focusedMessage?.mailbox.split("::", 1)[0] === "Spam"
+              ? "not_spam"
+              : "spam",
+          )
+        }
+        onTrash={() => void applyMailboxAction("trash")}
+        onPermanentDelete={permanentlyDelete}
+        onReply={(message) => void reply(message)}
+        onReplyAll={(message) => void reply(message, true)}
+        onForward={(message) => void forward(message)}
+        onToggleRead={(read) => void toggleRead(read)}
+        onSummarize={() => void summarize()}
+        onCopyAi={() =>
+          aiResult &&
+          navigator.clipboard
+            .writeText(aiResult)
+            .catch(() =>
+              showNativeMessage(
+                t("errors.generic"),
+                t("errors.copyFailed"),
+                "error",
+              ),
+            )
+        }
+        unsubscribeLoading={unsubscribeLoading}
+        onUnsubscribe={(message) => void unsubscribe(message)}
+        onToggleStar={(message, starred) => void toggleStar(message, starred)}
+      />
+    </div>
+  );
+
+  function showError(error: unknown, title = t("errors.generic")) {
+    void showNativeMessage(
+      title,
+      error instanceof Error ? error.message : String(error),
+      "error",
+    );
+  }
+}
+
+function updateThread(
+  thread: MailThread,
+  update: (message: MailSummary) => MailSummary,
+): MailThread {
+  return {
+    ...thread,
+    messages: thread.messages.map(update),
+    sourceMessages: thread.sourceMessages?.map(update),
+    latest: update(thread.latest),
+  };
+}
+
+function readAiSettings(): AiSettings {
+  try {
+    return {
+      ...defaultAi,
+      ...JSON.parse(window.localStorage.getItem("dakia.ai") ?? "{}"),
+    };
+  } catch {
+    return defaultAi;
+  }
+}

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -9,6 +9,7 @@ import type {
   MailRebuildProgress,
   MailCursor,
   MailSummary,
+  ConversationTarget,
   MessageContent,
   MailThread,
   MailThreadPage,
@@ -125,6 +126,8 @@ const desktopApi = {
         limit: 500,
       },
     }),
+  conversationForTarget: (target: ConversationTarget) =>
+    invoke<MailThread | null>("conversation_for_target", { target }),
   setCategory: (messageId: string, category: string) =>
     invoke<void>("set_message_category", { messageId, category }),
   setStarred: (messageId: string, starred: boolean) =>
@@ -153,6 +156,8 @@ const desktopApi = {
     body: string;
     accountId?: string;
     messageId?: string;
+    rfcMessageId?: string;
+    threadId?: string;
     count: number;
     sound?: string;
   }) => invoke<void>("send_desktop_notification", { notification }),
@@ -499,6 +504,34 @@ const demoApi: typeof desktopApi = {
           .includes(text.toLowerCase()),
     );
   },
+  conversationForTarget: async (target) => {
+    const exact = target.localMessageId
+      ? demoMessages.find(
+          (message) =>
+            message.account_id === target.accountId &&
+            message.id === target.localMessageId,
+        )
+      : undefined;
+    const rfc = target.rfcMessageId
+      ? demoMessages.find(
+          (message) =>
+            message.account_id === target.accountId &&
+            message.message_id?.toLowerCase() ===
+              target.rfcMessageId?.toLowerCase(),
+        )
+      : undefined;
+    const threadId = exact?.thread_id ?? rfc?.thread_id ?? target.threadId;
+    if (!threadId) return null;
+    return (
+      groupMessages(
+        demoMessages.filter(
+          (message) =>
+            message.account_id === target.accountId &&
+            message.thread_id === threadId,
+        ),
+      )[0] ?? null
+    );
+  },
   setCategory: async (messageId, category) => {
     const message = demoMessages.find((item) => item.id === messageId);
     if (message) {
@@ -629,4 +662,9 @@ const demoApi: typeof desktopApi = {
 
 const isTauri =
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
-export const api = isTauri || !import.meta.env.DEV ? desktopApi : demoApi;
+// Native UI verification can use the same fictional mailbox as browser
+// development without opening or mutating a developer's real local store.
+const useNativeDemoApi =
+  import.meta.env.DEV && import.meta.env.VITE_DAKIA_DEMO_API === "1";
+export const api =
+  (isTauri && !useNativeDemoApi) || !import.meta.env.DEV ? desktopApi : demoApi;

--- a/apps/desktop/src/components/MailList.test.tsx
+++ b/apps/desktop/src/components/MailList.test.tsx
@@ -47,6 +47,8 @@ function renderList(
       flagged: boolean,
     ) => void;
     onCategorize?: Parameters<typeof MailList>[0]["onCategorize"];
+    onOpen?: Parameters<typeof MailList>[0]["onOpen"];
+    onDoubleOpen?: Parameters<typeof MailList>[0]["onDoubleOpen"];
     aiConnected?: boolean;
   } = {},
 ) {
@@ -82,7 +84,8 @@ function renderList(
         onToggleReadThread={handlers.onToggleReadThread}
         onToggleStarThread={handlers.onToggleStarThread}
         onQuery={vi.fn()}
-        onOpen={vi.fn()}
+        onOpen={overrides.onOpen ?? vi.fn()}
+        onDoubleOpen={overrides.onDoubleOpen ?? vi.fn()}
         onSelect={vi.fn()}
         onSync={vi.fn()}
         onCompose={vi.fn()}
@@ -99,6 +102,39 @@ function renderList(
 }
 
 describe("MailList action feedback", () => {
+  it("keeps single-click selection and opens a dedicated reader on double-click", () => {
+    const onOpen = vi.fn();
+    const onDoubleOpen = vi.fn();
+    renderList({}, false, "Inbox", { onOpen, onDoubleOpen });
+
+    const row = screen.getByText("Subject 1").closest("button")!;
+    fireEvent.click(row);
+    fireEvent.doubleClick(row);
+
+    expect(onOpen).toHaveBeenCalled();
+    expect(onDoubleOpen).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "account:1" }),
+    );
+  });
+
+  it("does not double-open from the row selection control", () => {
+    const onDoubleOpen = vi.fn();
+    renderList({}, false, "Inbox", { onDoubleOpen });
+
+    fireEvent.doubleClick(screen.getAllByLabelText("Select")[0]);
+
+    expect(onDoubleOpen).not.toHaveBeenCalled();
+  });
+
+  it("does not double-open from the row star control", () => {
+    const onDoubleOpen = vi.fn();
+    renderList({}, false, "Inbox", { onDoubleOpen });
+
+    fireEvent.doubleClick(document.querySelector(".mail-star")!);
+
+    expect(onDoubleOpen).not.toHaveBeenCalled();
+  });
+
   it("keeps batch AI actions hidden even when a provider is connected", () => {
     renderList({}, false, "Inbox", { aiConnected: true });
 
@@ -142,6 +178,7 @@ describe("MailList action feedback", () => {
           onToggleStarThread={vi.fn()}
           onQuery={vi.fn()}
           onOpen={vi.fn()}
+          onDoubleOpen={vi.fn()}
           onSelect={vi.fn()}
           onSync={vi.fn()}
           onCompose={vi.fn()}
@@ -230,6 +267,7 @@ describe("MailList action feedback", () => {
           onToggleStarThread={vi.fn()}
           onQuery={vi.fn()}
           onOpen={vi.fn()}
+          onDoubleOpen={vi.fn()}
           onSelect={onSelect}
           onSync={vi.fn()}
           onCompose={vi.fn()}
@@ -328,6 +366,7 @@ describe("MailList action feedback", () => {
           onToggleStarThread={vi.fn()}
           onQuery={vi.fn()}
           onOpen={vi.fn()}
+          onDoubleOpen={vi.fn()}
           onSelect={vi.fn()}
           onSync={vi.fn()}
           onCompose={vi.fn()}
@@ -404,6 +443,7 @@ describe("MailList action feedback", () => {
           onToggleStarThread={vi.fn()}
           onQuery={vi.fn()}
           onOpen={vi.fn()}
+          onDoubleOpen={vi.fn()}
           onSelect={vi.fn()}
           onSync={vi.fn()}
           onCompose={vi.fn()}

--- a/apps/desktop/src/components/MailList.tsx
+++ b/apps/desktop/src/components/MailList.tsx
@@ -71,6 +71,7 @@ type Props = {
   exitingThreadIds?: Set<string>;
   onQuery: (value: string) => void;
   onOpen: (thread: MailThread) => void;
+  onDoubleOpen: (thread: MailThread) => void;
   onSelect: (ids: string[], checked: boolean) => void;
   onSync: () => void;
   onCompose: () => void;
@@ -115,6 +116,7 @@ export function MailList({
   exitingThreadIds = new Set(),
   onQuery,
   onOpen,
+  onDoubleOpen,
   onSelect,
   onSync,
   onCompose,
@@ -305,6 +307,7 @@ export function MailList({
             selected={selected}
             pendingActions={pendingActions}
             onOpen={onOpen}
+            onDoubleOpen={onDoubleOpen}
             onSelect={onSelect}
             onCategorize={onCategorize}
             onToggleStar={onToggleStar}
@@ -323,6 +326,7 @@ export function MailList({
             selected={selected}
             pendingActions={pendingActions}
             onOpen={onOpen}
+            onDoubleOpen={onDoubleOpen}
             onSelect={onSelect}
             onCategorize={onCategorize}
             onToggleStar={onToggleStar}
@@ -357,6 +361,7 @@ type RowsProps = Pick<
   | "selected"
   | "pendingActions"
   | "onOpen"
+  | "onDoubleOpen"
   | "onSelect"
   | "onCategorize"
   | "onToggleStar"
@@ -412,6 +417,7 @@ function ThreadRows({
   selected,
   pendingActions,
   onOpen,
+  onDoubleOpen,
   onSelect,
   onCategorize,
   onReplyThread,
@@ -587,6 +593,7 @@ function ThreadRows({
             }
             disabled={pending?.phase === "exiting"}
             onClick={() => onOpen(thread)}
+            onDoubleClick={() => onDoubleOpen(thread)}
             onContextMenu={(event) => {
               event.preventDefault();
               setContext({ thread, x: event.clientX, y: event.clientY });
@@ -595,6 +602,7 @@ function ThreadRows({
             <span
               className="mail-check"
               onClick={(event) => event.stopPropagation()}
+              onDoubleClick={(event) => event.stopPropagation()}
             >
               <Checkbox
                 size="xs"
@@ -642,6 +650,7 @@ function ThreadRows({
                     : "actions.star",
                 )}
                 data-active={sourceMessages.some((item) => item.is_flagged)}
+                onDoubleClick={(event) => event.stopPropagation()}
                 onClick={(event) => {
                   event.stopPropagation();
                   onToggleStarThread(

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -736,6 +736,45 @@ describe("Reader unsubscribe action", () => {
     expect(api.content).toHaveBeenLastCalledWith(nextLatest.id);
   });
 
+  it("opens a dedicated reader on the explicitly focused thread message", async () => {
+    const earlier = {
+      ...message,
+      id: "focused-earlier",
+      from_name: "Earlier Sender",
+      received_at: "2026-07-19T09:00:00Z",
+    };
+    const latest = {
+      ...message,
+      id: "unfocused-latest",
+      uid: 2,
+      from_name: "Latest Sender",
+      received_at: "2026-07-19T11:00:00Z",
+    };
+    vi.mocked(api.content).mockImplementation(async (id) => ({
+      body_text: id === earlier.id ? "Focused body" : "Latest body",
+      attachments: [],
+    }));
+
+    render(
+      <MantineProvider>
+        <Reader
+          {...props}
+          message={earlier}
+          messages={[earlier, latest]}
+          focusedMessageId={earlier.id}
+        />
+      </MantineProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", {
+        name: "Collapse message from Earlier Sender",
+      }),
+    ).toHaveAttribute("aria-expanded", "true");
+    expect(await screen.findByText("Focused body")).toBeVisible();
+    expect(api.content).not.toHaveBeenCalledWith(latest.id);
+  });
+
   it("keeps the selected expanded message open when a newer message arrives", async () => {
     const earlier = {
       ...message,

--- a/apps/desktop/src/components/Reader.tsx
+++ b/apps/desktop/src/components/Reader.tsx
@@ -64,6 +64,7 @@ function usesMacDeleteKey() {
 type Props = {
   message?: MailSummary;
   messages?: MailSummary[];
+  focusedMessageId?: string;
   accountEmail?: string;
   aiResult?: string;
   aiLoading: boolean;
@@ -87,6 +88,7 @@ type Props = {
 export function Reader({
   message,
   messages,
+  focusedMessageId,
   accountEmail,
   aiResult,
   aiLoading,
@@ -130,6 +132,11 @@ export function Reader({
     [message, messages],
   );
   const latestMessage = threadMessages.at(-1);
+  const requestedMessageId = threadMessages.some(
+    (threadMessage) => threadMessage.id === focusedMessageId,
+  )
+    ? focusedMessageId
+    : latestMessage?.id;
   const threadKey = latestMessage
     ? `${latestMessage.account_id}:${latestMessage.thread_id || latestMessage.id}`
     : message
@@ -138,14 +145,14 @@ export function Reader({
   const [expandedMessage, setExpandedMessage] = useState<{
     threadKey?: string;
     id?: string;
-  }>(() => ({ threadKey, id: latestMessage?.id }));
+  }>(() => ({ threadKey, id: requestedMessageId }));
   // Render the final chronological message immediately when a new conversation
   // arrives. Keeping the chosen ID in state means later mailbox updates do not
   // interrupt someone reading an earlier message.
   const expandedMessageId =
     expandedMessage?.threadKey === threadKey
       ? expandedMessage?.id
-      : latestMessage?.id;
+      : requestedMessageId;
   const expandedMessageSummary = threadMessages.find(
     (threadMessage) => threadMessage.id === expandedMessageId,
   );
@@ -198,12 +205,14 @@ export function Reader({
   }
   useHotkeys(permanentDeleteHotkeys);
   useEffect(() => {
-    setExpandedMessage((current) =>
-      current.threadKey === threadKey
-        ? current
-        : { threadKey, id: latestMessage?.id },
-    );
-  }, [threadKey]);
+    setExpandedMessage((current) => {
+      if (current.threadKey !== threadKey)
+        return { threadKey, id: requestedMessageId };
+      if (focusedMessageId && current.id !== requestedMessageId)
+        return { threadKey, id: requestedMessageId };
+      return current;
+    });
+  }, [focusedMessageId, requestedMessageId, threadKey]);
   const previousThreadMessages = useRef(threadMessages);
   useEffect(() => {
     setExpandedMessage((current) => {

--- a/apps/desktop/src/nativeWindows.ts
+++ b/apps/desktop/src/nativeWindows.ts
@@ -11,6 +11,7 @@ import type {
   MailHydrated,
   MailRebuildProgress,
   NotificationSettings,
+  NotificationAction,
   RealtimeSyncStatus,
 } from "./types";
 
@@ -161,21 +162,11 @@ export function onNotificationSettingsChanged(
 }
 
 export function onDesktopNotificationAction(
-  handler: (notification: {
-    accountId?: string;
-    messageId?: string;
-    count: number;
-  }) => void,
+  handler: (notification: NotificationAction) => void,
 ): Promise<UnlistenFn> {
   if (!isTauri()) return Promise.resolve(() => undefined);
   return listen("notification-action", (event) =>
-    handler(
-      event.payload as {
-        accountId?: string;
-        messageId?: string;
-        count: number;
-      },
-    ),
+    handler(event.payload as NotificationAction),
   );
 }
 

--- a/apps/desktop/src/notifications.test.ts
+++ b/apps/desktop/src/notifications.test.ts
@@ -29,9 +29,22 @@ const message = (id: string): MailSummary => ({
 
 describe("new-mail notification copy", () => {
   it("shows the sender and subject for one message", () => {
-    expect(buildNewMailNotification([message("1")], true, copy)).toMatchObject({
+    expect(
+      buildNewMailNotification(
+        [{ ...message("1"), message_id: "<message-1@example.com>" }],
+        true,
+        copy,
+      ),
+    ).toMatchObject({
       title: "Mara",
       body: "Subject 1",
+      extra: {
+        accountId: "account",
+        messageId: "1",
+        rfcMessageId: "<message-1@example.com>",
+        threadId: "1",
+        count: 1,
+      },
     });
   });
 
@@ -44,6 +57,10 @@ describe("new-mail notification copy", () => {
   it("batches several messages into one summary", () => {
     expect(
       buildNewMailNotification([message("1"), message("2")], true, copy),
-    ).toMatchObject({ title: "2 new emails", body: "2 messages arrived" });
+    ).toEqual({
+      title: "2 new emails",
+      body: "2 messages arrived",
+      extra: { count: 2 },
+    });
   });
 });

--- a/apps/desktop/src/notifications.ts
+++ b/apps/desktop/src/notifications.ts
@@ -79,6 +79,8 @@ export function buildNewMailNotification(
       extra: {
         accountId: message.account_id,
         messageId: message.id,
+        rfcMessageId: message.message_id ?? undefined,
+        threadId: message.thread_id,
         count: 1,
       },
     };
@@ -118,6 +120,14 @@ export async function sendNewMailNotification(
       messageId:
         typeof notification.extra.messageId === "string"
           ? notification.extra.messageId
+          : undefined,
+      rfcMessageId:
+        typeof notification.extra.rfcMessageId === "string"
+          ? notification.extra.rfcMessageId
+          : undefined,
+      threadId:
+        typeof notification.extra.threadId === "string"
+          ? notification.extra.threadId
           : undefined,
       count: notification.extra.count,
       sound: settings.soundEnabled ? notificationSound() : undefined,

--- a/apps/desktop/src/readerWindow.test.ts
+++ b/apps/desktop/src/readerWindow.test.ts
@@ -1,0 +1,185 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const eventMocks = vi.hoisted(() => ({ emitTo: vi.fn(), listen: vi.fn() }));
+const windowMocks = vi.hoisted(() => ({ getCurrentWindow: vi.fn() }));
+const webviewMocks = vi.hoisted(() => ({
+  getAllWebviewWindows: vi.fn(),
+  WebviewWindow: vi.fn(),
+}));
+const readerSeeds = new Map<string, string>();
+const readerSeedStorage = {
+  getItem: (key: string) => readerSeeds.get(key) ?? null,
+  setItem: (key: string, value: string) => readerSeeds.set(key, value),
+  removeItem: (key: string) => readerSeeds.delete(key),
+  clear: () => readerSeeds.clear(),
+};
+
+vi.mock("@tauri-apps/api/event", () => eventMocks);
+vi.mock("@tauri-apps/api/window", () => windowMocks);
+vi.mock("@tauri-apps/api/webviewWindow", () => webviewMocks);
+
+describe("reader window infrastructure", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    readerSeedStorage.clear();
+    window.sessionStorage.clear();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: readerSeedStorage,
+    });
+    window.history.replaceState({}, "", "/");
+    delete (window as Window & { __TAURI_INTERNALS__?: unknown })
+      .__TAURI_INTERNALS__;
+    Object.defineProperty(window, "open", {
+      configurable: true,
+      writable: true,
+      value: vi.fn(() => ({}) as Window),
+    });
+  });
+
+  it("uses a deterministic label-safe hash without identifiers", async () => {
+    const { readerWindowLabel } = await import("./readerWindow");
+    const target = {
+      accountId: "account/alex@example.com",
+      threadId: "<conversations/123> with spaces",
+    };
+
+    const label = await readerWindowLabel(target);
+    expect(label).toBe(await readerWindowLabel(target));
+    expect(label).toMatch(/^reader-[a-f0-9]{32}$/);
+    expect(label).not.toContain("alex");
+  });
+
+  it("uses an opaque localStorage token for browser reader targets", async () => {
+    const { openReaderWindow } = await import("./readerWindow");
+
+    await openReaderWindow({
+      target: {
+        accountId: "account-1",
+        threadId: "thread-secret",
+        localMessageId: "message-secret",
+      },
+      focusedMessageId: "message-secret",
+    });
+
+    expect(window.open).toHaveBeenCalledOnce();
+    const [url, label] = vi.mocked(window.open).mock.calls[0];
+    const params = new URL(String(url), "http://localhost").searchParams;
+    const token = params.get("seedKey");
+    expect(params.get("view")).toBe("reader");
+    expect(token).toBeTruthy();
+    expect(String(url)).not.toContain("thread-secret");
+    expect(String(label)).toMatch(/^reader-[a-f0-9]{32}$/);
+    expect(readerSeedStorage.getItem(`dakia.reader-seed.${token}`)).toContain(
+      "thread-secret",
+    );
+  });
+
+  it("consumes the handoff seed once and preserves it for window reloads", async () => {
+    const token = "reader-seed";
+    readerSeedStorage.setItem(
+      `dakia.reader-seed.${token}`,
+      JSON.stringify({
+        target: { accountId: "account-1", threadId: "thread-1" },
+        focusedMessageId: "message-3",
+      }),
+    );
+    window.history.replaceState({}, "", `/?view=reader&seedKey=${token}`);
+    const { readReaderSeed } = await import("./readerWindow");
+
+    expect(readReaderSeed()).toEqual({
+      target: { accountId: "account-1", threadId: "thread-1" },
+      focusedMessageId: "message-3",
+    });
+    expect(readReaderSeed()).toEqual({
+      target: { accountId: "account-1", threadId: "thread-1" },
+      focusedMessageId: "message-3",
+    });
+  });
+
+  it("focuses and retargets an existing conversation window", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ =
+      {};
+    const existing = {
+      label: "reader-9128d2de",
+      show: vi.fn(),
+      setFocus: vi.fn(),
+    };
+    webviewMocks.getAllWebviewWindows.mockResolvedValue([existing]);
+    const { openReaderWindow, readerWindowLabel } =
+      await import("./readerWindow");
+    const seed = {
+      target: { accountId: "account-1", threadId: "thread-1" },
+      focusedMessageId: "message-2",
+    };
+    existing.label = await readerWindowLabel(seed.target);
+
+    await openReaderWindow(seed);
+
+    expect(existing.show).toHaveBeenCalledOnce();
+    expect(existing.setFocus).toHaveBeenCalledOnce();
+    expect(eventMocks.emitTo).toHaveBeenCalledWith(
+      existing.label,
+      "reader-target",
+      seed,
+    );
+    expect(webviewMocks.WebviewWindow).not.toHaveBeenCalled();
+  });
+
+  it("rejects when native reader-window creation fails", async () => {
+    (window as Window & { __TAURI_INTERNALS__?: unknown }).__TAURI_INTERNALS__ =
+      {};
+    webviewMocks.getAllWebviewWindows.mockResolvedValue([]);
+    webviewMocks.WebviewWindow.mockImplementation(function () {
+      return {
+        once: (
+          event: string,
+          handler: (payload: { payload: string }) => void,
+        ) => {
+          if (event === "tauri://error")
+            queueMicrotask(() => handler({ payload: "denied" }));
+        },
+      };
+    });
+    const { openReaderWindow } = await import("./readerWindow");
+
+    await expect(
+      openReaderWindow({
+        target: { accountId: "account-1", threadId: "thread-1" },
+      }),
+    ).rejects.toThrow("Could not open reader window: denied");
+    expect(readerSeeds.size).toBe(0);
+  });
+
+  it("rejects when an opaque reader seed cannot be stored", async () => {
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        ...readerSeedStorage,
+        setItem: () => {
+          throw new Error("storage denied");
+        },
+      },
+    });
+    const { openReaderWindow } = await import("./readerWindow");
+
+    await expect(
+      openReaderWindow({
+        target: { accountId: "account-1", threadId: "thread-1" },
+      }),
+    ).rejects.toThrow("Could not create reader window seed");
+  });
+
+  it("rejects and removes its seed when a browser blocks the popup", async () => {
+    vi.mocked(window.open).mockReturnValueOnce(null);
+    const { openReaderWindow } = await import("./readerWindow");
+
+    await expect(
+      openReaderWindow({
+        target: { accountId: "account-1", threadId: "thread-1" },
+      }),
+    ).rejects.toThrow("Could not open reader window");
+    expect(readerSeeds.size).toBe(0);
+  });
+});

--- a/apps/desktop/src/readerWindow.ts
+++ b/apps/desktop/src/readerWindow.ts
@@ -1,0 +1,216 @@
+import { emitTo, listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow } from "@tauri-apps/api/window";
+import {
+  getAllWebviewWindows,
+  WebviewWindow,
+} from "@tauri-apps/api/webviewWindow";
+import type { ConversationTarget } from "./types";
+
+export type { ConversationTarget } from "./types";
+
+export type ReaderWindowSeed = {
+  target: ConversationTarget;
+  focusedMessageId?: string;
+};
+
+export type ReaderWindowMutation = {
+  accountId: string;
+  threadId?: string;
+  messageIds: string[];
+  mutation:
+    | "archive"
+    | "spam"
+    | "not_spam"
+    | "trash"
+    | "delete"
+    | "read"
+    | "star"
+    | "unsubscribe";
+};
+export type ReaderWindowFailure = { accountId: string };
+
+const readerSeedStoragePrefix = "dakia.reader-seed.";
+const activeReaderSeedKey = "dakia.reader-active-seed";
+
+const isTauri = () => "__TAURI_INTERNALS__" in window;
+
+/**
+ * A label is intentionally derived only from a stable, non-PII digest. Tauri
+ * labels are restrictive, while account/thread identifiers are not.
+ */
+export async function readerWindowLabel(target: ConversationTarget) {
+  const identity = `${target.accountId}\u0000${target.threadId ?? target.localMessageId ?? target.rfcMessageId ?? ""}`;
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(identity),
+  );
+  const hash = [...new Uint8Array(digest)]
+    .slice(0, 16)
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+  return `reader-${hash}`;
+}
+
+function storeReaderSeed(seed: ReaderWindowSeed) {
+  try {
+    const token = crypto.randomUUID();
+    window.localStorage.setItem(
+      `${readerSeedStoragePrefix}${token}`,
+      JSON.stringify(seed),
+    );
+    return token;
+  } catch {
+    return undefined;
+  }
+}
+
+export function readReaderSeed(): ReaderWindowSeed | undefined {
+  const token = new URLSearchParams(window.location.search).get("seedKey");
+  try {
+    const key = token ? `${readerSeedStoragePrefix}${token}` : undefined;
+    const value =
+      (key ? window.localStorage.getItem(key) : null) ??
+      window.sessionStorage.getItem(activeReaderSeedKey);
+    if (key) window.localStorage.removeItem(key);
+    if (!value) return undefined;
+    const seed = JSON.parse(value) as Partial<ReaderWindowSeed>;
+    if (!isConversationTarget(seed.target)) return undefined;
+    const validSeed = {
+      target: seed.target,
+      focusedMessageId:
+        typeof seed.focusedMessageId === "string"
+          ? seed.focusedMessageId
+          : undefined,
+    };
+    window.sessionStorage.setItem(
+      activeReaderSeedKey,
+      JSON.stringify(validSeed),
+    );
+    return validSeed;
+  } catch {
+    return undefined;
+  }
+}
+
+function isConversationTarget(value: unknown): value is ConversationTarget {
+  if (!value || typeof value !== "object") return false;
+  const target = value as Partial<ConversationTarget>;
+  return Boolean(
+    typeof target.accountId === "string" &&
+    target.accountId &&
+    (typeof target.threadId === "string" ||
+      typeof target.localMessageId === "string" ||
+      typeof target.rfcMessageId === "string"),
+  );
+}
+
+export async function openReaderWindow(seed: ReaderWindowSeed): Promise<void> {
+  const label = await readerWindowLabel(seed.target);
+  if (!isTauri()) {
+    const token = storeReaderSeed(seed);
+    if (!token) throw new Error("Could not create reader window seed");
+    const opened = window.open(
+      `/?${new URLSearchParams({ view: "reader", seedKey: token }).toString()}`,
+      label,
+      "popup=yes,width=980,height=760,resizable=yes,scrollbars=no",
+    );
+    if (!opened) {
+      window.localStorage.removeItem(`${readerSeedStoragePrefix}${token}`);
+      throw new Error("Could not open reader window");
+    }
+    return;
+  }
+
+  const existing = (await getAllWebviewWindows()).find(
+    (candidate) => candidate.label === label,
+  );
+  if (existing) {
+    await existing.show();
+    await existing.setFocus();
+    await emitTo(label, "reader-target", seed);
+    return;
+  }
+
+  const token = storeReaderSeed(seed);
+  if (!token) throw new Error("Could not create reader window seed");
+  await new Promise<void>((resolve, reject) => {
+    const readerWindow = new WebviewWindow(label, {
+      url: `/?${new URLSearchParams({ view: "reader", seedKey: token }).toString()}`,
+      title: "Dakia",
+      width: 980,
+      height: 760,
+      minWidth: 600,
+      minHeight: 480,
+      center: true,
+      focus: true,
+      resizable: true,
+      decorations: true,
+      shadow: true,
+      titleBarStyle: "overlay",
+      hiddenTitle: true,
+    });
+    readerWindow.once("tauri://created", () => resolve());
+    readerWindow.once("tauri://error", (event) => {
+      window.localStorage.removeItem(`${readerSeedStoragePrefix}${token}`);
+      reject(
+        new Error(`Could not open reader window: ${String(event.payload)}`),
+      );
+    });
+  });
+}
+
+export function onReaderTarget(
+  handler: (seed: ReaderWindowSeed) => void,
+): Promise<UnlistenFn> {
+  if (!isTauri()) return Promise.resolve(() => undefined);
+  return listen<ReaderWindowSeed>("reader-target", (event) => {
+    if (isConversationTarget(event.payload.target)) {
+      window.sessionStorage.setItem(
+        activeReaderSeedKey,
+        JSON.stringify(event.payload),
+      );
+      handler(event.payload);
+    }
+  });
+}
+
+export async function notifyReaderWindowMutated(
+  mutation: ReaderWindowMutation,
+) {
+  if (!isTauri()) return;
+  try {
+    await emitTo("main", "reader-window-mutated", mutation);
+  } catch (error) {
+    // The mailbox mutation has already succeeded; a closing main window must
+    // not turn it into a reader-window failure.
+    console.warn("Could not refresh the main mailbox window", error);
+  }
+}
+
+export function onReaderWindowMutated(
+  handler: (mutation: ReaderWindowMutation) => void,
+): Promise<UnlistenFn> {
+  if (!isTauri()) return Promise.resolve(() => undefined);
+  return listen<ReaderWindowMutation>("reader-window-mutated", (event) =>
+    handler(event.payload),
+  );
+}
+
+export async function notifyReaderWindowFailed(failure: ReaderWindowFailure) {
+  if (!isTauri()) return;
+  await emitTo("main", "reader-window-failed", failure);
+}
+
+export function onReaderWindowFailed(
+  handler: (failure: ReaderWindowFailure) => void,
+): Promise<UnlistenFn> {
+  if (!isTauri()) return Promise.resolve(() => undefined);
+  return listen<ReaderWindowFailure>("reader-window-failed", (event) =>
+    handler(event.payload),
+  );
+}
+
+export async function closeReaderWindow() {
+  if (isTauri()) await getCurrentWindow().close();
+  else window.close();
+}

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -801,6 +801,25 @@ textarea {
   display: flex;
   flex-direction: column;
 }
+.reader-window {
+  height: 100dvh;
+  min-height: 0;
+  background: var(--dakia-paper);
+  position: relative;
+}
+.reader-window-titlebar {
+  position: absolute;
+  z-index: 20;
+  inset: 0 0 auto 72px;
+  height: 26px;
+}
+.reader-window .reader {
+  height: 100%;
+}
+.reader-window-loading {
+  display: grid;
+  place-items: center;
+}
 .reader-toolbar {
   min-height: 54px;
   padding: 26px 10px 0;

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -87,6 +87,20 @@ export type MailThreadPage = {
   conversations: MailThread[];
   nextCursor: MailCursor | null;
 };
+export type ConversationTarget = {
+  accountId: string;
+  localMessageId?: string;
+  rfcMessageId?: string;
+  threadId?: string;
+  mailbox?: string;
+};
+export type NotificationAction = {
+  accountId?: string;
+  messageId?: string;
+  rfcMessageId?: string;
+  threadId?: string;
+  count: number;
+};
 export type SmartSectionId = "starred" | MailCategory | "seen";
 export type SmartSection = {
   id: SmartSectionId;

--- a/apps/desktop/testdata/tauri-contract-origins.json
+++ b/apps/desktop/testdata/tauri-contract-origins.json
@@ -18,6 +18,9 @@
     "notification-action": "native",
     "notification-settings-changed": "frontend",
     "outbox-changed": "frontend",
+    "reader-target": "frontend",
+    "reader-window-failed": "frontend",
+    "reader-window-mutated": "frontend",
     "select-account": "frontend",
     "settings-changed": "frontend"
   }

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -321,6 +321,23 @@ pub struct SearchQuery {
     pub cursor: Option<MailCursor>,
 }
 
+/// A durable conversation locator for surfaces that can outlive a concrete
+/// mailbox/UID move. Resolution deliberately remains account-scoped and
+/// fail-closed when a logical RFC Message-ID appears in multiple threads.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ConversationTarget {
+    pub account_id: AccountId,
+    #[serde(default)]
+    pub local_message_id: Option<String>,
+    #[serde(default)]
+    pub rfc_message_id: Option<String>,
+    #[serde(default)]
+    pub thread_id: Option<String>,
+    #[serde(default)]
+    pub mailbox: Option<String>,
+}
+
 #[derive(FromRow)]
 struct LegacyAccountRow {
     id: String,
@@ -2540,6 +2557,140 @@ impl Store {
         Ok(self.search_conversation_page(query).await?.conversations)
     }
 
+    /// Resolves a notification or deep-link target without applying list
+    /// pagination. A concrete local ID wins while it remains valid; a moved
+    /// message can fall back to its RFC Message-ID, then its supplied thread
+    /// ID. A local ID found under another account, or an RFC Message-ID that
+    /// spans multiple threads, is never allowed to select a conversation.
+    pub async fn conversation_for_target(
+        &self,
+        target: &ConversationTarget,
+    ) -> Result<Option<MailConversation>> {
+        let account_id = target.account_id.to_string();
+        if let Some(local_message_id) = target
+            .local_message_id
+            .as_deref()
+            .filter(|message_id| !message_id.trim().is_empty())
+        {
+            if let Some(message) = self.message(local_message_id).await? {
+                if message.account_id != account_id || !target_allows_mailbox(&message, target) {
+                    return Ok(None);
+                }
+                let rfc_matches = target
+                    .rfc_message_id
+                    .as_deref()
+                    .and_then(normalize_message_id)
+                    .map_or(true, |expected| {
+                        message
+                            .message_id
+                            .as_deref()
+                            .and_then(normalize_message_id)
+                            .as_deref()
+                            == Some(expected.as_str())
+                    });
+                let thread_matches = target
+                    .thread_id
+                    .as_deref()
+                    .filter(|thread_id| !thread_id.trim().is_empty())
+                    .map_or(true, |thread_id| message.thread_id == thread_id);
+                if rfc_matches && thread_matches {
+                    return self
+                        .complete_conversation(
+                            &message.account_id,
+                            &message.thread_id,
+                            target.mailbox.as_deref(),
+                        )
+                        .await;
+                }
+            }
+        }
+
+        if let Some(rfc_message_id) = target
+            .rfc_message_id
+            .as_deref()
+            .and_then(normalize_message_id)
+        {
+            let candidates = sqlx::query_as::<_, MailSummary>("SELECT id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals FROM messages WHERE account_id = ? AND LOWER(TRIM(message_id)) = ?")
+                .bind(&account_id)
+                .bind(format!("<{rfc_message_id}>"))
+                .fetch_all(&self.pool)
+                .await?;
+            let thread_ids = candidates
+                .into_iter()
+                .filter(|message| target_allows_mailbox(message, target))
+                .filter(|message| {
+                    message
+                        .message_id
+                        .as_deref()
+                        .and_then(normalize_message_id)
+                        .as_deref()
+                        == Some(rfc_message_id.as_str())
+                })
+                .map(|message| message.thread_id)
+                .collect::<HashSet<_>>();
+            match thread_ids.len() {
+                0 => {}
+                1 => {
+                    let thread_id = thread_ids
+                        .into_iter()
+                        .next()
+                        .expect("one RFC Message-ID match has one thread");
+                    return self
+                        .complete_conversation(&account_id, &thread_id, target.mailbox.as_deref())
+                        .await;
+                }
+                _ => return Ok(None),
+            }
+        }
+
+        if let Some(thread_id) = target
+            .thread_id
+            .as_deref()
+            .filter(|thread_id| !thread_id.trim().is_empty())
+        {
+            let exists = sqlx::query_as::<_, MailSummary>("SELECT id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals FROM messages WHERE account_id = ? AND thread_id = ? ORDER BY received_at, id")
+                .bind(&account_id)
+                .bind(thread_id)
+                .fetch_all(&self.pool)
+                .await?
+                .into_iter()
+                .any(|message| target_allows_mailbox(&message, target));
+            if exists {
+                return self
+                    .complete_conversation(&account_id, thread_id, target.mailbox.as_deref())
+                    .await;
+            }
+        }
+
+        Ok(None)
+    }
+
+    async fn complete_conversation(
+        &self,
+        account_id: &str,
+        thread_id: &str,
+        mailbox: Option<&str>,
+    ) -> Result<Option<MailConversation>> {
+        let mut source_messages = sqlx::query_as::<_, MailSummary>("SELECT id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, '' AS body_text, NULL AS body_html, content_state, unsubscribe_kind, unsubscribe_url, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, '' AS classification_signals FROM messages WHERE account_id = ? AND thread_id = ? ORDER BY received_at, id")
+            .bind(account_id)
+            .bind(thread_id)
+            .fetch_all(&self.pool)
+            .await?;
+        if mailbox.is_some_and(|mailbox| matches!(mailbox_family(mailbox), "Spam" | "Trash")) {
+            let mailbox = mailbox_family(mailbox.unwrap_or_default());
+            source_messages.retain(|message| mailbox_family(&message.mailbox) == mailbox);
+        } else {
+            source_messages
+                .retain(|message| !matches!(mailbox_family(&message.mailbox), "Spam" | "Trash"));
+        }
+        Ok(mail_conversation_from_sources(
+            account_id.to_owned(),
+            thread_id.to_owned(),
+            source_messages,
+            mailbox,
+        ))
+    }
+
     /// Returns a page of matching conversations. The cursor addresses the
     /// newest matching message for each conversation, not its hydrated
     /// account-wide members, so a thread can never reappear on a later page.
@@ -2615,38 +2766,12 @@ impl Store {
         let conversations = grouped
             .into_iter()
             .filter_map(|((account_id, thread_id), source_messages)| {
-                // Keep every durable locator for mutation fan-out. `messages`
-                // below is only the mailbox-preferred reader/list projection,
-                // so it may intentionally collapse logical Message-ID copies.
-                let messages =
-                    deduplicate_message_copies(source_messages.clone(), query.mailbox.as_deref());
-                let latest = messages.last()?.clone();
-                let mut participants = source_messages
-                    .iter()
-                    .map(|message| {
-                        message
-                            .from_name
-                            .clone()
-                            .unwrap_or_else(|| message.from_address.clone())
-                    })
-                    .collect::<HashSet<_>>()
-                    .into_iter()
-                    .collect::<Vec<_>>();
-                participants.sort();
-                Some(MailConversation {
-                    id: format!("{account_id}:{thread_id}"),
+                mail_conversation_from_sources(
                     account_id,
                     thread_id,
-                    message_count: messages.len(),
-                    unread: source_messages.iter().any(|message| !message.is_read),
-                    has_attachments: source_messages
-                        .iter()
-                        .any(|message| message.has_attachments),
-                    participants,
-                    latest,
-                    messages,
                     source_messages,
-                })
+                    query.mailbox.as_deref(),
+                )
             })
             .collect::<Vec<_>>();
         let conversations = conversations
@@ -3034,6 +3159,54 @@ impl Store {
         tx.commit().await?;
         Ok(())
     }
+}
+
+fn target_allows_mailbox(message: &MailSummary, target: &ConversationTarget) -> bool {
+    match target.mailbox.as_deref() {
+        Some(mailbox) if matches!(mailbox_family(mailbox), "Spam" | "Trash") => {
+            mailbox_family(&message.mailbox) == mailbox_family(mailbox)
+        }
+        Some(_) | None => !matches!(mailbox_family(&message.mailbox), "Spam" | "Trash"),
+    }
+}
+
+fn mail_conversation_from_sources(
+    account_id: String,
+    thread_id: String,
+    source_messages: Vec<MailSummary>,
+    preferred_mailbox: Option<&str>,
+) -> Option<MailConversation> {
+    // Keep every durable locator for mutation fan-out. `messages` below is
+    // only the mailbox-preferred reader/list projection, so it may
+    // intentionally collapse logical Message-ID copies.
+    let messages = deduplicate_message_copies(source_messages.clone(), preferred_mailbox);
+    let latest = messages.last()?.clone();
+    let mut participants = source_messages
+        .iter()
+        .map(|message| {
+            message
+                .from_name
+                .clone()
+                .unwrap_or_else(|| message.from_address.clone())
+        })
+        .collect::<HashSet<_>>()
+        .into_iter()
+        .collect::<Vec<_>>();
+    participants.sort();
+    Some(MailConversation {
+        id: format!("{account_id}:{thread_id}"),
+        account_id,
+        thread_id,
+        message_count: messages.len(),
+        unread: source_messages.iter().any(|message| !message.is_read),
+        has_attachments: source_messages
+            .iter()
+            .any(|message| message.has_attachments),
+        participants,
+        latest,
+        messages,
+        source_messages,
+    })
 }
 
 fn deduplicate_message_copies(
@@ -6300,6 +6473,233 @@ mod tests {
         assert_eq!(conversations[0].messages[0].id, "inbox-copy");
         let serialized = serde_json::to_value(&conversations[0]).unwrap();
         assert_eq!(serialized["sourceMessages"].as_array().unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn conversation_target_falls_back_after_a_move_and_keeps_copy_locators() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let mut inbox = message("Topic", "Inbox copy");
+        inbox.id = "inbox-copy".into();
+        inbox.account_id = account_id.to_string();
+        inbox.message_id = Some("<root@example.test>".into());
+        let mut archive = inbox.clone();
+        archive.id = "archive-copy".into();
+        archive.mailbox = "Archive".into();
+        archive.uid = 2;
+        let mut reply = message("Re: Topic", "Reply");
+        reply.id = "reply".into();
+        reply.account_id = account_id.to_string();
+        reply.uid = 3;
+        reply.message_id = Some("<reply@example.test>".into());
+        reply.in_reply_to = Some("<root@example.test>".into());
+        store
+            .upsert_messages(&[inbox, archive, reply])
+            .await
+            .unwrap();
+        let newer_threads = (0..120)
+            .map(|index| {
+                let mut newer = message("Newer", "Unrelated conversation");
+                newer.id = format!("newer-{index}");
+                newer.account_id = account_id.to_string();
+                newer.uid = 100 + index;
+                newer.message_id = Some(format!("<newer-{index}@example.test>"));
+                newer.thread_id = format!("newer-thread-{index}");
+                newer.received_at += chrono::Duration::minutes(i64::from(index + 1));
+                newer
+            })
+            .collect::<Vec<_>>();
+        store.upsert_messages(&newer_threads).await.unwrap();
+
+        let by_local = store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: Some("inbox-copy".into()),
+                rfc_message_id: None,
+                thread_id: None,
+                mailbox: Some("INBOX".into()),
+            })
+            .await
+            .unwrap()
+            .expect("local target resolves");
+        assert_eq!(by_local.messages.len(), 2);
+        assert_eq!(by_local.source_messages.len(), 3);
+        assert!(by_local
+            .source_messages
+            .iter()
+            .any(|message| message.id == "archive-copy"));
+
+        sqlx::query("DELETE FROM messages WHERE id = 'inbox-copy'")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let by_rfc = store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: Some("stale-local-id-after-move".into()),
+                rfc_message_id: Some(" <ROOT@EXAMPLE.TEST> ".into()),
+                thread_id: None,
+                mailbox: Some("INBOX".into()),
+            })
+            .await
+            .unwrap()
+            .expect("RFC Message-ID fallback resolves");
+        assert_eq!(by_rfc.id, by_local.id);
+        assert_eq!(by_rfc.source_messages.len(), 2);
+
+        let by_thread = store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: None,
+                rfc_message_id: None,
+                thread_id: Some(by_local.thread_id.clone()),
+                mailbox: Some("INBOX".into()),
+            })
+            .await
+            .unwrap()
+            .expect("thread fallback resolves");
+        assert_eq!(by_thread.id, by_local.id);
+    }
+
+    #[tokio::test]
+    async fn conversation_target_rejects_mismatches_and_ambiguous_rfc_ids() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let other_account_id = uuid::Uuid::new_v4();
+        let mut account_message = message("Account target", "Owned by account");
+        account_message.id = "account-message".into();
+        account_message.account_id = account_id.to_string();
+        account_message.message_id = Some("<account@example.test>".into());
+        let mut other_message = account_message.clone();
+        other_message.id = "other-account-message".into();
+        other_message.account_id = other_account_id.to_string();
+        other_message.uid = 2;
+        store
+            .upsert_messages(&[account_message.clone(), other_message])
+            .await
+            .unwrap();
+        assert!(store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: Some("other-account-message".into()),
+                rfc_message_id: Some("<account@example.test>".into()),
+                thread_id: Some(account_message.thread_id.clone()),
+                mailbox: None,
+            })
+            .await
+            .unwrap()
+            .is_none());
+
+        let mut recycled = account_message.clone();
+        recycled.id = "recycled-local-id".into();
+        recycled.uid = 9;
+        recycled.message_id = Some("<replacement@example.test>".into());
+        recycled.thread_id = "replacement-thread".into();
+        store.upsert_messages(&[recycled]).await.unwrap();
+        let original = store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: Some("recycled-local-id".into()),
+                rfc_message_id: Some("<account@example.test>".into()),
+                thread_id: Some(account_message.thread_id.clone()),
+                mailbox: None,
+            })
+            .await
+            .unwrap()
+            .expect("recycled local IDs fall back to the durable target");
+        assert!(original
+            .source_messages
+            .iter()
+            .any(|message| message.id == "account-message"));
+        assert!(!original
+            .source_messages
+            .iter()
+            .any(|message| message.id == "recycled-local-id"));
+
+        let mut first = message("First", "First duplicate");
+        first.id = "first-duplicate".into();
+        first.account_id = account_id.to_string();
+        first.uid = 3;
+        first.message_id = Some("<duplicated@example.test>".into());
+        let mut second = first.clone();
+        second.id = "second-duplicate".into();
+        second.uid = 4;
+        store.upsert_messages(&[first, second]).await.unwrap();
+        // A stale or repaired index can retain duplicate RFC IDs in separate
+        // threads. The resolver must not choose either one by an arbitrary
+        // query order, even when the caller also supplies a thread fallback.
+        sqlx::query("UPDATE messages SET thread_id = 'other-thread' WHERE id = 'second-duplicate'")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        assert!(store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: None,
+                rfc_message_id: Some("<DUPLICATED@example.test>".into()),
+                thread_id: Some("other-thread".into()),
+                mailbox: None,
+            })
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn conversation_target_keeps_spam_family_isolated() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let mut inbox = message("Topic", "Inbox");
+        inbox.id = "inbox".into();
+        inbox.account_id = account_id.to_string();
+        inbox.message_id = Some("<inbox@example.test>".into());
+        let mut spam = message("Re: Topic", "Spam reply");
+        spam.id = "spam".into();
+        spam.account_id = account_id.to_string();
+        spam.mailbox = "Spam::Bulk".into();
+        spam.uid = 2;
+        spam.message_id = Some("<spam@example.test>".into());
+        spam.in_reply_to = Some("<inbox@example.test>".into());
+        store.upsert_messages(&[inbox, spam]).await.unwrap();
+
+        assert!(store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: None,
+                rfc_message_id: Some("<spam@example.test>".into()),
+                thread_id: None,
+                mailbox: None,
+            })
+            .await
+            .unwrap()
+            .is_none());
+        let spam_only = store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: None,
+                rfc_message_id: Some("<spam@example.test>".into()),
+                thread_id: None,
+                mailbox: Some("Spam".into()),
+            })
+            .await
+            .unwrap()
+            .expect("explicit Spam target resolves");
+        assert_eq!(spam_only.messages.len(), 1);
+        assert_eq!(spam_only.source_messages.len(), 1);
+        let nested_spam = store
+            .conversation_for_target(&ConversationTarget {
+                account_id,
+                local_message_id: Some("spam".into()),
+                rfc_message_id: None,
+                thread_id: None,
+                mailbox: Some("Spam::Bulk".into()),
+            })
+            .await
+            .unwrap()
+            .expect("nested Spam target resolves within its family");
+        assert_eq!(nested_spam.messages.len(), 1);
+        assert_eq!(spam_only.messages[0].mailbox, "Spam::Bulk");
     }
 
     #[tokio::test]

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -2580,7 +2580,7 @@ impl Store {
                     .rfc_message_id
                     .as_deref()
                     .and_then(normalize_message_id)
-                    .map_or(true, |expected| {
+                    .is_none_or(|expected| {
                         message
                             .message_id
                             .as_deref()
@@ -2592,7 +2592,7 @@ impl Store {
                     .thread_id
                     .as_deref()
                     .filter(|thread_id| !thread_id.trim().is_empty())
-                    .map_or(true, |thread_id| message.thread_id == thread_id);
+                    .is_none_or(|thread_id| message.thread_id == thread_id);
                 if rfc_matches && thread_matches {
                     return self
                         .complete_conversation(
@@ -6505,7 +6505,7 @@ mod tests {
                 newer.uid = 100 + index;
                 newer.message_id = Some(format!("<newer-{index}@example.test>"));
                 newer.thread_id = format!("newer-thread-{index}");
-                newer.received_at += chrono::Duration::minutes(i64::from(index + 1));
+                newer.received_at += chrono::Duration::minutes(index + 1);
                 newer
             })
             .collect::<Vec<_>>();


### PR DESCRIPTION
## Summary

- Open single-message notification targets in a dedicated native conversation window.
- Open or focus the same window when a thread is double-clicked.
- Keep grouped notifications on the main Inbox and preserve single-click selection.
- Support the complete Reader action set, including permanent delete.

## Root cause

Notification clicks focused the main window, loaded the first Inbox page, and matched only an exact local ID in deduplicated display messages. This failed for moved, paginated, deduplicated, stale, or grouped targets.

## Validation

- Frontend: 284 tests across 30 files
- Core Rust: 271 tests plus 5 boundary tests
- Desktop Rust: 79 tests
- TypeScript typecheck
- 63 release and contract tests
- Isolated native macOS verification with a fictional mailbox