### PR TITLE
Add hosted build cost measurement workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,18 @@
 version: 2
+
+# Consolidate routine npm and Cargo version updates into one weekly PR so the
+# Linux verification workflow runs once per update cycle.
+multi-ecosystem-groups:
+  weekly-dependencies:
+    schedule:
+      interval: weekly
+
 updates:
   - package-ecosystem: npm
     directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies
   - package-ecosystem: cargo
     directory: /
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 5
+    patterns: ["*"]
+    multi-ecosystem-group: weekly-dependencies

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -1,0 +1,156 @@
+name: Hosted build measurement
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Why this hosted build measurement is needed
+        required: true
+        type: string
+      run_hosted_measurement:
+        description: Explicitly authorize paid hosted macOS and Windows build jobs
+        required: true
+        default: false
+        type: boolean
+
+concurrency:
+  group: hosted-build-measurement
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate-request:
+    name: Validate measurement request
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Require an explicit reason and authorization
+        env:
+          REASON: ${{ inputs.reason }}
+          ENABLED: ${{ inputs.run_hosted_measurement }}
+        run: |
+          test -n "$(printf '%s' "$REASON" | tr -d '[:space:]')"
+          test "$ENABLED" = true
+
+  build:
+    name: ${{ matrix.name }}
+    needs: validate-request
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS Apple Silicon DMG
+            runner: macos-15
+            platform: macos
+            arch: aarch64
+            bundle_arch: arm64
+            target: aarch64-apple-darwin
+            bundles: dmg
+            artifact_glob: target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+          - name: macOS Intel DMG
+            runner: macos-15-intel
+            platform: macos
+            arch: x86_64
+            bundle_arch: x86_64
+            target: x86_64-apple-darwin
+            bundles: dmg
+            artifact_glob: target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+          - name: Windows x64 NSIS installer
+            runner: windows-2025
+            platform: windows
+            arch: x86_64
+            bundle_arch: x86_64
+            target: x86_64-pc-windows-msvc
+            bundles: nsis
+            artifact_glob: target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          lfs: true
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.89.0 --profile minimal
+          rustup default 1.89.0
+      - name: Install JavaScript dependencies
+        run: npm ci --ignore-scripts
+      - name: Prepare packaged assets
+        run: npm run prepare:desktop-assets
+      - name: Build target-specific CLI sidecar
+        env:
+          TAURI_ENV_PLATFORM: ${{ matrix.platform }}
+          TAURI_ENV_ARCH: ${{ matrix.arch }}
+          ORT_LIB_LOCATION: ${{ matrix.platform == 'macos' && format('{0}/apps/desktop/src-tauri/frameworks', github.workspace) || '' }}
+          ORT_PREFER_DYNAMIC_LINK: ${{ matrix.platform == 'macos' && '1' || '' }}
+        run: bash ./scripts/bundle-cli.sh release
+      - name: Build the web frontend
+        run: npm run build:web
+      - name: Write non-release Tauri overlay
+        run: |
+          printf '%s\n' '{"build":{"beforeBuildCommand":""},"bundle":{"createUpdaterArtifacts":false}}' > "$RUNNER_TEMP/tauri-measurement.conf.json"
+      - name: Build unsigned measurement package
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'macos' && '-' || '' }}
+          ORT_LIB_LOCATION: ${{ matrix.platform == 'macos' && format('{0}/apps/desktop/src-tauri/frameworks', github.workspace) || '' }}
+          ORT_PREFER_DYNAMIC_LINK: ${{ matrix.platform == 'macos' && '1' || '' }}
+        run: |
+          ./node_modules/.bin/tauri build \
+            --target "${{ matrix.target }}" \
+            --bundles "${{ matrix.bundles }}" \
+            --config apps/desktop/src-tauri/tauri.conf.json \
+            --config "$RUNNER_TEMP/tauri-measurement.conf.json"
+      - name: Verify package exists and record checksum
+        run: |
+          shopt -s nullglob
+          files=( ${{ matrix.artifact_glob }} )
+          test "${#files[@]}" -eq 1
+          test -s "${files[0]}"
+          if command -v shasum >/dev/null; then
+            shasum -a 256 "${files[0]}"
+          else
+            sha256sum "${files[0]}"
+          fi
+      - name: Verify macOS DMG contents
+        if: matrix.platform == 'macos'
+        run: |
+          mount_dir="$RUNNER_TEMP/dakia-measurement-mount"
+          mkdir -p "$mount_dir"
+          hdiutil attach -readonly -nobrowse -mountpoint "$mount_dir" ${{ matrix.artifact_glob }}
+          trap 'hdiutil detach "$mount_dir" -quiet || true' EXIT
+          app="$mount_dir/Dakia.app"
+          test -L "$mount_dir/Applications"
+          test -x "$app/Contents/MacOS/dakia-desktop"
+          test -x "$app/Contents/MacOS/dakia"
+          /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist"
+          lipo -archs "$app/Contents/MacOS/dakia-desktop" | grep -wx "${{ matrix.bundle_arch }}"
+          lipo -archs "$app/Contents/MacOS/dakia" | grep -wx "${{ matrix.bundle_arch }}"
+          test -s "$app/Contents/Resources/resources/email-classifier-v2/model.onnx"
+          test -s "$app/Contents/Resources/THIRD_PARTY_NOTICES.md"
+          "$app/Contents/MacOS/dakia" --version
+          "$app/Contents/MacOS/dakia" --help >/dev/null
+      - name: Verify Windows installer exists
+        if: matrix.platform == 'windows'
+        run: |
+          files=( ${{ matrix.artifact_glob }} )
+          test "${#files[@]}" -eq 1
+          test -s "${files[0]}"
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: hosted-build-measurement-${{ matrix.target }}-${{ github.run_id }}
+          path: ${{ matrix.artifact_glob }}
+          if-no-files-found: error
+          retention-days: 1
+          compression-level: 0
+      - name: Explain measurement boundary
+        run: |
+          echo "Built an unsigned, non-publishing measurement package."
+          echo "No GitHub Release, tag, updater artifact, signature, or notarization was created."

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -84,14 +84,19 @@ jobs:
       - name: Install JavaScript dependencies
         run: npm ci --ignore-scripts
       - name: Prepare packaged assets
