### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -939,7 +939,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "dakia-cli"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-core"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -993,7 +993,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-desktop"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/DakiaMail/dakia-desktop"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dakia",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "identifier": "dev.dakia.mail",
   "build": {
     "beforeDevCommand": "npm run dev:desktop-web",

--- a/docs/releases/v0.4.0.md
+++ b/docs/releases/v0.4.0.md
@@ -1,0 +1,31 @@
+# Dakia v0.4.0
+
+This release makes conversations easier to work with, adds safer control over
+deleted mail, and improves performance for larger local mailboxes.
+
+## What's new
+
+- **Conversations in their own windows.** Open a conversation in a dedicated
+  reader window while keeping the main mailbox available. Message actions taken
+  in the reader are reflected in the main mailbox.
+- **Permanent deletion when you choose it.** A message can now be deleted
+  permanently after an explicit confirmation. Dakia targets the exact provider
+  message and removes its local record only after the provider operation
+  succeeds.
+
+## Improvements and fixes
+
+- Improved local database performance for conversation loading and mailbox
+  updates, including fewer database round trips and better handling of larger
+  datasets.
+- Hardened HTML and plain-text rendering for provider-shaped messages so quoted
+  history and current content are separated more reliably without hiding
+  legitimate message text.
+- Added Gmail OAuth verification guidance during account setup.
+- Updated PostCSS and the command-line argument parser dependencies.
+- Expanded regression coverage for reader windows, permanent deletion,
+  database behavior, native events, and mail rendering.
+
+## Download
+
+Dakia v0.4.0 supports Apple Silicon Macs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dakia",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dakia",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "dependencies": {
         "@browsermt/bergamot-translator": "^0.4.9",
         "@mantine/core": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dakia",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.4.0",
   "type": "module",
   "scripts": {
     "dev": "./scripts/dev.sh",


### PR DESCRIPTION
## Summary
- bump all desktop, CLI, and core version authorities to 0.4.0
- add the reviewed human-readable v0.4.0 changelog
- prepare source metadata for the signed Apple Silicon release

## Verification
- npm run verify:local
- 273 core tests, 79 Tauri tests, 17 CLI/provider/subprocess tests, 5 mail-boundary tests
- 284 frontend tests and 63 release-script tests
- Rust formatting and Clippy, TypeScript typecheck, Prettier, and production web build
- signed/notarized/stapled app and DMG; mounted-DMG and updater-archive startup checks
- updater signature and artifact checksums verified
- production R2 latest.json validated at version 0.4.0

## Platform
- Apple Silicon verified
- Intel automation skipped under the owner-authorized waiver