### PR TITLE
Open email body mailto links in Dakia compose

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -2351,6 +2351,9 @@ export default function App() {
         onComposeTo={(message, address) =>
           openComposeWindow({ accountId: message.account_id, to: address })
         }
+        onComposeLink={(message, seed) =>
+          openComposeWindow({ ...seed, accountId: message.account_id })
+        }
         onAddressContextMenu={(message, address) =>
           void api
             .showEmailAddressContextMenu(

--- a/apps/desktop/src/ReaderWindowApp.tsx
+++ b/apps/desktop/src/ReaderWindowApp.tsx
@@ -542,6 +542,9 @@ export function ReaderWindowApp() {
         onComposeTo={(message, address) =>
           openComposeWindow({ accountId: message.account_id, to: address })
         }
+        onComposeLink={(message, seed) =>
+          openComposeWindow({ ...seed, accountId: message.account_id })
+        }
         onAddressContextMenu={(message, address) =>
           void readerApi
             .showEmailAddressContextMenu(

--- a/apps/desktop/src/components/HtmlMessage.test.tsx
+++ b/apps/desktop/src/components/HtmlMessage.test.tsx
@@ -1,5 +1,5 @@
 import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import appleMailReplySection from "../test/fixtures/apple-mail-reply-section.html?raw";
 import freshdeskReplySection from "../test/fixtures/freshdesk-reply-section.html?raw";
 import outlookWordReplySection from "../test/fixtures/outlook-word-reply-section.html?raw";
@@ -545,6 +545,33 @@ describe("HTML email appearance", () => {
     expect(anchor?.getAttribute("tabindex")).toBe("0");
     expect((anchor as HTMLElement | null)?.dataset.dakiaExternalHref).toBe(
       "https://example.test/details",
+    );
+  });
+
+  it("routes a clicked mailto link to Dakia's compose handler", () => {
+    const onMailto = vi.fn();
+    render(
+      <HtmlMessage
+        html={
+          '<a href="mailto:juhan%2Btamm@example.com?subject=Tere">Write</a>'
+        }
+        title="Message with email link"
+        showHistoryLabel="Show history"
+        hideHistoryLabel="Hide history"
+        onMailto={onMailto}
+      />,
+    );
+
+    const root = renderedEmailRoot(
+      screen.getByRole("document", { name: "Message with email link" }),
+    );
+    const anchor = root?.querySelector("a");
+    expect(anchor).not.toBeNull();
+    fireEvent.click(anchor!);
+
+    expect(onMailto).toHaveBeenCalledOnce();
+    expect(onMailto).toHaveBeenCalledWith(
+      "mailto:juhan%2Btamm@example.com?subject=Tere",
     );
   });
 

--- a/apps/desktop/src/components/HtmlMessage.tsx
+++ b/apps/desktop/src/components/HtmlMessage.tsx
@@ -8,6 +8,7 @@ type Props = {
   title: string;
   showHistoryLabel: string;
   hideHistoryLabel: string;
+  onMailto?: (href: string) => void;
 };
 
 type EmailDocument = {
@@ -612,6 +613,7 @@ function useShadowEmailDocument(
   host: RefObject<HTMLDivElement | null>,
   source?: string,
   slotLightDom = false,
+  onMailto?: (href: string) => void,
 ) {
   useEffect(() => {
     const element = host.current;
@@ -664,6 +666,10 @@ function useShadowEmailDocument(
       event.stopPropagation();
       const href = anchor.getAttribute("data-dakia-external-href");
       if (href && safeUrl(href, "href") && !href.startsWith("#")) {
+        if (/^mailto:/i.test(href) && onMailto) {
+          onMailto(href);
+          return;
+        }
         void api
           .openExternal(href)
           .catch((error) =>
@@ -692,7 +698,7 @@ function useShadowEmailDocument(
       shadow.removeEventListener("auxclick", activateLink, true);
       shadow.removeEventListener("keydown", activateLink, true);
     };
-  }, [host, slotLightDom, source]);
+  }, [host, onMailto, slotLightDom, source]);
 }
 
 export function HtmlMessage({
@@ -700,6 +706,7 @@ export function HtmlMessage({
   title,
   showHistoryLabel,
   hideHistoryLabel,
+  onMailto,
 }: Props) {
   const host = useRef<HTMLDivElement>(null);
   const historyHost = useRef<HTMLDivElement>(null);
@@ -728,8 +735,8 @@ export function HtmlMessage({
   }, []);
 
   useEffect(() => setHistoryVisible(false), [html]);
-  useShadowEmailDocument(host, email.source, true);
-  useShadowEmailDocument(historyHost, email.historySource);
+  useShadowEmailDocument(host, email.source, true, onMailto);
+  useShadowEmailDocument(historyHost, email.historySource, false, onMailto);
 
   return (
     <div

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -66,6 +66,7 @@ const props = {
   onSummarize: vi.fn(),
   onCopyAi: vi.fn(),
   onComposeTo: vi.fn(),
+  onComposeLink: vi.fn(),
   onAddressContextMenu: vi.fn(),
   unsubscribeLoading: false,
   onUnsubscribe: vi.fn(),
@@ -147,6 +148,34 @@ describe("Reader unsubscribe action", () => {
     );
     fireEvent.click(screen.getByRole("button", { name: "Unsubscribe" }));
     expect(props.onUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it("opens email-body mailto links in Dakia compose with the message account context", async () => {
+    vi.mocked(api.content).mockResolvedValue({
+      body_text: "Write to Juhan",
+      body_html:
+        '<p><a href="mailto:juhan%2Btamm@example.com?subject=Tere&amp;body=Kohtume%20homme">Write to Juhan</a></p>',
+      attachments: [],
+    });
+    render(
+      <MantineProvider>
+        <Reader {...props} message={message} />
+      </MantineProvider>,
+    );
+
+    const documentRole = await screen.findByRole("document", {
+      name: "Weekly notes",
+    });
+    const surface = documentRole.shadowRoot?.firstElementChild as HTMLElement;
+    const anchor = surface.shadowRoot?.querySelector("a");
+    expect(anchor).not.toBeNull();
+    fireEvent.click(anchor!);
+
+    expect(props.onComposeLink).toHaveBeenCalledWith(message, {
+      to: "juhan+tamm@example.com",
+      subject: "Tere",
+      body: "Kohtume homme",
+    });
   });
 
   it("disables unsubscribe while the request is in progress", () => {

--- a/apps/desktop/src/components/Reader.tsx
+++ b/apps/desktop/src/components/Reader.tsx
@@ -42,6 +42,8 @@ import {
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { api, messageContentErrorFromUnknown } from "../api";
+import type { ComposeSeed } from "../composeWindow";
+import { composeSeedFromMailto } from "../mailto";
 import { confirmNativeAction, showNativeMessage } from "../nativeFeedback";
 import {
   detectTranslationLanguage,
@@ -87,6 +89,7 @@ type Props = {
   onSummarize: () => void;
   onCopyAi: () => void;
   onComposeTo: (message: MailSummary, address: string) => void;
+  onComposeLink?: (message: MailSummary, seed: ComposeSeed) => void;
   onAddressContextMenu: (message: MailSummary, address: string) => void;
   unsubscribeLoading: boolean;
   onUnsubscribe: (message: MailSummary) => void;
@@ -113,6 +116,7 @@ export function Reader({
   onSummarize,
   onCopyAi,
   onComposeTo,
+  onComposeLink,
   onAddressContextMenu,
   unsubscribeLoading,
   onUnsubscribe,
@@ -575,6 +579,7 @@ export function Reader({
             onReplyAll={() => onReplyAll(threadMessage)}
             onForward={() => onForward(threadMessage)}
             onComposeTo={(address) => onComposeTo(threadMessage, address)}
+            onComposeLink={(seed) => onComposeLink?.(threadMessage, seed)}
             onAddressContextMenu={(address) =>
               onAddressContextMenu(threadMessage, address)
             }
@@ -607,6 +612,7 @@ function ThreadMessage({
   onReplyAll,
   onForward,
   onComposeTo,
+  onComposeLink,
   onAddressContextMenu,
   threadUnread,
   onToggleRead,
@@ -630,6 +636,7 @@ function ThreadMessage({
   onReplyAll: () => void;
   onForward: () => void;
   onComposeTo: (address: string) => void;
+  onComposeLink: (seed: ComposeSeed) => void;
   onAddressContextMenu: (address: string) => void;
   threadUnread: boolean;
   onToggleRead: (read: boolean) => void;
@@ -1055,6 +1062,10 @@ function ThreadMessage({
           title={message.subject}
           showHistoryLabel={t("reader.showHistory")}
           hideHistoryLabel={t("reader.hideHistory")}
+          onMailto={(href) => {
+            const seed = composeSeedFromMailto(href);
+            if (seed) onComposeLink(seed);
+          }}
         />
       ) : (
         <PlainTextMessage text={displayContent?.body_text ?? ""} />

--- a/apps/desktop/src/mailto.test.ts
+++ b/apps/desktop/src/mailto.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { composeSeedFromMailto } from "./mailto";
+
+describe("composeSeedFromMailto", () => {
+  it("preserves standard mailto compose fields", () => {
+    expect(
+      composeSeedFromMailto(
+        "mailto:juhan%2Btamm@example.com?cc=abi%40example.com&subject=Tere%20Juhan&body=Kohtume%20homme",
+      ),
+    ).toEqual({
+      to: "juhan+tamm@example.com",
+      cc: "abi@example.com",
+      subject: "Tere Juhan",
+      body: "Kohtume homme",
+    });
+  });
+
+  it("opens recipient-free links and treats field names case-insensitively", () => {
+    expect(
+      composeSeedFromMailto(
+        "mailto:?TO=juhan+tag@example.com&CC=abi+tag@example.com&SUBJECT=C++",
+      ),
+    ).toEqual({
+      to: "juhan+tag@example.com",
+      cc: "abi+tag@example.com",
+      subject: "C++",
+    });
+    expect(composeSeedFromMailto("mailto:?subject=Feedback")).toEqual({
+      subject: "Feedback",
+    });
+  });
+
+  it("rejects non-mailto and malformed links", () => {
+    expect(composeSeedFromMailto("https://example.com")).toBeUndefined();
+    expect(composeSeedFromMailto("mailto:%E0%A4%A")).toBeUndefined();
+    expect(
+      composeSeedFromMailto("mailto:user@example.com?subject=%E0%A4%A"),
+    ).toBeUndefined();
+  });
+});

--- a/apps/desktop/src/mailto.ts
+++ b/apps/desktop/src/mailto.ts
@@ -1,0 +1,46 @@
+import type { ComposeSeed } from "./composeWindow";
+
+export function composeSeedFromMailto(href: string): ComposeSeed | undefined {
+  if (!/^mailto:/i.test(href)) return undefined;
+  const queryIndex = href.indexOf("?");
+  const encodedRecipients = href.slice(
+    href.indexOf(":") + 1,
+    queryIndex === -1 ? undefined : queryIndex,
+  );
+  let recipients: string;
+  try {
+    recipients = decodeURIComponent(encodedRecipients);
+  } catch {
+    return undefined;
+  }
+
+  const fields = new Map<string, string[]>();
+  try {
+    for (const pair of (queryIndex === -1 ? "" : href.slice(queryIndex + 1))
+      .split("&")
+      .filter(Boolean)) {
+      const separator = pair.indexOf("=");
+      const encodedName = separator === -1 ? pair : pair.slice(0, separator);
+      const encodedValue = separator === -1 ? "" : pair.slice(separator + 1);
+      const name = decodeURIComponent(encodedName).toLowerCase();
+      const values = fields.get(name) ?? [];
+      values.push(decodeURIComponent(encodedValue));
+      fields.set(name, values);
+    }
+  } catch {
+    return undefined;
+  }
+
+  const seed: ComposeSeed = {};
+  const to = [recipients, ...(fields.get("to") ?? [])]
+    .filter(Boolean)
+    .join(", ");
+  const cc = (fields.get("cc") ?? []).filter(Boolean).join(", ");
+  const subject = fields.get("subject")?.[0];
+  const body = fields.get("body")?.[0];
+  if (to) seed.to = to;
+  if (cc) seed.cc = cc;
+  if (subject !== undefined) seed.subject = subject;
+  if (body !== undefined) seed.body = body;
+  return seed;
+}


### PR DESCRIPTION
## Summary

- Route `mailto:` links in HTML email bodies to Dakia’s compose window.
- Preserve recipient, CC, subject, and body fields, including encoded values.
- Maintain the originating message account context.
- Add coverage for link handling, parsing, malformed URLs, and recipient-free links.

## Testing

- Added Vitest coverage for mailto parsing and HTML Reader integration.
- Added regression coverage verifying compose routing and decoded fields.