-        run: npm run prepare:desktop-assets
+        run: bash ./scripts/prepare-desktop-assets.sh
       - name: Build target-specific CLI sidecar
         env:
           TAURI_ENV_PLATFORM: ${{ matrix.platform }}
           TAURI_ENV_ARCH: ${{ matrix.arch }}
-          ORT_LIB_LOCATION: ${{ matrix.platform == 'macos' && format('{0}/apps/desktop/src-tauri/frameworks', github.workspace) || '' }}
-          ORT_PREFER_DYNAMIC_LINK: ${{ matrix.platform == 'macos' && '1' || '' }}
-        run: bash ./scripts/bundle-cli.sh release
+        run: |
+          if [[ "${{ matrix.platform }}" == "macos" ]]; then
+            export ORT_LIB_LOCATION="$GITHUB_WORKSPACE/apps/desktop/src-tauri/frameworks"
+            export ORT_PREFER_DYNAMIC_LINK=1
+          else
+            unset ORT_LIB_LOCATION ORT_PREFER_DYNAMIC_LINK
+          fi
+          bash ./scripts/bundle-cli.sh release
       - name: Build the web frontend
         run: npm run build:web
       - name: Write non-release Tauri overlay
@@ -100,14 +105,19 @@ jobs:
       - name: Build unsigned measurement package
         env:
           APPLE_SIGNING_IDENTITY: ${{ matrix.platform == 'macos' && '-' || '' }}
-          ORT_LIB_LOCATION: ${{ matrix.platform == 'macos' && format('{0}/apps/desktop/src-tauri/frameworks', github.workspace) || '' }}
-          ORT_PREFER_DYNAMIC_LINK: ${{ matrix.platform == 'macos' && '1' || '' }}
         run: |
+          if [[ "${{ matrix.platform }}" == "macos" ]]; then
+            export ORT_LIB_LOCATION="$GITHUB_WORKSPACE/apps/desktop/src-tauri/frameworks"
+            export ORT_PREFER_DYNAMIC_LINK=1
+          else
+            unset ORT_LIB_LOCATION ORT_PREFER_DYNAMIC_LINK
+          fi
           ./node_modules/.bin/tauri build \
             --target "${{ matrix.target }}" \
             --bundles "${{ matrix.bundles }}" \
             --config apps/desktop/src-tauri/tauri.conf.json \
-            --config "$RUNNER_TEMP/tauri-measurement.conf.json"
+            --config "$RUNNER_TEMP/tauri-measurement.conf.json" \
+            -- --locked
       - name: Verify package exists and record checksum
         run: |
           shopt -s nullglob
@@ -131,6 +141,10 @@ jobs:
           test -x "$app/Contents/MacOS/dakia-desktop"
           test -x "$app/Contents/MacOS/dakia"
           /usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist"
+          expected_version="$(node -p "require('./package.json').version")"
+          actual_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$app/Contents/Info.plist")"
+          test "$actual_version" = "$expected_version"
+          test "$(readlink "$mount_dir/Applications")" = /Applications
           lipo -archs "$app/Contents/MacOS/dakia-desktop" | grep -wx "${{ matrix.bundle_arch }}"
           lipo -archs "$app/Contents/MacOS/dakia" | grep -wx "${{ matrix.bundle_arch }}"
           test -s "$app/Contents/Resources/resources/email-classifier-v2/model.onnx"
@@ -139,10 +153,32 @@ jobs:
           "$app/Contents/MacOS/dakia" --help >/dev/null
       - name: Verify Windows installer exists
         if: matrix.platform == 'windows'
+        shell: pwsh
         run: |
-          files=( ${{ matrix.artifact_glob }} )
-          test "${#files[@]}" -eq 1
-          test -s "${files[0]}"
+          $installer = Get-ChildItem -Path 'target/x86_64-pc-windows-msvc/release/bundle/nsis' -Filter '*.exe' | Select-Object -First 1
+          if ($null -eq $installer -or $installer.Length -eq 0) { throw 'Missing NSIS installer.' }
+          $installDir = Join-Path $env:RUNNER_TEMP 'dakia-measurement-install'
+          try {
+            & $installer.FullName /S "/D=$installDir"
+            if ($LASTEXITCODE -ne 0) { throw "NSIS installer failed with exit code $LASTEXITCODE." }
+            $app = Join-Path $installDir 'dakia-desktop.exe'
+            if (-not (Test-Path -PathType Leaf $app)) { throw 'Installed desktop executable is missing.' }
+            $sidecar = Get-ChildItem -Path $installDir -Recurse -Filter 'dakia.exe' | Select-Object -First 1
+            if ($null -eq $sidecar) { throw 'Installed Dakia CLI sidecar is missing.' }
+            foreach ($required in @('model.onnx', 'tokenizer.json', 'THIRD_PARTY_NOTICES.md')) {
+              if ($null -eq (Get-ChildItem -Path $installDir -Recurse -Filter $required | Select-Object -First 1)) {
+                throw "Installed package is missing $required."
+              }
+            }
+            $expectedVersion = node -p "require('./package.json').version"
+            $actualVersion = & $sidecar.FullName --version
+            if ($actualVersion -ne "dakia $expectedVersion") { throw "Unexpected CLI version: $actualVersion" }
+            & $sidecar.FullName --help | Out-Null
+            if ($LASTEXITCODE -ne 0) { throw 'Installed CLI help command failed.' }
+          } finally {
+            $uninstaller = Join-Path $installDir 'uninstall.exe'
+            if (Test-Path -PathType Leaf $uninstaller) { & $uninstaller /S }
+          }
       - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
         with:
           name: hosted-build-measurement-${{ matrix.target }}-${{ github.run_id }}

--- a/PLAN.md
+++ b/PLAN.md
@@ -49,8 +49,8 @@ CLI are verified on Windows.
 - Add a `workflow_dispatch` release workflow requiring a version, immutable
   source revision, release notes, a non-empty reason, and an explicit publish
   confirmation.
-- Use the trusted self-hosted Apple Silicon runner for both macOS artifacts,
-  and a trusted Windows runner for the Windows installer.
+- Use hosted macOS Apple Silicon, hosted macOS Intel, and hosted Windows x64
+  runners only for an explicitly dispatched release workflow.
 - Protect the publish job with a GitHub `release` environment and upload only
   an exact asset allowlist with verified checksums.
 - Create the GitHub Release as a draft, download and compare its assets, then
@@ -82,8 +82,5 @@ usage from configuration or estimates.
 2. A Windows code-signing policy and certificate source are required. An
    unsigned NSIS installer is not an acceptable substitute without an explicit
    owner waiver.
-3. A trusted Windows x64 runner must be designated. GitHub-hosted Windows is
-   acceptable for infrequent manual releases, while a self-hosted Windows
-   runner avoids Actions-minute charges but must never accept fork PRs.
-4. GitHub CLI or equivalent authenticated read access is required to complete
+3. GitHub CLI or equivalent authenticated read access is required to complete
    the organization billing analysis.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,89 @@
+# Cross-platform GitHub release plan
+
+## Objective
+
+Provide an explicitly dispatched GitHub release workflow that creates and
+publishes Dakia downloads for macOS Apple Silicon, macOS Intel, and Windows
+x64. Keep ordinary pull-request verification Linux-only and cost-bounded.
+
+## Non-goals
+
+- No scheduled release builds.
+- No macOS or Windows packaging on pull requests.
+- No release, tag, publication, credential, billing, or organization-setting
+  mutation without a separate explicit authorization.
+- Linux remains a verification platform in this scope; it is not a packaged
+  release target.
+
+## Decisions recorded
+
+- GitHub Releases are the requested publishing surface for the three requested
+  downloads.
+- Existing R2/Tauri updater publication remains an independent follow-up until
+  its Apple-Silicon-only manifest and publisher can safely support the new
+  targets. A GitHub download release must not silently claim automatic updates.
+- Ordinary PR checks retain the existing single Ubuntu classifier/validation
+  workflow, its cancellation behavior, and its scoped test selection.
+
+## Phase 1 — release contracts and platform prerequisites
+
+**Status:** in progress
+
+- Make CLI sidecar bundling work on Windows x64, including the `.exe` naming
+  convention required by Tauri.
+- Establish pinned, verified Windows ONNX Runtime packaging and loading.
+- Parameterize macOS packaging/verification for `aarch64` and `x86_64` while
+  preserving signing, notarization, archive, and checksum checks.
+- Add Windows NSIS installer and installed-artifact verification.
+- Extend release-script tests from Apple-Silicon-only assumptions to both macOS
+  architectures and Windows where host-independent.
+
+**Acceptance:** Each target creates the expected immutable, checksum-covered
+artifact; macOS artifacts are signed/notarized; Windows installer and bundled
+CLI are verified on Windows.
+
+## Phase 2 — manually dispatched GitHub workflow
+
+**Status:** pending Phase 1
+
+- Add a `workflow_dispatch` release workflow requiring a version, immutable
+  source revision, release notes, a non-empty reason, and an explicit publish
+  confirmation.
+- Use the trusted self-hosted Apple Silicon runner for both macOS artifacts,
+  and a trusted Windows runner for the Windows installer.
+- Protect the publish job with a GitHub `release` environment and upload only
+  an exact asset allowlist with verified checksums.
+- Create the GitHub Release as a draft, download and compare its assets, then
+  publish it only after verification.
+
+**Acceptance:** No PR or schedule can invoke a release build. A manual,
+protected dispatch produces exactly the three documented downloads or fails
+without publishing a partial release.
+
+## Phase 3 — documentation and measured cost controls
+
+**Status:** pending Phase 2
+
+- Replace stale nightly/local-only release documentation with the dispatch,
+  runner, secret, verification, rollback, and failure-handling procedures.
+- Document the Linux-only PR lane and its cost target.
+- Record the DakiaMail organization’s actual Actions usage, included quota,
+  budget, spending limit, artifact/cache storage, and the cost of three
+  representative PR/release runs.
+
+**Acceptance:** An authorized maintainer can perform a release without relying
+on unpublished local knowledge, and the budget report distinguishes measured
+usage from configuration or estimates.
+
+## Required owner inputs before Phase 2
+
+1. The GitHub `release` environment must hold/reveal access only to trusted
+   release jobs, with approval protection enabled.
+2. A Windows code-signing policy and certificate source are required. An
+   unsigned NSIS installer is not an acceptable substitute without an explicit
+   owner waiver.
+3. A trusted Windows x64 runner must be designated. GitHub-hosted Windows is
+   acceptable for infrequent manual releases, while a self-hosted Windows
+   runner avoids Actions-minute charges but must never accept fork PRs.
+4. GitHub CLI or equivalent authenticated read access is required to complete
+   the organization billing analysis.

--- a/scripts/bundle-cli.sh
+++ b/scripts/bundle-cli.sh
@@ -14,6 +14,9 @@ case "$platform" in
   linux)
     target="${arch}-unknown-linux-gnu"
     ;;
+  windows | mingw* | msys*)
+    target="${arch}-pc-windows-msvc"
+    ;;
   *)
     echo "Bundling the Dakia CLI is not supported for platform: $platform" >&2
     exit 1
@@ -36,12 +39,21 @@ case "$profile" in
 esac
 
 cd "$repo_root"
-cargo build -p dakia-cli --bin dakia --target "$target" $profile_args
+cargo build --locked -p dakia-cli --bin dakia --target "$target" $profile_args
 
+executable=dakia
+if [ "$platform" = windows ] || echo "$platform" | grep -Eq '^(mingw|msys)'; then
+  executable=dakia.exe
+fi
 destination="$repo_root/apps/desktop/src-tauri/binaries/dakia-$target"
+if [ "$executable" = dakia.exe ]; then
+  destination="$destination.exe"
+fi
 mkdir -p "$(dirname "$destination")"
-cp "$repo_root/target/$target/$cargo_profile/dakia" "$destination"
-chmod 755 "$destination"
+cp "$repo_root/target/$target/$cargo_profile/$executable" "$destination"
+if [ "$executable" = dakia ]; then
+  chmod 755 "$destination"
+fi
 
 if [ "$platform" = "macos" ] || [ "$platform" = "darwin" ]; then
   # The sidecar lives in Contents/MacOS in a packaged app and next to the

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -29,12 +29,16 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /APPLE_SIGNING_IDENTITY: \$\{\{ matrix\.platform == 'macos' && '-' \|\| '' \}\}/);
   assert.match(workflow, /retention-days: 1/);
   assert.match(workflow, /hdiutil attach/);
-  assert.match(workflow, /Verify Windows installer exists/);
+  assert.match(workflow, /NSIS installer failed/);
+  assert.match(workflow, /Installed Dakia CLI sidecar is missing/);
+  assert.match(workflow, /uninstall\.exe/);
   assert.match(workflow, /group: hosted-build-measurement/);
+  assert.match(workflow, /bash \.\/scripts\/prepare-desktop-assets\.sh/);
+  assert.match(workflow, /-- --locked/);
   assert.doesNotMatch(workflow, /gh release|gh api|TAURI_SIGNING_PRIVATE_KEY|notary/i);
 });
 
-test("Windows CLI sidecars keep Tauri's target-qualified executable name", () => {
+test("Windows CLI sidecars are built for the MSVC target", () => {
   assert.match(cliBundler, /windows \| mingw\* \| msys\*\)/);
   assert.match(cliBundler, /target="\$\{arch\}-pc-windows-msvc"/);
   assert.match(cliBundler, /executable=dakia\.exe/);

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = new URL("..", import.meta.url).pathname;
+const workflow = readFileSync(
+  join(root, ".github", "workflows", "hosted-build-measurement.yml"),
+  "utf8",
+);
+const cliBundler = readFileSync(join(root, "scripts", "bundle-cli.sh"), "utf8");
+
+test("hosted build measurement is dispatch-only and explicitly opt-in", () => {
+  assert.match(workflow, /^on:\n  workflow_dispatch:/m);
+  assert.match(workflow, /run_hosted_measurement:/);
+  assert.match(workflow, /test "\$ENABLED" = true/);
+  assert.doesNotMatch(workflow, /^  push:|^  schedule:/m);
+});
+
+test("hosted build measurement covers both Macs and Windows without release writes", () => {
+  for (const value of ["macos-15", "macos-15-intel", "windows-2025"]) {
+    assert.match(workflow, new RegExp(`runner: ${value}`));
+  }
+  assert.match(workflow, /aarch64-apple-darwin/);
+  assert.match(workflow, /x86_64-apple-darwin/);
+  assert.match(workflow, /x86_64-pc-windows-msvc/);
+  assert.match(workflow, /createUpdaterArtifacts":false/);
+  assert.match(workflow, /beforeBuildCommand":""/);
+  assert.match(workflow, /APPLE_SIGNING_IDENTITY: \$\{\{ matrix\.platform == 'macos' && '-' \|\| '' \}\}/);
+  assert.match(workflow, /retention-days: 1/);
+  assert.match(workflow, /hdiutil attach/);
+  assert.match(workflow, /Verify Windows installer exists/);
+  assert.match(workflow, /group: hosted-build-measurement/);
+  assert.doesNotMatch(workflow, /gh release|gh api|TAURI_SIGNING_PRIVATE_KEY|notary/i);
+});
+
+test("Windows CLI sidecars keep Tauri's target-qualified executable name", () => {
+  assert.match(cliBundler, /windows \| mingw\* \| msys\*\)/);
+  assert.match(cliBundler, /target="\$\{arch\}-pc-windows-msvc"/);
+  assert.match(cliBundler, /executable=dakia\.exe/);
+  assert.match(cliBundler, /destination="\$destination\.exe"/);
+  assert.match(cliBundler, /\$repo_root\/target\/\$target\/\$cargo_profile\/\$executable/);
+  assert.match(cliBundler, /cargo build --locked/);
+});


### PR DESCRIPTION
Adds one grouped weekly Dependabot update across npm and Cargo, Windows CLI sidecar support, and an explicitly opt-in non-publishing hosted build-measurement workflow for macOS Apple Silicon, macOS Intel, and Windows x64.\n\nThe workflow has read-only repository permissions, no release/tag/publish/sign/notarization path, 45-minute job caps, global concurrency, 1-day artifact retention, and contract coverage.\n\nLocal verification: YAML parse; node --test scripts/hosted-build-measurement.node-test.mjs; node --test scripts/*.node-test.mjs (66 passed).\n\nA GitHub dispatch was attempted but GitHub requires workflow_dispatch files to exist on the default branch first. After merge, dispatch the workflow with run_hosted_measurement=true to measure hosted-runner cost.