### PR TITLE
Fix people categorization across desktop, CLI, and core

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -100,10 +100,8 @@ jobs:
           cargo fmt --all -- --check
           cargo clippy -p dakia-core --all-targets -- -D warnings
           cargo test -p dakia-core -- \
-            --skip classification::tests::local_model_classifies_representative_email_types \
-            --skip classification::tests::does_not_treat_a_branded_monthly_update_as_personal_correspondence \
-            --skip classification::tests::does_not_treat_brand_marketing_as_personal_correspondence \
-            --skip classification::tests::bulk_insurance_price_promotion_is_not_a_transaction
+            --skip classification::model_integration_tests::local_model_and_policy_classify_the_production_regression_corpus \
+            --skip classification::model_integration_tests::model_and_policy_preserve_representative_categories
           cargo clippy -p dakia-cli --all-targets -- -D warnings
           cargo test -p dakia-cli
       - id: mail_boundary

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -12,10 +12,11 @@ use dakia_core::storage::{ConversationTarget, MessageContentFetchAcquire};
 use dakia_core::{
     ai::{AiConfig, AiProvider, AiService},
     mailbox_action_destination, provider, Account, AccountAuth, AccountDraft, Attachment,
-    CachedMessageContent, ComposeMessage, LocalEmailClassifier, MailConversation,
-    MailConversationPage, MailRebuildJob, MailService, MailSummary, MailboxAction, OAuthFlow,
-    OAuthProviderConfig, ProviderPreset, SearchQuery, SmartInboxPage, SmartInboxQuery, Store,
-    SyncProgress, SyncResult, UnsubscribeOutcome,
+    CachedMessageContent, ComposeMessage, EmailClassificationInput, LocalEmailClassifier,
+    MailConversation, MailConversationPage, MailRebuildJob, MailService, MailSummary,
+    MailboxAction, ModelClassificationUpdate, OAuthFlow, OAuthProviderConfig, ProviderPreset,
+    SearchQuery, SmartInboxPage, SmartInboxQuery, Store, SyncProgress, SyncResult,
+    UnsubscribeOutcome,
 };
 use secrecy::SecretString;
 use serde::Deserialize;
@@ -68,6 +69,7 @@ struct AppState {
     store: Store,
     data_dir: PathBuf,
     classifier: Mutex<Box<dyn EmailClassifier>>,
+    classification_owner: String,
     classification: Arc<ClassificationScheduler>,
     realtime: RealtimeSyncManager,
     remote_operation_slots: Arc<Semaphore>,
@@ -77,16 +79,24 @@ struct AppState {
 }
 
 trait EmailClassifier: Send {
+    fn revision(&self) -> &str {
+        "test-classifier"
+    }
+
     fn classify(
         &mut self,
-        emails: &[String],
+        emails: &[EmailClassificationInput],
     ) -> anyhow::Result<Vec<dakia_core::classification::ModelClassification>>;
 }
 
 impl EmailClassifier for LocalEmailClassifier {
+    fn revision(&self) -> &str {
+        LocalEmailClassifier::revision(self)
+    }
+
     fn classify(
         &mut self,
-        emails: &[String],
+        emails: &[EmailClassificationInput],
     ) -> anyhow::Result<Vec<dakia_core::classification::ModelClassification>> {
         LocalEmailClassifier::classify(self, emails)
     }
@@ -342,6 +352,15 @@ fn validate_classification_output_count(
     Ok(())
 }
 
+fn validate_classification_apply_count(attempted: usize, applied: usize) -> anyhow::Result<usize> {
+    if attempted != applied {
+        anyhow::bail!(
+            "classification batch became stale ({applied}/{attempted} results applied); retrying with current evidence"
+        );
+    }
+    Ok(applied)
+}
+
 async fn retry_classification_batch<T, F, Fut>(mut operation: F) -> anyhow::Result<T>
 where
     F: FnMut() -> Fut,
@@ -470,6 +489,17 @@ mod classification_scheduler_tests {
                 .unwrap_err()
                 .to_string(),
             "classifier returned 4 results for 3 messages"
+        );
+    }
+
+    #[test]
+    fn stale_classification_apply_is_retryable_instead_of_counted_as_progress() {
+        assert_eq!(validate_classification_apply_count(3, 3).unwrap(), 3);
+        assert_eq!(
+            validate_classification_apply_count(3, 0)
+                .unwrap_err()
+                .to_string(),
+            "classification batch became stale (0/3 results applied); retrying with current evidence"
         );
     }
 }
@@ -1393,7 +1423,7 @@ mod message_content_repair_tests {
     impl EmailClassifier for UnexpectedClassifier {
         fn classify(
             &mut self,
-            _emails: &[String],
+            _emails: &[EmailClassificationInput],
         ) -> anyhow::Result<Vec<dakia_core::classification::ModelClassification>> {
             panic!("message-content loading must not invoke email classification")
         }
@@ -1405,6 +1435,7 @@ mod message_content_repair_tests {
             store,
             data_dir: PathBuf::new(),
             classifier: Mutex::new(Box::new(UnexpectedClassifier)),
+            classification_owner: "message-content-test".into(),
             classification: Arc::new(ClassificationScheduler::default()),
             mail_rebuilds: Mutex::new(HashMap::new()),
             account_operations: AccountOperationLocks::default(),
@@ -3488,6 +3519,16 @@ fn kick_classification(state: Arc<AppState>) -> u64 {
 }
 
 async fn classify_pending_batch(state: Arc<AppState>) -> anyhow::Result<usize> {
+    let model_revision = state
+        .classifier
+        .lock()
+        .map_err(|_| anyhow::anyhow!("email classifier lock is unavailable"))?
+        .revision()
+        .to_owned();
+    state
+        .store
+        .claim_classification_revision(&state.classification_owner, &model_revision)
+        .await?;
     let messages = state
         .store
         .messages_for_model_classification_batch(CLASSIFICATION_BATCH_SIZE)
@@ -3496,16 +3537,26 @@ async fn classify_pending_batch(state: Arc<AppState>) -> anyhow::Result<usize> {
         return Ok(0);
     }
     let ids: Vec<String> = messages.iter().map(|message| message.id.clone()).collect();
-    let inputs: Vec<String> = messages
+    let known_correspondence = state
+        .store
+        .messages_from_known_correspondents(&messages)
+        .await?;
+    let inputs: Vec<EmailClassificationInput> = messages
         .iter()
         .map(|message| {
-            dakia_core::classification::email_text(
+            let body = if message.body_text.trim().is_empty() {
+                &message.snippet
+            } else {
+                &message.body_text
+            };
+            EmailClassificationInput::new(
                 message.from_name.as_deref(),
                 &message.from_address,
                 &message.subject,
-                &message.snippet,
+                body,
                 &message.classification_signals,
             )
+            .with_known_correspondence(known_correspondence.contains(&message.id))
         })
         .collect();
     let classifier_state = state.clone();
@@ -3519,17 +3570,39 @@ async fn classify_pending_batch(state: Arc<AppState>) -> anyhow::Result<usize> {
     .await
     .map_err(|error| anyhow::anyhow!("email classifier task failed: {error}"))??;
     validate_classification_output_count(ids.len(), classifications.len())?;
-    let updates: Vec<(String, String, f64)> = ids
-        .into_iter()
+    let updates: Vec<ModelClassificationUpdate> = messages
+        .iter()
         .zip(classifications)
-        .map(|(id, result)| (id, result.category, result.confidence))
+        .map(|(message, result)| {
+            ModelClassificationUpdate::from_message(
+                message,
+                result.category,
+                result.confidence,
+                known_correspondence.contains(&message.id),
+                &state.classification_owner,
+                &model_revision,
+            )
+        })
         .collect();
     let count = updates.len();
-    state.store.apply_model_classifications(&updates).await?;
-    Ok(count)
+    let applied = state.store.apply_model_classifications(&updates).await?;
+    validate_classification_apply_count(count, applied)
 }
 
 async fn drain_pending_classifications(state: Arc<AppState>) -> anyhow::Result<()> {
+    let result = drain_pending_classifications_owned(state.clone()).await;
+    let release = state
+        .store
+        .release_classification_revision(&state.classification_owner)
+        .await;
+    match (result, release) {
+        (Err(error), _) => Err(error),
+        (Ok(()), Err(error)) => Err(error),
+        (Ok(()), Ok(())) => Ok(()),
+    }
+}
+
+async fn drain_pending_classifications_owned(state: Arc<AppState>) -> anyhow::Result<()> {
     let mut classified = 0;
     loop {
         let generation = state.classification.next_generation();
@@ -4389,6 +4462,7 @@ pub fn run() {
                     store,
                     data_dir,
                     classifier: Mutex::new(Box::new(classifier)),
+                    classification_owner: Uuid::new_v4().to_string(),
                     classification: Arc::new(ClassificationScheduler::default()),
                     mail_rebuilds: Mutex::new(mail_rebuilds),
                     account_operations: AccountOperationLocks::default(),

--- a/crates/dakia-cli/src/main.rs
+++ b/crates/dakia-cli/src/main.rs
@@ -3,8 +3,8 @@ use base64::{engine::general_purpose::STANDARD, Engine};
 use clap::{Args, Parser, Subcommand};
 use dakia_core::{
     ai::{AiConfig, AiProvider, AiService},
-    mailbox_action_destination, ComposeMessage, LocalEmailClassifier, MailService, MailboxAction,
-    SearchQuery, Store,
+    mailbox_action_destination, ComposeMessage, EmailClassificationInput, LocalEmailClassifier,
+    MailService, MailboxAction, ModelClassificationUpdate, SearchQuery, Store,
 };
 use directories::ProjectDirs;
 use secrecy::SecretString;
@@ -250,28 +250,7 @@ async fn main() -> Result<()> {
             }
         }
         Command::Classify(args) => {
-            let messages = if args.all {
-                store.messages_for_model_reclassification().await?
-            } else {
-                Vec::new()
-            };
-            let mut classifier = LocalEmailClassifier::from_dir(args.model_dir)?;
-            let mut classified = 0;
-            if args.all {
-                for batch in messages.chunks(CLASSIFICATION_BATCH_SIZE) {
-                    classified += classify_batch(&store, &mut classifier, batch).await?;
-                }
-            } else {
-                loop {
-                    let batch = store
-                        .messages_for_model_classification_batch(CLASSIFICATION_BATCH_SIZE)
-                        .await?;
-                    if batch.is_empty() {
-                        break;
-                    }
-                    classified += classify_batch(&store, &mut classifier, &batch).await?;
-                }
-            }
+            let classified = run_classification(&store, args).await?;
             if cli.json {
                 println!("{}", serde_json::json!({"classified" : classified}));
             } else {
@@ -408,35 +387,109 @@ async fn main() -> Result<()> {
     Ok(())
 }
 
+async fn run_classification(store: &Store, args: ClassifyArgs) -> Result<usize> {
+    let owner = Uuid::new_v4().to_string();
+    let result = run_owned_classification(store, args, &owner).await;
+    let release = store.release_classification_revision(&owner).await;
+    match (result, release) {
+        (Err(error), _) => Err(error),
+        (Ok(_), Err(error)) => Err(error),
+        (Ok(classified), Ok(())) => Ok(classified),
+    }
+}
+
+async fn run_owned_classification(store: &Store, args: ClassifyArgs, owner: &str) -> Result<usize> {
+    let mut classifier = LocalEmailClassifier::from_dir(args.model_dir)?;
+    store
+        .claim_classification_revision(owner, classifier.revision())
+        .await?;
+    let messages = if args.all {
+        store.messages_for_model_reclassification().await?
+    } else {
+        Vec::new()
+    };
+    let mut classified = 0;
+    if args.all {
+        for batch in messages.chunks(CLASSIFICATION_BATCH_SIZE) {
+            classified += classify_batch(store, &mut classifier, batch, owner).await?;
+        }
+    } else {
+        loop {
+            let batch = store
+                .messages_for_model_classification_batch(CLASSIFICATION_BATCH_SIZE)
+                .await?;
+            if batch.is_empty() {
+                break;
+            }
+            classified += classify_batch(store, &mut classifier, &batch, owner).await?;
+        }
+    }
+    Ok(classified)
+}
+
 async fn classify_batch(
     store: &Store,
     classifier: &mut LocalEmailClassifier,
     messages: &[dakia_core::MailSummary],
+    owner: &str,
 ) -> Result<usize> {
+    let model_revision = classifier.revision().to_owned();
+    store
+        .claim_classification_revision(owner, &model_revision)
+        .await?;
     let ids: Vec<String> = messages.iter().map(|message| message.id.clone()).collect();
-    let inputs: Vec<String> = messages
+    let known_correspondence = store.messages_from_known_correspondents(messages).await?;
+    let inputs: Vec<EmailClassificationInput> = messages
         .iter()
         .map(|message| {
-            dakia_core::classification::email_text(
+            let body = if message.body_text.trim().is_empty() {
+                &message.snippet
+            } else {
+                &message.body_text
+            };
+            EmailClassificationInput::new(
                 message.from_name.as_deref(),
                 &message.from_address,
                 &message.subject,
-                &message.snippet,
+                body,
                 &message.classification_signals,
             )
+            .with_known_correspondence(known_correspondence.contains(&message.id))
         })
         .collect();
     let classifications = classifier.classify(&inputs)?;
-    let updates = classification_updates(ids, classifications)?;
+    let updates = classification_updates(ids, classifications)?
+        .into_iter()
+        .zip(messages)
+        .map(|((_id, category, confidence), message)| {
+            ModelClassificationUpdate::from_message(
+                message,
+                category,
+                confidence,
+                known_correspondence.contains(&message.id),
+                owner,
+                &model_revision,
+            )
+        })
+        .collect::<Vec<_>>();
     let count = updates.len();
-    store.apply_model_classifications(&updates).await?;
-    Ok(count)
+    let applied = store.apply_model_classifications(&updates).await?;
+    validate_classification_apply_count(count, applied)
+}
+
+fn validate_classification_apply_count(attempted: usize, applied: usize) -> Result<usize> {
+    if attempted != applied {
+        bail!(
+            "classification batch became stale ({applied}/{attempted} results applied); rerun after the active classifier finishes"
+        );
+    }
+    Ok(applied)
 }
 
 fn classification_updates(
     ids: Vec<String>,
     classifications: Vec<dakia_core::classification::ModelClassification>,
-) -> Result<Vec<(String, String, f64)>> {
+) -> Result<Vec<(String, String, Option<f64>)>> {
     if ids.len() != classifications.len() {
         bail!(
             "classifier returned {} results for {} messages",
@@ -847,7 +900,7 @@ mod tests {
             vec!["message-1".into(), "message-2".into()],
             vec![ModelClassification {
                 category: "work".into(),
-                confidence: 0.9,
+                confidence: Some(0.9),
             }],
         )
         .expect_err("short classifier output must not partially update messages");
@@ -865,11 +918,11 @@ mod tests {
             vec![
                 ModelClassification {
                     category: "work".into(),
-                    confidence: 0.9,
+                    confidence: Some(0.9),
                 },
                 ModelClassification {
                     category: "personal".into(),
-                    confidence: 0.8,
+                    confidence: Some(0.8),
                 },
             ],
         )
@@ -878,6 +931,17 @@ mod tests {
         assert_eq!(
             error.to_string(),
             "classifier returned 2 results for 1 messages"
+        );
+    }
+
+    #[test]
+    fn stale_classification_apply_stops_instead_of_looping() {
+        assert_eq!(validate_classification_apply_count(2, 2).unwrap(), 2);
+        assert_eq!(
+            validate_classification_apply_count(2, 0)
+                .unwrap_err()
+                .to_string(),
+            "classification batch became stale (0/2 results applied); rerun after the active classifier finishes"
         );
     }
 

--- a/crates/dakia-core/src/classification.rs
+++ b/crates/dakia-core/src/classification.rs
@@ -5,22 +5,80 @@
 
 use anyhow::{bail, Context, Result};
 use ort::{session::Session, value::Tensor};
+use sha2::{Digest, Sha256};
 use std::path::Path;
 use tokenizers::{PaddingParams, Tokenizer, TruncationParams};
 
 const MAX_SEQUENCE_LENGTH: usize = 384;
 const INFERENCE_BATCH_SIZE: usize = 16;
 const CATEGORY_WIDTH: usize = 6;
+const MAX_EVIDENCE_BODY_CHARS: usize = 4_000;
 
 #[derive(Debug, Clone)]
 pub struct ModelClassification {
     pub category: String,
-    pub confidence: f64,
+    /// Probability for the stored category when it is the model's own winner.
+    /// Deterministic policy overrides deliberately have no model confidence.
+    pub confidence: Option<f64>,
+}
+
+/// The trusted fields that make up one classification request.
+///
+/// `classification_signals` is deliberately distinct from message content: it
+/// contains only RFC/header information extracted by the mail parser. Do not
+/// put it into `subject` or `body_text`, and do not derive it by parsing the
+/// model prompt. Message authors control the latter two fields.
+#[derive(Debug, Clone)]
+pub struct EmailClassificationInput {
+    pub from_name: Option<String>,
+    pub from_address: String,
+    pub subject: String,
+    pub body_text: String,
+    pub classification_signals: String,
+    /// Account-local thread evidence: a verified participant relationship or
+    /// a message in the user's Sent/thread history. It is not derived from a
+    /// sender-controlled Reply-To header.
+    pub known_correspondence: bool,
+}
+
+impl EmailClassificationInput {
+    pub fn new(
+        from_name: Option<&str>,
+        from_address: &str,
+        subject: &str,
+        body_text: &str,
+        classification_signals: &str,
+    ) -> Self {
+        Self {
+            from_name: from_name.map(str::to_owned),
+            from_address: from_address.to_owned(),
+            subject: subject.to_owned(),
+            body_text: body_text.chars().take(MAX_EVIDENCE_BODY_CHARS).collect(),
+            classification_signals: classification_signals.to_owned(),
+            known_correspondence: false,
+        }
+    }
+
+    pub fn with_known_correspondence(mut self, known_correspondence: bool) -> Self {
+        self.known_correspondence = known_correspondence;
+        self
+    }
+
+    fn model_text(&self) -> String {
+        email_text(
+            self.from_name.as_deref(),
+            &self.from_address,
+            &self.subject,
+            &self.body_text,
+            &self.classification_signals,
+        )
+    }
 }
 
 pub struct LocalEmailClassifier {
     session: Session,
     tokenizer: Tokenizer,
+    revision: String,
 }
 
 impl LocalEmailClassifier {
@@ -28,6 +86,11 @@ impl LocalEmailClassifier {
     /// Every required file is read locally; no model download is attempted.
     pub fn from_dir(dir: impl AsRef<Path>) -> Result<Self> {
         let dir = dir.as_ref();
+        let manifest = read_asset(dir, "MANIFEST.json")?;
+        let revision = Sha256::digest(&manifest)
+            .iter()
+            .map(|byte| format!("{byte:02x}"))
+            .collect();
         let mut tokenizer =
             Tokenizer::from_bytes(read_asset(dir, "tokenizer.json")?).map_err(|error| {
                 anyhow::anyhow!("could not load bundled email-classifier tokenizer: {error}")
@@ -47,18 +110,36 @@ impl LocalEmailClassifier {
             .context("could not create bundled email-classifier runtime")?
             .commit_from_file(dir.join("model.onnx"))
             .context("could not load bundled ONNX email classifier")?;
-        Ok(Self { session, tokenizer })
+        Ok(Self {
+            session,
+            tokenizer,
+            revision,
+        })
     }
 
-    pub fn classify(&mut self, emails: &[String]) -> Result<Vec<ModelClassification>> {
+    /// Stable revision of the complete bundled model manifest. Storage keeps
+    /// it separately from deterministic policy so replacing model assets
+    /// automatically requeues model-owned decisions.
+    pub fn revision(&self) -> &str {
+        &self.revision
+    }
+
+    pub fn classify(
+        &mut self,
+        emails: &[EmailClassificationInput],
+    ) -> Result<Vec<ModelClassification>> {
         if emails.is_empty() {
             return Ok(Vec::new());
         }
         let mut classifications = Vec::with_capacity(emails.len());
         for batch in emails.chunks(INFERENCE_BATCH_SIZE) {
+            let model_inputs: Vec<String> = batch
+                .iter()
+                .map(EmailClassificationInput::model_text)
+                .collect();
             let encodings = self
                 .tokenizer
-                .encode_batch(batch.to_vec(), true)
+                .encode_batch(model_inputs, true)
                 .map_err(|error| {
                     anyhow::anyhow!("could not tokenize emails for local classification: {error}")
                 })?;
@@ -96,13 +177,12 @@ impl LocalEmailClassifier {
                     .enumerate()
                     .max_by(|left, right| left.1.total_cmp(right.1))
                     .expect("classifier category output has a fixed nonzero width");
+                let model_category = map_category(index);
+                let model_confidence = f64::from(*confidence);
+                let category = resolve_category(model_category, model_confidence, &batch[offset]);
                 classifications.push(ModelClassification {
-                    category: apply_high_precision_signals(
-                        apply_structural_signals(map_category(index), &batch[offset]),
-                        &batch[offset],
-                    )
-                    .to_owned(),
-                    confidence: f64::from(*confidence),
+                    category: category.to_owned(),
+                    confidence: (category == model_category).then_some(model_confidence),
                 });
             }
         }
@@ -187,182 +267,796 @@ fn map_category(index: usize) -> &'static str {
     }
 }
 
-fn apply_structural_signals(category: &'static str, input: &str) -> &'static str {
-    // RFC 2369 list-unsubscribe headers are explicit mailing-list metadata.
-    // Generic unsubscribe wording in the body is deliberately not used here:
-    // security and account-action emails commonly carry that footer too.
-    if category == "notifications" && input.contains("Mailing-list unsubscribe header present") {
-        "newsletters"
-    } else {
-        category
+/// Resolves the model result with evidence that is more reliable than natural
+/// language classification. The order is intentional:
+///
+/// 1. Verified person-to-person correspondence is preserved.
+/// 2. RFC list/bulk metadata outranks sender-authored lexical phrases.
+/// 3. Concrete transaction language outranks weak model/provider hints.
+/// 4. Explicit promotion evidence defeats reply-shaped sales sequences.
+/// 5. Automated or organisation-branded mail that the model calls People is a
+///    notification. Gmail categories are merely a final fallback.
+fn resolve_category(
+    model_category: &'static str,
+    _model_confidence: f64,
+    input: &EmailClassificationInput,
+) -> &'static str {
+    let evidence = ClassificationEvidence::from(input);
+
+    if evidence.is_known_correspondence() {
+        return "people";
+    }
+    if evidence.has_list_or_bulk_evidence() {
+        return "newsletters";
+    }
+    if evidence.has_strong_transaction_intent() {
+        return "transactions";
+    }
+    if evidence.has_promotion_evidence() {
+        return "newsletters";
+    }
+    if evidence.has_service_notification_intent() {
+        return "notifications";
+    }
+    if model_category == "people" && (evidence.is_automated() || evidence.is_organisation()) {
+        return "notifications";
+    }
+
+    // People is precision-first. A large model score or human-sounding prose
+    // cannot establish a relationship: transactional brands and cold sales
+    // frequently receive a confident PERSONAL output. Only verified,
+    // account-local correspondence above can elevate mail into People.
+    if model_category == "people" {
+        return "other";
+    }
+
+    // Provider categories are useful hints, but must never outrank the
+    // independently observed message/header evidence above.
+    match evidence.gmail_category() {
+        // Personal is deliberately not an elevation signal. Gmail can label
+        // an automated order or account message Personal, and it cannot prove
+        // a relationship with the sender.
+        Some("personal") => model_category,
+        Some("promotions") | Some("forums") => "newsletters",
+        Some("social") | Some("updates") => "notifications",
+        _ => model_category,
     }
 }
 
-fn apply_high_precision_signals(category: &'static str, input: &str) -> &'static str {
-    let input = input.to_ascii_lowercase();
-    let transaction_markers = [
-        "password reset",
-        "reset password",
-        "verification code",
-        "confirmation code",
-        "invoice",
-        "receipt",
-        "payment receipt",
-        "order confirmation",
-        "booking confirmation",
-        "reservation confirmation",
-    ];
-    if input.contains("sender mailbox role: automated no-reply service")
-        && input.contains("unsubscribe footer present in message content")
-        && input.contains("good price")
-    {
-        // A price promotion from a bulk, unsubscribable sender is marketing,
-        // even if it describes a future offer-invoice. A receipt or order
-        // confirmation does not satisfy this promotion-specific combination.
-        "newsletters"
-    } else if transaction_markers
-        .iter()
-        .any(|marker| input.contains(marker))
-    {
-        "transactions"
-    } else if input.contains("gmail category: personal") {
-        "people"
-    } else if input.contains("gmail category: promotions")
-        || input.contains("gmail category: forums")
-    {
-        "newsletters"
-    } else if input.contains("gmail category: social") || input.contains("gmail category: updates")
-    {
-        "notifications"
-    } else if input.contains("account executive")
-        && [
-            "book a meeting",
-            "schedule a quick call",
-            "would you be open to a meeting",
-            "would you be open to a short conversation",
-        ]
-        .iter()
-        .any(|marker| input.contains(marker))
-    {
-        // Sales sequences often use `Re:` to imitate a conversation. An
-        // explicit sales role plus meeting CTA is stronger newsletter evidence.
-        "newsletters"
-    } else if (category == "notifications"
-        && input.contains("personal statement")
-        && !input.contains("sender mailbox role: automated no-reply service")
-        && !input.contains("automatically generated message header"))
-        || (category == "newsletters"
-            && input.contains("body: have a look at this")
-            && input.contains("project manager")
-            && !input.contains("mailing-list unsubscribe header present")
-            && !input.contains("automatically generated message header"))
-        || (category != "people"
-            && (input.contains("subject: re:") || input.contains("subject: fwd:"))
-            && !input.contains("sender mailbox role: automated no-reply service")
-            && !input.contains("sender mailbox role: marketing department")
-            && !input.contains("mailing-list unsubscribe header present")
-            && !input.contains("automatically generated message header"))
-    {
-        // Personal or reply-shaped mail from a reachable sender is
-        // correspondence unless stronger automation/list signals are present.
-        "people"
-    } else if (category == "people" || category == "transactions")
-        && ["want to get more clients", "earn 2% interest"]
+struct ClassificationEvidence {
+    subject: String,
+    body: String,
+    display_name: String,
+    mailbox: String,
+    domain: String,
+    signals: Vec<String>,
+    known_correspondence: bool,
+}
+
+impl From<&EmailClassificationInput> for ClassificationEvidence {
+    fn from(input: &EmailClassificationInput) -> Self {
+        let (mailbox, domain) = input.from_address.rsplit_once('@').unwrap_or(("", ""));
+        Self {
+            subject: normalise_message_text(&input.subject),
+            body: normalise_message_text(&input.body_text),
+            display_name: input
+                .from_name
+                .as_deref()
+                .unwrap_or_default()
+                .to_lowercase(),
+            mailbox: mailbox.to_lowercase(),
+            domain: domain.to_lowercase(),
+            // Only the dedicated parser-produced signal field is trusted for
+            // RFC/Gmail evidence. Subject and body text can imitate it.
+            signals: input
+                .classification_signals
+                .lines()
+                .map(|signal| signal.trim().to_lowercase())
+                .filter(|signal| !signal.is_empty())
+                .collect(),
+            known_correspondence: input.known_correspondence,
+        }
+    }
+}
+
+impl ClassificationEvidence {
+    fn message_contains_any(&self, markers: &[&str]) -> bool {
+        markers.iter().any(|marker| {
+            let marker = marker.to_lowercase();
+            self.subject.contains(&marker) || self.body.contains(&marker)
+        })
+    }
+
+    fn has_signal(&self, signal: &str) -> bool {
+        self.signals.iter().any(|candidate| candidate == signal)
+    }
+
+    fn has_strong_transaction_intent(&self) -> bool {
+        self.message_contains_any(&[
+            "password reset",
+            "reset password",
+            "verification code",
+            "confirmation code",
+            "payment receipt",
+            "payment failed",
+            "payment failure",
+            "payment declined",
+            "order confirmation",
+            "booking confirmation",
+            "reservation confirmation",
+            "viga maksmisel",
+            "makse ebaõnnestus",
+            "makse on vastu võetud",
+            "tellimuse kinnit",
+            "tellimus on saadetud",
+            "bestellbestätigung",
+            "bestellung wurde versandt",
+            "zahlung fehlgeschlagen",
+        ]) || self.message_contains_any(&["your invoice", "invoice attached", "your receipt"])
+            || (self.has_business_sender_evidence()
+                && self.message_contains_any(&[
+                    "dispatched",
+                    "has shipped",
+                    "shipment",
+                    "delivery confirmation",
+                    "delivery status",
+                ]))
+    }
+
+    fn has_list_or_bulk_evidence(&self) -> bool {
+        self.has_signal("mailing-list unsubscribe header present")
+            || self.has_signal("mailing-list identifier header present")
+            || self.has_signal("bulk-mail precedence header")
+            || self.has_signal("mailing-list precedence header")
+    }
+
+    fn has_promotion_evidence(&self) -> bool {
+        self.message_contains_any(&[
+            "newsletter:",
+            "marketing campaign",
+            "exclusive offer",
+            "prize draw",
+            "want to get more clients",
+            "earn 2% interest",
+            "live webinar",
+        ]) || (self.message_contains_any(&["kasvata"])
+            && self.message_contains_any(&["sissetulek"]))
+            || (self.message_contains_any(&["account executive"])
+                && self.message_contains_any(&[
+                    "book a meeting",
+                    "schedule a quick call",
+                    "would you be open to a meeting",
+                    "would you be open to a short conversation",
+                ]))
+    }
+
+    fn is_automated(&self) -> bool {
+        self.has_signal("automatically generated message header")
+            || self.has_signal("automatically replied message header")
+            || [
+                "noreply",
+                "no-reply",
+                "do-not-reply",
+                "donotreply",
+                "mailer-daemon",
+            ]
             .iter()
-            .any(|marker| input.contains(marker))
-    {
-        // Clear product-acquisition language is promotional even if sent from
-        // an ordinary mailbox rather than a conventional marketing address.
-        "newsletters"
-    } else if category == "notifications"
-        && ((input.contains("sender mailbox role: automated no-reply service")
-            && ["prize draw", "marketing campaign", "exclusive offer"]
-                .iter()
-                .any(|marker| input.contains(marker)))
-            || input.contains("subject: newsletter:"))
-    {
-        "newsletters"
-    } else if [
-        "subject: a decision has been made",
-        "subject: your application has been successfully submitted",
-        "subject: security alert",
-        "subject: new sign-in",
-        "subject: new login",
-        "subject: approve sign-in",
-        "subject: did you just log in",
-        "subject: account recovery",
-        "confirm your google account settings",
-        "review your google account settings",
-    ]
-    .iter()
-    .any(|marker| input.contains(marker))
-        || (category == "people"
-            && (input.contains("sender mailbox role: automated no-reply service")
-                || input.contains("automatically generated message header")))
-    {
-        "notifications"
-    } else {
-        category
+            .any(|marker| self.mailbox.contains(marker))
+    }
+
+    fn is_organisation(&self) -> bool {
+        let domain_labels = self
+            .domain
+            .split('.')
+            .map(|label| {
+                label
+                    .chars()
+                    .filter(|character| character.is_ascii_alphanumeric())
+                    .collect::<String>()
+            })
+            .filter(|label| {
+                label.len() >= 4
+                    && !matches!(
+                        label.as_str(),
+                        "email"
+                            | "mail"
+                            | "news"
+                            | "info"
+                            | "notify"
+                            | "updates"
+                            | "notifications"
+                            | "noreply"
+                            | "example"
+                            | "test"
+                            | "localhost"
+                    )
+            })
+            .collect::<Vec<_>>();
+        let display_compact = self
+            .display_name
+            .chars()
+            .filter(|character| character.is_ascii_alphanumeric())
+            .collect::<String>();
+        let display_words = self
+            .display_name
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .filter(|word| word.len() >= 3)
+            .collect::<Vec<_>>();
+        let brand_shaped_display = display_words.len() == 1 || self.display_name.contains('.');
+        brand_shaped_display
+            && domain_labels.iter().any(|domain_label| {
+                display_words.iter().any(|word| *word == domain_label)
+                    || display_compact.contains(domain_label)
+            })
+    }
+
+    fn is_known_correspondence(&self) -> bool {
+        self.known_correspondence
+            && self.has_person_shaped_identity()
+            && !self.has_role_mailbox()
+            && !self.is_automated()
+            && !self.has_list_or_bulk_evidence()
+    }
+
+    fn has_role_mailbox(&self) -> bool {
+        const ROLES: &[&str] = &[
+            "admin",
+            "billing",
+            "contact",
+            "customer",
+            "customercare",
+            "customerservice",
+            "events",
+            "hello",
+            "help",
+            "helpdesk",
+            "info",
+            "marketing",
+            "news",
+            "newsletter",
+            "notifications",
+            "notify",
+            "orders",
+            "security",
+            "sales",
+            "service",
+            "support",
+            "supportdesk",
+            "team",
+            "updates",
+        ];
+        self.mailbox
+            .split(|character: char| !character.is_ascii_alphanumeric())
+            .any(|part| ROLES.contains(&part))
+    }
+
+    fn has_person_shaped_identity(&self) -> bool {
+        const ORGANISATION_WORDS: &[&str] = &[
+            "ag",
+            "as",
+            "association",
+            "bank",
+            "bv",
+            "company",
+            "corp",
+            "corporation",
+            "foundation",
+            "gmbh",
+            "group",
+            "inc",
+            "limited",
+            "llc",
+            "ltd",
+            "marketing",
+            "newsletter",
+            "ou",
+            "oü",
+            "oy",
+            "plc",
+            "sa",
+            "shop",
+            "store",
+            "support",
+            "team",
+        ];
+        if self.display_name.contains('.') {
+            return false;
+        }
+        let words = self
+            .display_name
+            .split(|character: char| !character.is_alphabetic())
+            .filter(|word| word.chars().count() >= 2)
+            .collect::<Vec<_>>();
+        words.len() >= 2 && !words.iter().any(|word| ORGANISATION_WORDS.contains(word))
+    }
+
+    fn has_business_sender_evidence(&self) -> bool {
+        self.is_automated() || self.is_organisation() || self.has_role_mailbox()
+    }
+
+    fn has_service_notification_intent(&self) -> bool {
+        self.message_contains_any(&[
+            "a decision has been made",
+            "application has been successfully submitted",
+            "security alert",
+            "new sign-in",
+            "new login",
+            "approve sign-in",
+            "did you just log in",
+            "account recovery",
+            "confirm your google account settings",
+            "review your google account settings",
+        ]) || ((self.is_automated() || self.is_organisation())
+            && self.message_contains_any(&["welcome", "tere tulemast", "konto", "account update"]))
+    }
+
+    fn gmail_category(&self) -> Option<&str> {
+        if self.has_signal("gmail category: personal") {
+            Some("personal")
+        } else if self.has_signal("gmail category: promotions") {
+            Some("promotions")
+        } else if self.has_signal("gmail category: social") {
+            Some("social")
+        } else if self.has_signal("gmail category: updates") {
+            Some("updates")
+        } else if self.has_signal("gmail category: forums") {
+            Some("forums")
+        } else {
+            None
+        }
+    }
+}
+
+fn normalise_message_text(value: &str) -> String {
+    value
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+#[cfg(test)]
+mod resolver_tests {
+    use super::*;
+
+    fn email(
+        name: Option<&str>,
+        address: &str,
+        subject: &str,
+        body: &str,
+        signals: &str,
+    ) -> EmailClassificationInput {
+        EmailClassificationInput::new(name, address, subject, body, signals)
+    }
+
+    #[test]
+    fn transaction_intent_beats_model_and_gmail_evidence() {
+        let amazon = email(
+            Some("Amazon.de"),
+            "shipment-tracking@amazon.de",
+            "Dispatched: ‘BENFEI 6-in-1 USB C HUB…’",
+            "Your order has been dispatched and is on its way.",
+            "Gmail category: Personal",
+        );
+        let nojus_payment = email(
+            Some("Nojus.ee"),
+            "noreply@nojus.ee",
+            "[NOJUS.EE] VIGA MAKSMISEL",
+            "TEIE MAKSE EBAÕNNESTUS. PALUN PROOVIGE UUESTI.",
+            "Gmail category: Personal",
+        );
+        let nojus_order = email(
+            Some("Nojus.ee"),
+            "orders@nojus.ee",
+            "[Nojus.ee] Tellimuse kinnitamine",
+            "Teie tellimus on vastu võetud.",
+            "Gmail category: Personal",
+        );
+        let nojus_accepted_payment = email(
+            Some("Nojus.ee"),
+            "noreply@nojus.ee",
+            "[Nojus.ee] Makse on vastu võetud",
+            "Teie makse on vastu võetud.",
+            "Gmail category: Personal",
+        );
+
+        assert_eq!(resolve_category("people", 0.99, &amazon), "transactions");
+        assert_eq!(
+            resolve_category("newsletters", 0.87, &nojus_payment),
+            "transactions"
+        );
+        assert_eq!(
+            resolve_category("people", 0.98, &nojus_order),
+            "transactions"
+        );
+        assert_eq!(
+            resolve_category("people", 0.98, &nojus_accepted_payment),
+            "transactions"
+        );
+    }
+
+    #[test]
+    fn organisation_welcome_is_a_notification_not_people() {
+        let welcome = email(
+            Some("Nojus.ee"),
+            "info@nojus.ee",
+            "[Nojus.ee] Tere tulemast!",
+            "Tere tulemast Nojus.ee kontole.",
+            "Gmail category: Personal",
+        );
+
+        assert_eq!(resolve_category("people", 0.96, &welcome), "notifications");
+    }
+
+    #[test]
+    fn real_bulk_headers_are_authoritative_newsletter_evidence() {
+        let bigbank = email(
+            Some("Bigbank"),
+            "news@bigbank.ee",
+            "Kasvata Bigbankis enda sissetulekud",
+            "Loe selle kuu pakkumist.",
+            "Mailing-list identifier header present\nBulk-mail precedence header\nGmail category: Personal",
+        );
+
+        assert_eq!(resolve_category("people", 0.98, &bigbank), "newsletters");
+
+        let acquisition_without_headers = email(
+            Some("Bigbank"),
+            "info@bigbank.ee",
+            "Kasvata Bigbankis enda sissetulekud",
+            "Tutvu pakkumisega.",
+            "",
+        );
+        assert_eq!(
+            resolve_category("people", 0.97, &acquisition_without_headers),
+            "newsletters"
+        );
+
+        let branded_subdomain = email(
+            Some("Bigbank"),
+            "info@email.bigbank.ee",
+            "Konto teade",
+            "Vaata oma kontot.",
+            "",
+        );
+        assert_eq!(
+            resolve_category("people", 0.98, &branded_subdomain),
+            "notifications"
+        );
+
+        let shipment_trends = email(
+            Some("Logistics Weekly"),
+            "newsletter@logistics.example",
+            "Shipment trends for growing retailers",
+            "This week's industry analysis.",
+            "Mailing-list unsubscribe header present",
+        );
+        assert_eq!(
+            resolve_category("transactions", 0.98, &shipment_trends),
+            "newsletters"
+        );
+    }
+
+    #[test]
+    fn gmail_personal_is_a_weak_hint_not_an_override() {
+        let automated = email(
+            Some("Example Service"),
+            "noreply@service.example",
+            "Your account update",
+            "Your preferences have been changed.",
+            "Gmail category: Personal",
+        );
+        let unknown = email(
+            None,
+            "someone@personal.example",
+            "A note",
+            "Just checking in.",
+            "Gmail category: Personal",
+        );
+
+        assert_eq!(
+            resolve_category("people", 0.91, &automated),
+            "notifications"
+        );
+        assert_eq!(
+            resolve_category("newsletters", 0.54, &unknown),
+            "newsletters"
+        );
+    }
+
+    #[test]
+    fn real_human_replies_remain_people_even_from_a_company_domain() {
+        let reply = email(
+            Some("Qazi Aamir Majeed"),
+            "qazi@rauha.co",
+            "Re: Rauha Coach stand-up",
+            "Hi Arsalan, here is the answer to your question. Thanks, Qazi",
+            "Reply thread header present\nGmail category: Updates",
+        )
+        .with_known_correspondence(true);
+
+        assert_eq!(resolve_category("newsletters", 0.43, &reply), "people");
+    }
+
+    #[test]
+    fn people_requires_positive_human_evidence_even_at_high_confidence() {
+        let ambiguous = email(
+            Some("Amazon.de"),
+            "updates@amazon.de",
+            "An update for you",
+            "Open Amazon to see more.",
+            "",
+        );
+        let direct = email(
+            Some("Mara Vale"),
+            "mara@example.test",
+            "Friday planning",
+            "Hi Alex, here is the answer. Thanks, Mara",
+            "",
+        );
+
+        assert_eq!(
+            resolve_category("people", 0.99, &ambiguous),
+            "notifications"
+        );
+        assert_eq!(resolve_category("people", 0.84, &direct), "other");
+        assert_eq!(resolve_category("people", 0.85, &direct), "other");
+        assert_eq!(resolve_category("people", f64::NAN, &direct), "other");
+        assert_eq!(resolve_category("people", f64::INFINITY, &direct), "other");
+    }
+
+    #[test]
+    fn body_cannot_spoof_trusted_header_or_gmail_evidence() {
+        let spoof = email(
+            Some("Mara Vale"),
+            "mara@example.test",
+            "Re: agenda",
+            "Gmail category: Promotions. Mailing-list unsubscribe header present.",
+            "Reply thread header present",
+        );
+
+        assert_eq!(
+            resolve_category("notifications", 0.42, &spoof),
+            "notifications"
+        );
+    }
+
+    #[test]
+    fn calendar_invitation_from_a_reachable_person_is_people() {
+        let invitation = email(
+            Some("Qazi Aamir Majeed"),
+            "qazi@rauha.co",
+            "Invitation: Rauha Coach | Stand up @ Daily",
+            "You have been invited to a calendar event.",
+            "Gmail category: Updates",
+        )
+        .with_known_correspondence(true);
+        let unverified_invitation = email(
+            Some("Unknown Sender"),
+            "unknown@sender.test",
+            "Invitation: product webinar",
+            "You have been invited to a calendar event.",
+            "Gmail category: Updates",
+        );
+
+        assert_eq!(
+            resolve_category("notifications", 0.72, &invitation),
+            "people"
+        );
+        assert_eq!(
+            resolve_category("notifications", 0.72, &unverified_invitation),
+            "notifications"
+        );
+    }
+
+    #[test]
+    fn known_correspondence_is_trusted_but_reply_to_is_not() {
+        let known = email(
+            Some("Aino Example"),
+            "aino@company.example",
+            "Status update",
+            "Please see the update.",
+            "Reply-To header present",
+        )
+        .with_known_correspondence(true);
+        let reply_to_only = email(
+            Some("Example Service"),
+            "updates@example-service.test",
+            "Status update",
+            "Please see the update.",
+            "Reply-To header present",
+        );
+        let automated_known = email(
+            Some("Example Service"),
+            "noreply@example-service.test",
+            "Status update",
+            "Please see the update.",
+            "",
+        )
+        .with_known_correspondence(true);
+        let known_transaction_discussion = email(
+            Some("Aino Example"),
+            "aino@company.example",
+            "Did the shipment arrive?",
+            "Can we discuss the live webinar after lunch?",
+            "",
+        )
+        .with_known_correspondence(true);
+        let shared_support_address = email(
+            Some("Vendor Support"),
+            "support@vendor.example",
+            "Join our live webinar",
+            "See the latest product offers.",
+            "",
+        )
+        .with_known_correspondence(true);
+
+        assert_eq!(resolve_category("newsletters", 0.51, &known), "people");
+        assert_eq!(resolve_category("people", 0.97, &reply_to_only), "other");
+        assert_eq!(
+            resolve_category("people", 0.97, &automated_known),
+            "notifications"
+        );
+        assert_eq!(
+            resolve_category("transactions", 0.97, &known_transaction_discussion),
+            "people"
+        );
+        assert_eq!(
+            resolve_category("people", 0.97, &shared_support_address),
+            "newsletters"
+        );
+    }
+
+    #[test]
+    fn precedence_and_automation_exclusions_are_stable() {
+        let all_evidence = email(
+            Some("Amazon.de"),
+            "noreply@amazon.de",
+            "  DISPATCHED:  order 123 ",
+            "Your shipment is ready.",
+            "Mailing-list unsubscribe header present\nAutomatically generated message header",
+        )
+        .with_known_correspondence(true);
+        let no_reply_reply = email(
+            Some("Example Service"),
+            "no-reply@example-service.test",
+            "RE: Your account",
+            "This is an automatically generated response.",
+            "",
+        );
+        let list_reply = email(
+            Some("Example List"),
+            "list@example.test",
+            "Re: Weekly discussion",
+            "A digest.",
+            "Mailing-list precedence header",
+        )
+        .with_known_correspondence(true);
+
+        assert_eq!(
+            resolve_category("people", 0.99, &all_evidence),
+            "newsletters"
+        );
+        assert_eq!(
+            resolve_category("people", 0.99, &no_reply_reply),
+            "notifications"
+        );
+        assert_eq!(resolve_category("people", 0.99, &list_reply), "newsletters");
+    }
+
+    #[test]
+    fn reply_subject_without_trusted_thread_context_cannot_elevate_people() {
+        let sales_reply = email(
+            Some("Pat Example"),
+            "pat@company.test",
+            "Re: a quick opportunity",
+            "I would like to sell you something.",
+            "",
+        );
+        let synthetic_thread_reply = email(
+            Some("Pat Example"),
+            "pat@company.test",
+            "Re: a quick opportunity",
+            "I would like to sell you something.",
+            "Reply thread header present",
+        );
+        let invoice_tips = email(
+            Some("Example Publication"),
+            "bulletin@example.test",
+            "Invoice software tips for teams",
+            "This week's practical newsletter.",
+            "Mailing-list unsubscribe header present",
+        );
+        let order_workflow = email(
+            Some("Example Publication"),
+            "bulletin@example.test",
+            "Improve your order workflow",
+            "This week's practical newsletter.",
+            "Mailing-list unsubscribe header present",
+        );
+        let first_contact = email(
+            Some("Pat Example"),
+            "pat@company.test",
+            "Question about our project",
+            "Can you confirm the shipment arrived before our meeting?",
+            "",
+        );
+        let first_contact_dispatched_documents = email(
+            Some("Pat Example"),
+            "pat@company.test",
+            "Documents for our review",
+            "I dispatched the documents yesterday; can we review them tomorrow?",
+            "",
+        );
+
+        assert_eq!(resolve_category("people", 0.99, &sales_reply), "other");
+        assert_eq!(
+            resolve_category("people", 0.99, &synthetic_thread_reply),
+            "other"
+        );
+        assert_eq!(
+            resolve_category("people", 0.99, &invoice_tips),
+            "newsletters"
+        );
+        assert_eq!(
+            resolve_category("people", 0.99, &order_workflow),
+            "newsletters"
+        );
+        assert_eq!(resolve_category("people", 0.99, &first_contact), "other");
+        assert_eq!(
+            resolve_category("people", 0.99, &first_contact_dispatched_documents),
+            "other"
+        );
+    }
+
+    #[test]
+    fn repeated_transaction_templates_are_consistent_despite_case_and_whitespace() {
+        let first = email(
+            Some("Amazon.de"),
+            "shipment-tracking@amazon.de",
+            "Dispatched: order 1",
+            "Your shipment is on its way.",
+            "",
+        );
+        let second = email(
+            Some("Amazon.de"),
+            "shipment-tracking@amazon.de",
+            "  dIsPaTcHeD:   order 2 ",
+            "Your   shipment is on its way.",
+            "Gmail category: Personal",
+        );
+
+        assert_eq!(resolve_category("people", 0.91, &first), "transactions");
+        assert_eq!(resolve_category("people", 0.91, &second), "transactions");
+    }
+
+    #[test]
+    fn classification_input_bounds_sender_controlled_body_work() {
+        let body = "õ".repeat(MAX_EVIDENCE_BODY_CHARS + 10_000);
+        let input = email(
+            Some("Example Sender"),
+            "sender@example.test",
+            "A bounded note",
+            &body,
+            "",
+        );
+
+        assert_eq!(input.body_text.chars().count(), MAX_EVIDENCE_BODY_CHARS);
     }
 }
 
 #[cfg(test)]
-mod tests {
+mod model_integration_tests {
     use super::*;
 
-    #[test]
-    fn local_model_classifies_representative_email_types() {
+    fn classifier() -> LocalEmailClassifier {
         let resources = Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("../../apps/desktop/src-tauri/resources/email-classifier-v2");
-        let mut classifier = LocalEmailClassifier::from_dir(resources).unwrap();
-        let emails = [
-            email_text(
-                Some("Mara Vale"),
-                "mara@example.test",
-                "Friday planning",
-                "Hi Alex, could we move our review to Friday afternoon? Thanks, Mara",
-                "",
-            ),
-            email_text(
-                Some("Acme Billing"),
-                "billing@example.com",
-                "Your payment receipt",
-                "Your payment of 42.00 EUR was received. Invoice attached.",
-                "",
-            ),
-            email_text(
-                Some("Example Security"),
-                "security@example.com",
-                "New sign-in alert",
-                "We noticed a new sign-in to your account from Tallinn.",
-                "",
-            ),
-            email_text(
-                Some("The Weekly Publication"),
-                "weekly@publication.example",
-                "This week's design notes",
-                "Your weekly newsletter with selected articles and product news.",
-                "",
-            ),
-        ];
-        let classifications = classifier.classify(&emails).unwrap();
-        assert!(matches!(
-            classifications[0].category.as_str(),
-            "people" | "notifications"
-        ));
-        assert_eq!(classifications[1].category, "transactions");
-        assert_eq!(classifications[2].category, "notifications");
-        assert!(matches!(
-            classifications[3].category.as_str(),
-            "newsletters" | "notifications"
-        ));
-        assert!(classifications
-            .iter()
-            .all(|item| (0.0..=1.0).contains(&item.confidence)));
+        LocalEmailClassifier::from_dir(resources).unwrap()
     }
 
     #[test]
-    fn classifier_category_mapping_covers_every_model_output() {
+    fn model_category_mapping_covers_every_output() {
         assert_eq!(map_category(0), "notifications");
         assert_eq!(map_category(1), "newsletters");
         assert_eq!(map_category(2), "people");
@@ -372,337 +1066,103 @@ mod tests {
     }
 
     #[test]
-    fn email_text_preserves_the_sender_display_name() {
-        let text = email_text(
-            Some("Example App Store"),
-            "updates-noreply@apps.example.test",
-            "Alex, your monthly update has arrived",
-            "Discover new apps and games recommended for you.",
-            "",
-        );
-
-        assert!(text.contains("Sender display name: Example App Store."));
-        assert!(text.contains("Sender mailbox: updates-noreply"));
-        assert!(text.contains("Sender domain: apps.example.test"));
-        assert!(text.contains("Sender mailbox role: automated no-reply service"));
-    }
-
-    #[test]
-    fn does_not_treat_a_branded_monthly_update_as_personal_correspondence() {
-        let resources = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../apps/desktop/src-tauri/resources/email-classifier-v2");
-        let mut classifier = LocalEmailClassifier::from_dir(resources).unwrap();
-        let email = email_text(
-            Some("Example App Store"),
-            "partners-noreply@apps.example.test",
-            "Alex, your monthly update has arrived",
-            "Discover new apps and games recommended for you in this monthly update from Example App Store.",
-            "Mailing-list unsubscribe header present",
-        );
-
-        let result = classifier.classify(&[email]).unwrap();
-        assert!(matches!(
-            result[0].category.as_str(),
-            "newsletters" | "notifications"
-        ));
-    }
-
-    #[test]
-    fn does_not_treat_brand_marketing_as_personal_correspondence() {
-        let resources = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../apps/desktop/src-tauri/resources/email-classifier-v2");
-        let mut classifier = LocalEmailClassifier::from_dir(resources).unwrap();
-        let emails = [
-            email_text(
-                Some("Example Bank"),
-                "noreply@bank.example.test",
-                "Thanks for being an Example Bank customer",
-                "Hello, Alex. Thank you for being with us. We are organising a prize draw for active customers. You may unsubscribe from Example Bank marketing emails.",
+    fn local_model_and_policy_classify_the_production_regression_corpus() {
+        let messages = [
+            EmailClassificationInput::new(
+                Some("Amazon.de"),
+                "versandbestaetigung@amazon.de",
+                "Dispatched: ‘BENFEI 6-in-1 USB C HUB…’",
+                "",
                 "",
             ),
-            email_text(
-                Some("Example Voice Platform"),
-                "marketing@voice.example.test",
-                "Live Webinar: Build a TTS Evaluation Pipeline That Works in Production",
-                "Join our live webinar to learn a framework for evaluating voice-agent TTS in production. Register to attend this marketing event.",
+            EmailClassificationInput::new(
+                Some("Nojus.ee"),
+                "seklos@nojus.lt",
+                "[Nojus.ee] Viga maksmisel",
                 "",
+                "Reply-To header present",
+            ),
+            EmailClassificationInput::new(
+                Some("Nojus.ee"),
+                "seklos@nojus.lt",
+                "[Nojus.ee] Tere tulemast!",
+                "",
+                "Reply-To header present",
+            ),
+            EmailClassificationInput::new(
+                Some("Bigbank"),
+                "info@email.bigbank.ee",
+                "Kasvata Bigbankis enda sissetulekut",
+                "",
+                "Mailing-list unsubscribe header present\nReply-To header present",
+            ),
+            EmailClassificationInput::new(
+                Some("Qazi Aamir Majeed"),
+                "qazi@rauha.co",
+                "Invitation: Rauha Coach | Stand up @ Daily",
+                "You have been invited to a calendar event.",
+                "",
+            )
+            .with_known_correspondence(true),
+        ];
+
+        let results = classifier().classify(&messages).unwrap();
+        assert_eq!(
+            results
+                .iter()
+                .map(|result| result.category.as_str())
+                .collect::<Vec<_>>(),
+            [
+                "transactions",
+                "transactions",
+                "notifications",
+                "newsletters",
+                "people",
+            ]
+        );
+        assert!(results.iter().all(|result| result
+            .confidence
+            .is_none_or(|confidence| (0.0..=1.0).contains(&confidence))));
+    }
+
+    #[test]
+    fn model_and_policy_preserve_representative_categories() {
+        let messages = [
+            EmailClassificationInput::new(
+                Some("Mara Vale"),
+                "mara@example.test",
+                "Friday planning",
+                "Hi Alex, could we move our review to Friday afternoon? Thanks, Mara",
+                "",
+            )
+            .with_known_correspondence(true),
+            EmailClassificationInput::new(
+                Some("Acme Billing"),
+                "billing@example.com",
+                "Your payment receipt",
+                "Your payment of 42.00 EUR was received. Invoice attached.",
+                "",
+            ),
+            EmailClassificationInput::new(
+                Some("Example Security"),
+                "security@example.com",
+                "New sign-in alert",
+                "We noticed a new sign-in to your account from Tallinn.",
+                "",
+            ),
+            EmailClassificationInput::new(
+                Some("The Weekly Publication"),
+                "weekly@publication.example",
+                "This week's design notes",
+                "Your weekly newsletter with selected articles and product news.",
+                "Mailing-list unsubscribe header present",
             ),
         ];
 
-        let results = classifier.classify(&emails).unwrap();
-        assert!(results
-            .iter()
-            .all(|result| matches!(result.category.as_str(), "newsletters" | "notifications")));
-    }
-
-    #[test]
-    fn decisive_transactional_messages_override_an_incompatible_model_category() {
-        let password_reset = email_text(
-            Some("Example Homes"),
-            "noreply@homes.example.test",
-            "Reset your password",
-            "Use this message to reset password for your account.",
-            "",
-        );
-        let receipt = email_text(
-            Some("Example Shop"),
-            "receipts@shop.example.test",
-            "Receipt",
-            "Thank you for your purchase.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("people", &password_reset),
-            "transactions"
-        );
-        assert_eq!(
-            apply_high_precision_signals("newsletters", &receipt),
-            "transactions"
-        );
-    }
-
-    #[test]
-    fn direct_personal_replies_override_non_person_categories() {
-        let reply = email_text(
-            Some("Jordan Example"),
-            "jordan@example.test",
-            "Re: Quick question about your Ciabatta recipe",
-            "Here is the answer to your question.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("newsletters", &reply),
-            "people"
-        );
-        assert_eq!(
-            apply_high_precision_signals("notifications", &reply),
-            "people"
-        );
-        assert_eq!(
-            apply_high_precision_signals("transactions", &reply),
-            "people"
-        );
-
-        let padded_reply = email_text(
-            Some("Mara Vale"),
-            "mara@example.test",
-            "  RE: Project question  ",
-            "Here is the answer.",
-            "",
-        );
-        assert_eq!(
-            apply_high_precision_signals("notifications", &padded_reply),
-            "people"
-        );
-    }
-
-    #[test]
-    fn decisive_service_updates_are_notifications() {
-        let decision = email_text(
-            Some("Example Public Service"),
-            "info@service.example.test",
-            "A decision has been made for you",
-            "Open the service to read the decision.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("newsletters", &decision),
-            "notifications"
-        );
-        assert_eq!(
-            apply_high_precision_signals("people", "Automatically generated message header",),
-            "notifications"
-        );
-    }
-
-    #[test]
-    fn unsubscribe_footer_does_not_turn_security_email_into_newsletter() {
-        let security_update = email_text(
-            Some("Example Social"),
-            "security@social.example.test",
-            "Did you just log in near Tallinn on a new device?",
-            "If this was not you, secure your account. You can unsubscribe from these emails in settings.",
-            "",
-        );
-
-        assert_eq!(
-            apply_structural_signals("notifications", &security_update),
-            "notifications"
-        );
-        assert_eq!(
-            apply_high_precision_signals("notifications", &security_update),
-            "notifications"
-        );
-    }
-
-    #[test]
-    fn genuine_list_header_still_can_resolve_generic_alert_as_newsletter() {
-        let newsletter = email_text(
-            Some("Example Weekly"),
-            "weekly@example.com",
-            "This week's links",
-            "Articles selected for you.",
-            "Mailing-list unsubscribe header present",
-        );
-
-        assert_eq!(
-            apply_structural_signals("notifications", &newsletter),
-            "newsletters"
-        );
-    }
-
-    #[test]
-    fn clear_product_acquisition_copy_is_not_personal_or_transactional() {
-        let marketing = email_text(
-            Some("Example Growth"),
-            "info@growth.example.test",
-            "Want to get more clients?",
-            "A solution for acquiring more customers.",
-            "",
-        );
-        let bank_promotion = email_text(
-            Some("Example Bank"),
-            "offers@bank.example.test",
-            "Earn 2% interest on your current account",
-            "Learn about the offer.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("people", &marketing),
-            "newsletters"
-        );
-        assert_eq!(
-            apply_high_precision_signals("transactions", &bank_promotion),
-            "newsletters"
-        );
-    }
-
-    #[test]
-    fn sales_follow_up_does_not_become_people_just_because_it_is_a_reply() {
-        let sales_follow_up = email_text(
-            Some("Jordan Example"),
-            "jordan@example.com",
-            "Re: Your business account",
-            "Would you be open to a short conversation? Book a meeting with me. Jordan Example, Account Executive.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("people", &sales_follow_up),
-            "newsletters"
-        );
-        assert_eq!(
-            apply_high_precision_signals("transactions", &sales_follow_up),
-            "newsletters"
-        );
-    }
-
-    #[test]
-    fn personal_statement_from_a_reachable_sender_is_people() {
-        let statement = email_text(
-            Some("G. Example"),
-            "person@example.com",
-            "Statement about my employment",
-            "I am providing this personal statement to support you.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("notifications", &statement),
-            "people"
-        );
-    }
-
-    #[test]
-    fn short_project_manager_note_is_people_not_a_newsletter() {
-        let note = email_text(
-            Some("Taylor Example"),
-            "taylor@example.com",
-            "Project details",
-            "Have a look at this. Regards, Taylor Example, Project Manager.",
-            "",
-        );
-
-        assert_eq!(apply_high_precision_signals("newsletters", &note), "people");
-    }
-
-    #[test]
-    fn gmail_server_categories_are_local_high_precision_signals() {
-        let personal = email_text(
-            Some("Mara"),
-            "mara@example.com",
-            "Hello",
-            "A note from Mara.",
-            "Gmail category: Personal",
-        );
-        let promotion = email_text(
-            Some("Example Store"),
-            "offers@example.com",
-            "This week's deal",
-            "Save on your next order.",
-            "Gmail category: Promotions",
-        );
-        let update = email_text(
-            Some("Example Service"),
-            "updates@example.com",
-            "Account update",
-            "A service update.",
-            "Gmail category: Updates",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("newsletters", &personal),
-            "people"
-        );
-        assert_eq!(
-            apply_high_precision_signals("people", &promotion),
-            "newsletters"
-        );
-        assert_eq!(
-            apply_high_precision_signals("people", &update),
-            "notifications"
-        );
-    }
-
-    #[test]
-    fn newsletter_subject_is_not_a_generic_notification() {
-        let bulletin = email_text(
-            Some("Example Publication"),
-            "bulletin@example.com",
-            "Newsletter: this week's product updates",
-            "The latest product bulletin.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("notifications", &bulletin),
-            "newsletters"
-        );
-    }
-
-    #[test]
-    fn bulk_insurance_price_promotion_is_not_a_transaction() {
-        let promotion = email_text(
-            Some("Example Bank"),
-            "noreply@bank.example.test",
-            "A good price for car insurance this season",
-            "Review our car insurance promotion and prize draw. This is a marketing email from Example Bank and you may unsubscribe.",
-            "",
-        );
-
-        assert_eq!(
-            apply_high_precision_signals("transactions", &promotion),
-            "newsletters"
-        );
-
-        let resources = Path::new(env!("CARGO_MANIFEST_DIR"))
-            .join("../../apps/desktop/src-tauri/resources/email-classifier-v2");
-        let mut classifier = LocalEmailClassifier::from_dir(resources).unwrap();
-        let result = classifier.classify(&[promotion]).unwrap();
-        assert_eq!(result[0].category, "newsletters");
+        let results = classifier().classify(&messages).unwrap();
+        assert_eq!(results[0].category, "people");
+        assert_eq!(results[1].category, "transactions");
+        assert_eq!(results[2].category, "notifications");
+        assert_eq!(results[3].category, "newsletters");
     }
 }

--- a/crates/dakia-core/src/lib.rs
+++ b/crates/dakia-core/src/lib.rs
@@ -10,7 +10,7 @@ pub mod storage;
 
 pub use account::{Account, AccountAuth, AccountDraft, AccountId};
 pub use ai::{AiConfig, AiProvider, AiService};
-pub use classification::{LocalEmailClassifier, ModelClassification};
+pub use classification::{EmailClassificationInput, LocalEmailClassifier, ModelClassification};
 pub use mail::{
     mailbox_action_destination, remote_mailbox, ComposeMessage, MailService, MailboxAction,
     RealtimeCycle, RealtimeMode, SyncProgress, SyncResult, UnsubscribeOutcome,
@@ -19,6 +19,6 @@ pub use oauth::{OAuthFlow, OAuthProviderConfig, OAuthTokens};
 pub use provider::{ProviderPreset, Security};
 pub use storage::{
     Attachment, AttachmentPresentation, CachedMessageContent, MailConversation,
-    MailConversationPage, MailCursor, MailRebuildJob, MailSummary, SearchQuery, SmartInboxPage,
-    SmartInboxQuery, SmartInboxSectionPage, Store,
+    MailConversationPage, MailCursor, MailRebuildJob, MailSummary, ModelClassificationUpdate,
+    SearchQuery, SmartInboxPage, SmartInboxQuery, SmartInboxSectionPage, Store,
 };

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -5054,6 +5054,53 @@ fn parse_first_address(value: &str) -> (Option<String>, String) {
     }
 }
 
+pub(crate) fn parsed_header_mailboxes(value: &str) -> Vec<String> {
+    let raw = format!("To: {value}\r\n\r\n");
+    let Some(parsed) = parse_header_block(raw.as_bytes()).ok() else {
+        return Vec::new();
+    };
+    match parsed
+        .header(HeaderName::To)
+        .and_then(HeaderValue::as_address)
+    {
+        Some(ParsedAddress::List(addresses)) => addresses
+            .iter()
+            .filter_map(|address| address.address.as_deref())
+            .filter(|address| is_bounded_mailbox_address(address))
+            .map(ToString::to_string)
+            .collect(),
+        Some(ParsedAddress::Group(groups)) => groups
+            .iter()
+            .flat_map(|group| group.addresses.iter())
+            .filter_map(|address| address.address.as_deref())
+            .filter(|address| is_bounded_mailbox_address(address))
+            .map(ToString::to_string)
+            .collect(),
+        None => Vec::new(),
+    }
+}
+
+fn is_bounded_mailbox_address(value: &str) -> bool {
+    if value.is_empty() || value.len() > 320 {
+        return false;
+    }
+    let Some((local, domain)) = value.split_once('@') else {
+        return false;
+    };
+    !local.is_empty()
+        && !domain.is_empty()
+        && !domain.contains('@')
+        && !local.starts_with('.')
+        && !local.ends_with('.')
+        && !domain.starts_with('.')
+        && !domain.ends_with('.')
+        && value.chars().all(|character| {
+            !character.is_whitespace()
+                && !character.is_control()
+                && !matches!(character, '<' | '>' | ',' | ';' | ':' | '"' | '(' | ')')
+        })
+}
+
 #[derive(Default)]
 struct BodySelection {
     plain: Vec<String>,
@@ -10785,5 +10832,20 @@ For you, Alex =E2=80=94 related to your saved topic."
 
         assert!(signals.contains("Gmail category: Promotions"));
         assert!(!signals.contains("\\Inbox"));
+    }
+
+    #[test]
+    fn sent_correspondents_use_rfc_mailboxes_not_display_name_text() {
+        assert_eq!(
+            parsed_header_mailboxes(
+                "\"victim@example.com\" <actual@example.net>, Friends: Aino <aino@example.test>, Qazi <qazi@rauha.co>;"
+            ),
+            vec![
+                "actual@example.net".to_string(),
+                "aino@example.test".to_string(),
+                "qazi@rauha.co".to_string(),
+            ]
+        );
+        assert!(parsed_header_mailboxes("victim@example.com in prose").is_empty());
     }
 }

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -39,6 +39,15 @@ const MESSAGE_CONTENT_CACHE_RECENT_WINDOW_DAYS: i64 = 30;
 /// part when interpreted by the sectioned MIME planner.
 const ATTACHMENT_PRESENTATION_CACHE_VERSION: &str = "2";
 const ATTACHMENT_PRESENTATION_VERSION: i64 = 2;
+/// Classification policy is versioned independently from the bundled model.
+/// A policy change must re-run model-owned classifications while preserving
+/// categories the user chose explicitly.
+const CLASSIFICATION_POLICY_VERSION: &str = "2";
+/// Prevent two concurrently running app/CLI versions from repeatedly claiming
+/// different classifier revisions and requeueing each other's results. A
+/// normal batch is far shorter than this; an inactive/crashed process yields
+/// automatically without a durable lock.
+const CLASSIFICATION_REVISION_ACTIVITY_SECONDS: i64 = 90;
 /// Foreground readers wait at most 60 seconds for another body fetch. Keep a
 /// short grace period beyond that before a crashed process's lease may be
 /// replaced, while preserving fresh claims across concurrently open processes.
@@ -309,6 +318,53 @@ pub struct CachedMessageContent {
     pub attachments: Vec<Attachment>,
 }
 
+/// One model decision tied to the exact catalogue evidence used for inference.
+/// Applying it is compare-and-swap: a concurrent sync that changes any input
+/// makes the result stale instead of letting it overwrite newer evidence.
+#[derive(Debug, Clone)]
+pub struct ModelClassificationUpdate {
+    id: String,
+    category: String,
+    confidence: Option<f64>,
+    expected_from_name: Option<String>,
+    expected_from_address: String,
+    expected_subject: String,
+    expected_snippet: String,
+    expected_body_text: String,
+    expected_signals: String,
+    expected_known_correspondence: bool,
+    expected_owner: String,
+    expected_model_revision: String,
+    expected_policy_revision: &'static str,
+}
+
+impl ModelClassificationUpdate {
+    pub fn from_message(
+        message: &MailSummary,
+        category: String,
+        confidence: Option<f64>,
+        known_correspondence: bool,
+        owner: &str,
+        model_revision: &str,
+    ) -> Self {
+        Self {
+            id: message.id.clone(),
+            category,
+            confidence,
+            expected_from_name: message.from_name.clone(),
+            expected_from_address: message.from_address.clone(),
+            expected_subject: message.subject.clone(),
+            expected_snippet: message.snippet.clone(),
+            expected_body_text: message.body_text.clone(),
+            expected_signals: message.classification_signals.clone(),
+            expected_known_correspondence: known_correspondence,
+            expected_owner: owner.to_owned(),
+            expected_model_revision: model_revision.to_owned(),
+            expected_policy_revision: CLASSIFICATION_POLICY_VERSION,
+        }
+    }
+}
+
 /// Minimal mailbox metadata used to refresh classification signals without
 /// downloading or changing an email's body or user-selected category.
 #[derive(Debug, Clone, FromRow)]
@@ -529,6 +585,7 @@ impl Store {
             "CREATE TABLE IF NOT EXISTS mailbox_catalog_state (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, remote_name TEXT NOT NULL, uid_validity INTEGER NOT NULL, remote_total INTEGER NOT NULL DEFAULT 0, historical_complete INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox))",
             "CREATE TABLE IF NOT EXISTS mail_rebuild_jobs (account_id TEXT PRIMARY KEY, phase TEXT NOT NULL, completed INTEGER NOT NULL DEFAULT 0, total INTEGER, updated_at TEXT NOT NULL)",
             "CREATE TABLE IF NOT EXISTS deleted_account_tombstones (account_id TEXT PRIMARY KEY, deleted_at TEXT NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS sent_correspondents (account_id TEXT NOT NULL, address TEXT NOT NULL COLLATE NOCASE, PRIMARY KEY(account_id, address))",
         ] {
             sqlx::query(statement)
                 .execute(&self.pool)
@@ -569,6 +626,7 @@ impl Store {
             "CREATE TRIGGER IF NOT EXISTS mailbox_action_tombstones_require_account BEFORE INSERT ON mailbox_action_tombstones WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
             "CREATE TRIGGER IF NOT EXISTS mailbox_catalog_state_require_account BEFORE INSERT ON mailbox_catalog_state WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
             "CREATE TRIGGER IF NOT EXISTS mail_rebuild_jobs_require_account BEFORE INSERT ON mail_rebuild_jobs WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
+            "CREATE TRIGGER IF NOT EXISTS sent_correspondents_require_account BEFORE INSERT ON sent_correspondents WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
         ] {
             sqlx::query(statement)
                 .execute(&self.pool)
@@ -715,6 +773,7 @@ impl Store {
                 .await?;
             }
         }
+        self.initialize_classification_policy().await?;
         self.migrate_attachment_presentation_metadata().await?;
         if !sync_state_exists {
             sqlx::query("INSERT OR IGNORE INTO mailbox_sync_state(account_id, mailbox, initialized_at) SELECT id, 'INBOX', ? FROM accounts")
@@ -725,6 +784,10 @@ impl Store {
         if migrated_legacy_profile {
             self.restore_legacy_desktop_profile().await?;
         }
+        // Legacy Sent rows are restored above. Backfill only after every
+        // source of existing messages has run, otherwise the one-time version
+        // marker would permanently skip those correspondents.
+        self.migrate_sent_correspondents().await?;
         // Replace the legacy body FTS before any migration-time message
         // updates. External-content FTS triggers must match the active table
         // definition or SQLite can report a malformed database.
@@ -738,6 +801,156 @@ impl Store {
                 self.rebuild_threads_for_account(&account_id).await?;
             }
         }
+        Ok(())
+    }
+
+    /// Fresh databases need a policy value so later write reservations have a
+    /// stable row. Existing values are not changed here: upgrades are guarded
+    /// by the owner-scoped classifier claim below.
+    async fn initialize_classification_policy(&self) -> Result<()> {
+        sqlx::query("INSERT OR IGNORE INTO app_meta(key, value) VALUES ('classification_policy_version', ?)")
+            .bind(CLASSIFICATION_POLICY_VERSION)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Claims or renews the current classifier model and policy for one drain.
+    /// A different live owner fails closed; a clean owner releases immediately
+    /// and the activity timeout remains only for crash recovery.
+    pub async fn claim_classification_revision(&self, owner: &str, revision: &str) -> Result<()> {
+        if owner.trim().is_empty() {
+            return Err(anyhow!("classification owner cannot be empty"));
+        }
+        if revision.trim().is_empty() {
+            return Err(anyhow!("classification model revision cannot be empty"));
+        }
+        let mut transaction = self.pool.begin().await?;
+        // Serialize the read/compare/update across CLI and desktop processes.
+        sqlx::query(
+            "UPDATE app_meta SET value = value WHERE key = 'classification_policy_version'",
+        )
+        .execute(&mut *transaction)
+        .await?;
+        let current_model: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM app_meta WHERE key = 'classification_model_revision'",
+        )
+        .fetch_optional(&mut *transaction)
+        .await?;
+        let current_policy: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM app_meta WHERE key = 'classification_policy_version'",
+        )
+        .fetch_optional(&mut *transaction)
+        .await?;
+        let current_owner: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM app_meta WHERE key = 'classification_revision_owner'",
+        )
+        .fetch_optional(&mut *transaction)
+        .await?;
+        let last_activity: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM app_meta WHERE key = 'classification_revision_active_at'",
+        )
+        .fetch_optional(&mut *transaction)
+        .await?;
+        let now = Utc::now().timestamp();
+        let another_owner_is_active = current_owner.as_deref().is_some_and(|value| value != owner)
+            && last_activity
+                .as_deref()
+                .and_then(|value| value.parse::<i64>().ok())
+                .is_some_and(|timestamp| {
+                    now.saturating_sub(timestamp) < CLASSIFICATION_REVISION_ACTIVITY_SECONDS
+                });
+        if another_owner_is_active {
+            return Err(anyhow!(
+                "another email classifier is active; retry after it finishes"
+            ));
+        }
+        let revisions_differ = current_model.as_deref() != Some(revision)
+            || current_policy.as_deref() != Some(CLASSIFICATION_POLICY_VERSION);
+        if revisions_differ {
+            sqlx::query("UPDATE messages SET classification_source = NULL, classification_confidence = NULL WHERE classification_source = 'model'")
+                .execute(&mut *transaction)
+                .await?;
+            sqlx::query("INSERT INTO app_meta(key, value) VALUES ('classification_model_revision', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+                .bind(revision)
+                .execute(&mut *transaction)
+                .await?;
+            sqlx::query("INSERT INTO app_meta(key, value) VALUES ('classification_policy_version', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+                .bind(CLASSIFICATION_POLICY_VERSION)
+                .execute(&mut *transaction)
+                .await?;
+        }
+        sqlx::query("INSERT INTO app_meta(key, value) VALUES ('classification_revision_active_at', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+            .bind(now.to_string())
+            .execute(&mut *transaction)
+            .await?;
+        sqlx::query("INSERT INTO app_meta(key, value) VALUES ('classification_revision_owner', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+            .bind(owner)
+            .execute(&mut *transaction)
+            .await?;
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    pub async fn release_classification_revision(&self, owner: &str) -> Result<()> {
+        let mut transaction = self.pool.begin().await?;
+        sqlx::query(
+            "UPDATE app_meta SET value = value WHERE key = 'classification_policy_version'",
+        )
+        .execute(&mut *transaction)
+        .await?;
+        let current_owner: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM app_meta WHERE key = 'classification_revision_owner'",
+        )
+        .fetch_optional(&mut *transaction)
+        .await?;
+        if current_owner.as_deref() == Some(owner) {
+            sqlx::query("DELETE FROM app_meta WHERE key IN ('classification_revision_owner', 'classification_revision_active_at')")
+                .execute(&mut *transaction)
+                .await?;
+        }
+        transaction.commit().await?;
+        Ok(())
+    }
+
+    async fn migrate_sent_correspondents(&self) -> Result<()> {
+        let version: Option<String> = sqlx::query_scalar(
+            "SELECT value FROM app_meta WHERE key = 'sent_correspondents_version'",
+        )
+        .fetch_optional(&self.pool)
+        .await?;
+        if version.as_deref() == Some("1") {
+            return Ok(());
+        }
+
+        let sent_headers = sqlx::query_as::<_, (String, String, String, String)>(
+            "SELECT account_id, to_addresses, cc_addresses, bcc_addresses FROM messages WHERE mailbox = 'Sent' OR mailbox LIKE 'Sent::%'",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+        let mut correspondents = HashSet::new();
+        for (account_id, to, cc, bcc) in sent_headers {
+            for address in [to, cc, bcc]
+                .iter()
+                .flat_map(|header| crate::mail::parsed_header_mailboxes(header))
+            {
+                correspondents.insert((account_id.clone(), address.to_lowercase()));
+            }
+        }
+        let mut tx = self.pool.begin().await?;
+        for (account_id, address) in correspondents {
+            sqlx::query(
+                "INSERT OR IGNORE INTO sent_correspondents(account_id, address) VALUES (?, ?)",
+            )
+            .bind(account_id)
+            .bind(address)
+            .execute(&mut *tx)
+            .await?;
+        }
+        sqlx::query("INSERT INTO app_meta(key, value) VALUES ('sent_correspondents_version', '1') ON CONFLICT(key) DO UPDATE SET value = excluded.value")
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -813,6 +1026,7 @@ impl Store {
                  UNION SELECT account_id FROM mailbox_catalog_state \
                  UNION SELECT account_id FROM mailbox_action_tombstones \
                  UNION SELECT account_id FROM mail_rebuild_jobs \
+                 UNION SELECT account_id FROM sent_correspondents \
              ) AS orphan \
              WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE id = orphan.account_id)",
         )
@@ -831,6 +1045,7 @@ impl Store {
             "DELETE FROM mailbox_catalog_state WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mailbox_catalog_state.account_id)",
             "DELETE FROM mailbox_action_tombstones WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mailbox_action_tombstones.account_id)",
             "DELETE FROM mail_rebuild_jobs WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mail_rebuild_jobs.account_id)",
+            "DELETE FROM sent_correspondents WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = sent_correspondents.account_id)",
         ] {
             sqlx::query(statement).execute(&mut *tx).await?;
         }
@@ -1213,6 +1428,10 @@ impl Store {
             .bind(id.to_string())
             .execute(&mut *tx)
             .await?;
+        sqlx::query("DELETE FROM sent_correspondents WHERE account_id = ?")
+            .bind(id.to_string())
+            .execute(&mut *tx)
+            .await?;
         sqlx::query("DELETE FROM messages WHERE account_id = ?")
             .bind(id.to_string())
             .execute(&mut *tx)
@@ -1238,6 +1457,7 @@ impl Store {
             "DELETE FROM mailbox_catalog_state WHERE account_id = ?",
             "DELETE FROM mailbox_sync_state WHERE account_id = ?",
             "DELETE FROM mailbox_action_tombstones WHERE account_id = ?",
+            "DELETE FROM sent_correspondents WHERE account_id = ?",
             "DELETE FROM messages WHERE account_id = ?",
         ] {
             sqlx::query(statement)
@@ -3203,6 +3423,27 @@ impl Store {
             .await?)
     }
 
+    /// Returns candidate message IDs whose sender is an RFC-parsed recipient
+    /// of account-local Sent mail. This is stronger People evidence than a
+    /// sender-controlled Reply-To, In-Reply-To, or reply-shaped subject.
+    pub async fn messages_from_known_correspondents(
+        &self,
+        messages: &[MailSummary],
+    ) -> Result<HashSet<String>> {
+        if messages.is_empty() {
+            return Ok(HashSet::new());
+        }
+        let placeholders = vec!["?"; messages.len()].join(",");
+        let sql = format!(
+            "SELECT candidate.id FROM messages candidate JOIN sent_correspondents known ON known.account_id = candidate.account_id AND known.address = candidate.from_address WHERE candidate.id IN ({placeholders})"
+        );
+        let mut query = sqlx::query_scalar::<_, String>(&sql);
+        for message in messages {
+            query = query.bind(&message.id);
+        }
+        Ok(query.fetch_all(&self.pool).await?.into_iter().collect())
+    }
+
     /// Messages eligible for an explicitly requested model reclassification.
     /// User-selected categories are deliberately excluded.
     pub async fn messages_for_model_reclassification(&self) -> Result<Vec<MailSummary>> {
@@ -3229,7 +3470,12 @@ impl Store {
     pub async fn update_classification_signals(&self, updates: &[(String, String)]) -> Result<()> {
         let mut tx = self.pool.begin().await?;
         for (id, signals) in updates {
-            sqlx::query("UPDATE messages SET classification_signals = ? WHERE id = ?")
+            // Evidence changes invalidate only model-owned decisions. Keep the
+            // visible category until the background classifier replaces it,
+            // and never override a user's explicit categorization.
+            sqlx::query("UPDATE messages SET classification_source = CASE WHEN classification_source = 'model' AND classification_signals != ? THEN NULL ELSE classification_source END, classification_confidence = CASE WHEN classification_source = 'model' AND classification_signals != ? THEN NULL ELSE classification_confidence END, classification_signals = ? WHERE id = ?")
+                .bind(signals)
+                .bind(signals)
                 .bind(signals)
                 .bind(id)
                 .execute(&mut *tx)
@@ -3241,19 +3487,39 @@ impl Store {
 
     pub async fn apply_model_classifications(
         &self,
-        classifications: &[(String, String, f64)],
-    ) -> Result<()> {
+        classifications: &[ModelClassificationUpdate],
+    ) -> Result<usize> {
         let mut tx = self.pool.begin().await?;
-        for (id, category, confidence) in classifications {
-            sqlx::query("UPDATE messages SET category = ?, classification_confidence = ?, classification_source = 'model' WHERE id = ? AND (classification_source IS NULL OR classification_source = 'model')")
-                .bind(category)
-                .bind(confidence)
-                .bind(id)
+        let mut applied = 0;
+        // Acquire the SQLite write reservation before checking evidence so a
+        // concurrent sync cannot change signals or Sent relationships between
+        // validation and commit.
+        sqlx::query(
+            "UPDATE app_meta SET value = value WHERE key = 'classification_policy_version'",
+        )
+        .execute(&mut *tx)
+        .await?;
+        for update in classifications {
+            let result = sqlx::query("UPDATE messages SET category = ?, classification_confidence = ?, classification_source = 'model' WHERE id = ? AND from_name IS ? AND from_address = ? AND subject = ? AND snippet = ? AND body_text = ? AND classification_signals = ? AND EXISTS(SELECT 1 FROM sent_correspondents known WHERE known.account_id = messages.account_id AND known.address = messages.from_address) = ? AND EXISTS(SELECT 1 FROM app_meta WHERE key = 'classification_revision_owner' AND value = ?) AND EXISTS(SELECT 1 FROM app_meta WHERE key = 'classification_model_revision' AND value = ?) AND EXISTS(SELECT 1 FROM app_meta WHERE key = 'classification_policy_version' AND value = ?) AND (classification_source IS NULL OR classification_source = 'model')")
+                .bind(&update.category)
+                .bind(update.confidence)
+                .bind(&update.id)
+                .bind(&update.expected_from_name)
+                .bind(&update.expected_from_address)
+                .bind(&update.expected_subject)
+                .bind(&update.expected_snippet)
+                .bind(&update.expected_body_text)
+                .bind(&update.expected_signals)
+                .bind(update.expected_known_correspondence)
+                .bind(&update.expected_owner)
+                .bind(&update.expected_model_revision)
+                .bind(update.expected_policy_revision)
                 .execute(&mut *tx)
                 .await?;
+            applied += result.rows_affected() as usize;
         }
         tx.commit().await?;
-        Ok(())
+        Ok(applied)
     }
 
     pub async fn attachments(&self, message_id: &str) -> Result<Vec<Attachment>> {
@@ -3612,7 +3878,7 @@ async fn persist_message_with_flag_policy(
         FlagUpdatePolicy::CompareAndSwap(expected_flags) => (false, expected_flags),
     };
     let (expected_read, expected_flagged) = expected_flags.unwrap_or_default();
-    sqlx::query("INSERT INTO messages(id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, threading_scanned, recipient_headers_scanned, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, unsubscribe_scanned, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox, uid) DO UPDATE SET message_id=excluded.message_id, in_reply_to=excluded.in_reply_to, reference_ids=excluded.reference_ids, threading_scanned=1, recipient_headers_scanned=1, subject=excluded.subject, from_name=excluded.from_name, from_address=excluded.from_address, to_addresses=excluded.to_addresses, cc_addresses=excluded.cc_addresses, bcc_addresses=excluded.bcc_addresses, reply_to_addresses=excluded.reply_to_addresses, received_at=excluded.received_at, snippet=CASE WHEN excluded.content_state = 'complete' THEN excluded.snippet ELSE messages.snippet END, body_text=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_text ELSE messages.body_text END, body_html=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_html ELSE messages.body_html END, content_state=CASE WHEN messages.content_state = 'complete' THEN messages.content_state ELSE excluded.content_state END, unsubscribe_kind=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_kind ELSE messages.unsubscribe_kind END, unsubscribe_url=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_url ELSE messages.unsubscribe_url END, unsubscribe_scanned=CASE WHEN excluded.content_state = 'complete' THEN 1 ELSE messages.unsubscribe_scanned END, is_read=CASE WHEN ? OR (? AND messages.is_read = ? AND messages.is_flagged = ?) THEN excluded.is_read ELSE messages.is_read END, is_flagged=CASE WHEN ? OR (? AND messages.is_read = ? AND messages.is_flagged = ?) THEN excluded.is_flagged ELSE messages.is_flagged END, has_attachments=CASE WHEN excluded.content_state = 'complete' THEN excluded.has_attachments ELSE messages.has_attachments END, classification_signals=excluded.classification_signals")
+    sqlx::query("INSERT INTO messages(id, account_id, mailbox, uid, message_id, in_reply_to, reference_ids, thread_id, threading_scanned, recipient_headers_scanned, subject, from_name, from_address, to_addresses, cc_addresses, bcc_addresses, reply_to_addresses, received_at, snippet, body_text, body_html, content_state, unsubscribe_kind, unsubscribe_url, unsubscribe_scanned, is_read, is_flagged, has_attachments, category, classification_confidence, classification_source, classification_signals) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, 1, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox, uid) DO UPDATE SET message_id=excluded.message_id, in_reply_to=excluded.in_reply_to, reference_ids=excluded.reference_ids, threading_scanned=1, recipient_headers_scanned=1, subject=excluded.subject, from_name=excluded.from_name, from_address=excluded.from_address, to_addresses=excluded.to_addresses, cc_addresses=excluded.cc_addresses, bcc_addresses=excluded.bcc_addresses, reply_to_addresses=excluded.reply_to_addresses, received_at=excluded.received_at, snippet=CASE WHEN excluded.content_state = 'complete' THEN excluded.snippet ELSE messages.snippet END, body_text=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_text ELSE messages.body_text END, body_html=CASE WHEN excluded.content_state = 'complete' THEN excluded.body_html ELSE messages.body_html END, content_state=CASE WHEN messages.content_state = 'complete' THEN messages.content_state ELSE excluded.content_state END, unsubscribe_kind=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_kind ELSE messages.unsubscribe_kind END, unsubscribe_url=CASE WHEN excluded.content_state = 'complete' THEN excluded.unsubscribe_url ELSE messages.unsubscribe_url END, unsubscribe_scanned=CASE WHEN excluded.content_state = 'complete' THEN 1 ELSE messages.unsubscribe_scanned END, is_read=CASE WHEN ? OR (? AND messages.is_read = ? AND messages.is_flagged = ?) THEN excluded.is_read ELSE messages.is_read END, is_flagged=CASE WHEN ? OR (? AND messages.is_read = ? AND messages.is_flagged = ?) THEN excluded.is_flagged ELSE messages.is_flagged END, has_attachments=CASE WHEN excluded.content_state = 'complete' THEN excluded.has_attachments ELSE messages.has_attachments END, classification_confidence=CASE WHEN messages.classification_source = 'model' AND (messages.from_name IS NOT excluded.from_name OR messages.from_address != excluded.from_address OR messages.subject != excluded.subject OR messages.classification_signals != excluded.classification_signals OR (excluded.content_state = 'complete' AND (messages.snippet != excluded.snippet OR messages.body_text != excluded.body_text))) THEN NULL ELSE messages.classification_confidence END, classification_source=CASE WHEN messages.classification_source = 'model' AND (messages.from_name IS NOT excluded.from_name OR messages.from_address != excluded.from_address OR messages.subject != excluded.subject OR messages.classification_signals != excluded.classification_signals OR (excluded.content_state = 'complete' AND (messages.snippet != excluded.snippet OR messages.body_text != excluded.body_text))) THEN NULL ELSE messages.classification_source END, classification_signals=excluded.classification_signals")
         .bind(&message.id).bind(&message.account_id).bind(&message.mailbox).bind(message.uid)
         .bind(&message.message_id).bind(&message.in_reply_to).bind(&message.reference_ids).bind(&message.thread_id)
         .bind(&message.subject).bind(&message.from_name)
@@ -3637,6 +3903,37 @@ async fn persist_message_with_flag_policy(
         .bind(expected_read)
         .bind(expected_flagged)
         .execute(&mut **tx).await?;
+    if message.mailbox == "Sent" || message.mailbox.starts_with("Sent::") {
+        let recipients = [
+            &message.to_addresses,
+            &message.cc_addresses,
+            &message.bcc_addresses,
+        ]
+        .into_iter()
+        .flat_map(|header| crate::mail::parsed_header_mailboxes(header))
+        .map(|address| address.to_lowercase())
+        .collect::<HashSet<_>>();
+        for recipient in recipients {
+            let inserted = sqlx::query(
+                "INSERT OR IGNORE INTO sent_correspondents(account_id, address) VALUES (?, ?)",
+            )
+            .bind(&message.account_id)
+            .bind(&recipient)
+            .execute(&mut **tx)
+            .await?;
+            if inserted.rows_affected() == 0 {
+                continue;
+            }
+            // A new user-authored message is durable relationship evidence.
+            // Reconsider only prior model decisions from that correspondent;
+            // explicit user categories remain authoritative.
+            sqlx::query("UPDATE messages SET classification_source = NULL, classification_confidence = NULL WHERE account_id = ? AND lower(from_address) = ? AND classification_source = 'model'")
+                .bind(&message.account_id)
+                .bind(recipient)
+                .execute(&mut **tx)
+                .await?;
+        }
+    }
     let effective_is_flagged = if matches!(flag_policy, FlagUpdatePolicy::CompareAndSwap(_)) {
         sqlx::query_scalar(
             "SELECT is_flagged FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?",
@@ -4264,6 +4561,508 @@ mod tests {
             classification_signals: String::new(),
             attachments: Vec::new(),
         }
+    }
+
+    #[tokio::test]
+    async fn classification_policy_upgrade_requeues_only_model_owned_categories_once() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("classification-policy.db");
+        let store = Store::open(&database).await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let account = account_with_id(account_id, "classification-policy@example.test");
+        store.save_account(&account).await.unwrap();
+
+        let mut model_owned = message("Dispatched: an order", "");
+        model_owned.id = "model-owned".into();
+        model_owned.account_id = account_id.to_string();
+        model_owned.category = Some("people".into());
+        model_owned.classification_confidence = Some(0.91);
+        model_owned.classification_source = Some("model".into());
+        let mut user_owned = message("A category chosen by the user", "");
+        user_owned.id = "user-owned".into();
+        user_owned.account_id = account_id.to_string();
+        user_owned.uid = 2;
+        user_owned.category = Some("people".into());
+        user_owned.classification_confidence = Some(1.0);
+        user_owned.classification_source = Some("user".into());
+        store
+            .upsert_messages(&[model_owned, user_owned])
+            .await
+            .unwrap();
+        sqlx::query("UPDATE app_meta SET value = '1' WHERE key = 'classification_policy_version'")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        drop(store);
+
+        let migrated = Store::open(&database).await.unwrap();
+        migrated
+            .claim_classification_revision("policy-owner", "test-model")
+            .await
+            .unwrap();
+        let pending = migrated.message("model-owned").await.unwrap().unwrap();
+        assert_eq!(pending.category.as_deref(), Some("people"));
+        assert_eq!(pending.classification_source, None);
+        assert_eq!(pending.classification_confidence, None);
+        let preserved = migrated.message("user-owned").await.unwrap().unwrap();
+        assert_eq!(preserved.category.as_deref(), Some("people"));
+        assert_eq!(preserved.classification_source.as_deref(), Some("user"));
+        assert_eq!(preserved.classification_confidence, Some(1.0));
+
+        let update = ModelClassificationUpdate::from_message(
+            &pending,
+            "transactions".into(),
+            Some(1.0),
+            false,
+            "policy-owner",
+            "test-model",
+        );
+        migrated
+            .apply_model_classifications(&[update])
+            .await
+            .unwrap();
+        drop(migrated);
+
+        let reopened = Store::open(&database).await.unwrap();
+        let classified = reopened.message("model-owned").await.unwrap().unwrap();
+        assert_eq!(classified.category.as_deref(), Some("transactions"));
+        assert_eq!(classified.classification_source.as_deref(), Some("model"));
+        assert_eq!(classified.classification_confidence, Some(1.0));
+
+        let old_policy_update = ModelClassificationUpdate::from_message(
+            &classified,
+            "people".into(),
+            Some(0.99),
+            false,
+            "policy-owner",
+            "test-model",
+        );
+        sqlx::query("UPDATE app_meta SET value = 'future-policy' WHERE key = 'classification_policy_version'")
+            .execute(&reopened.pool)
+            .await
+            .unwrap();
+        reopened
+            .apply_model_classifications(&[old_policy_update])
+            .await
+            .unwrap();
+        assert_eq!(
+            reopened
+                .message("model-owned")
+                .await
+                .unwrap()
+                .unwrap()
+                .category
+                .as_deref(),
+            Some("transactions"),
+            "an in-flight result from an older policy must fail the final CAS"
+        );
+    }
+
+    #[tokio::test]
+    async fn classification_model_revision_requeues_model_owned_rows_only_on_change() {
+        let store = Store::in_memory().await.unwrap();
+        let mut model_owned = message("Model-owned decision", "original evidence");
+        model_owned.id = "revision-model".into();
+        model_owned.category = Some("people".into());
+        model_owned.classification_confidence = Some(0.9);
+        model_owned.classification_source = Some("model".into());
+        let mut user_owned = message("User-owned decision", "original evidence");
+        user_owned.id = "revision-user".into();
+        user_owned.uid = 2;
+        user_owned.category = Some("people".into());
+        user_owned.classification_confidence = Some(1.0);
+        user_owned.classification_source = Some("user".into());
+        store
+            .upsert_messages(&[model_owned, user_owned])
+            .await
+            .unwrap();
+
+        store
+            .claim_classification_revision("revision-owner-a", "model-a")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .message("revision-model")
+                .await
+                .unwrap()
+                .unwrap()
+                .classification_source,
+            None
+        );
+        assert_eq!(
+            store
+                .message("revision-user")
+                .await
+                .unwrap()
+                .unwrap()
+                .classification_source
+                .as_deref(),
+            Some("user")
+        );
+
+        let pending = store.message("revision-model").await.unwrap().unwrap();
+        store
+            .apply_model_classifications(&[ModelClassificationUpdate::from_message(
+                &pending,
+                "notifications".into(),
+                Some(0.8),
+                false,
+                "revision-owner-a",
+                "model-a",
+            )])
+            .await
+            .unwrap();
+        store
+            .claim_classification_revision("revision-owner-a", "model-a")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .message("revision-model")
+                .await
+                .unwrap()
+                .unwrap()
+                .classification_source
+                .as_deref(),
+            Some("model")
+        );
+
+        let old_model_update = ModelClassificationUpdate::from_message(
+            &store.message("revision-model").await.unwrap().unwrap(),
+            "people".into(),
+            Some(0.99),
+            false,
+            "revision-owner-a",
+            "model-a",
+        );
+        assert_eq!(
+            store
+                .claim_classification_revision("revision-owner-b", "model-b")
+                .await
+                .unwrap_err()
+                .to_string(),
+            "another email classifier is active; retry after it finishes"
+        );
+        store
+            .release_classification_revision("revision-owner-a")
+            .await
+            .unwrap();
+        store
+            .claim_classification_revision("revision-owner-b", "model-b")
+            .await
+            .unwrap();
+        store
+            .apply_model_classifications(&[old_model_update])
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .message("revision-model")
+                .await
+                .unwrap()
+                .unwrap()
+                .classification_source,
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn concurrent_stores_cannot_ping_pong_active_classifier_revisions() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("classifier-revision-lease.db");
+        let first = Store::open(&database).await.unwrap();
+        let second = Store::open(&database).await.unwrap();
+
+        first
+            .claim_classification_revision("owner-a", "model-a")
+            .await
+            .unwrap();
+        assert!(second
+            .claim_classification_revision("owner-b", "model-b")
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("another email classifier is active"));
+        assert_eq!(
+            sqlx::query_scalar::<_, String>(
+                "SELECT value FROM app_meta WHERE key = 'classification_model_revision'",
+            )
+            .fetch_one(&second.pool)
+            .await
+            .unwrap(),
+            "model-a"
+        );
+
+        first
+            .release_classification_revision("owner-a")
+            .await
+            .unwrap();
+        second
+            .claim_classification_revision("owner-b", "model-b")
+            .await
+            .unwrap();
+        assert_eq!(
+            sqlx::query_scalar::<_, String>(
+                "SELECT value FROM app_meta WHERE key = 'classification_model_revision'",
+            )
+            .fetch_one(&first.pool)
+            .await
+            .unwrap(),
+            "model-b"
+        );
+
+        sqlx::query(
+            "UPDATE app_meta SET value = ? WHERE key = 'classification_revision_active_at'",
+        )
+        .bind((Utc::now().timestamp() - CLASSIFICATION_REVISION_ACTIVITY_SECONDS - 1).to_string())
+        .execute(&second.pool)
+        .await
+        .unwrap();
+        first
+            .claim_classification_revision("owner-c", "model-c")
+            .await
+            .unwrap();
+        assert_eq!(
+            sqlx::query_scalar::<_, String>(
+                "SELECT value FROM app_meta WHERE key = 'classification_model_revision'",
+            )
+            .fetch_one(&second.pool)
+            .await
+            .unwrap(),
+            "model-c",
+            "an expired owner must not block crash recovery"
+        );
+    }
+
+    #[tokio::test]
+    async fn classification_signal_changes_requeue_only_model_owned_categories() {
+        let store = Store::in_memory().await.unwrap();
+        store
+            .claim_classification_revision("test-owner", "test-model")
+            .await
+            .unwrap();
+        let mut model_owned = message("Account update", "");
+        model_owned.id = "signal-model".into();
+        model_owned.category = Some("people".into());
+        model_owned.classification_confidence = Some(0.8);
+        model_owned.classification_source = Some("model".into());
+        let mut user_owned = message("User override", "");
+        user_owned.id = "signal-user".into();
+        user_owned.category = Some("people".into());
+        user_owned.classification_confidence = Some(1.0);
+        user_owned.classification_source = Some("user".into());
+        store
+            .upsert_messages(&[model_owned, user_owned])
+            .await
+            .unwrap();
+
+        let stale_update = ModelClassificationUpdate::from_message(
+            &store.message("signal-model").await.unwrap().unwrap(),
+            "people".into(),
+            Some(0.8),
+            false,
+            "test-owner",
+            "test-model",
+        );
+
+        store
+            .update_classification_signals(&[
+                (
+                    "signal-model".into(),
+                    "Mailing-list unsubscribe header present".into(),
+                ),
+                (
+                    "signal-user".into(),
+                    "Mailing-list unsubscribe header present".into(),
+                ),
+            ])
+            .await
+            .unwrap();
+        store
+            .apply_model_classifications(&[stale_update])
+            .await
+            .unwrap();
+
+        let pending = store.message("signal-model").await.unwrap().unwrap();
+        assert_eq!(pending.category.as_deref(), Some("people"));
+        assert_eq!(pending.classification_source, None);
+        assert_eq!(pending.classification_confidence, None);
+        let preserved = store.message("signal-user").await.unwrap().unwrap();
+        assert_eq!(preserved.category.as_deref(), Some("people"));
+        assert_eq!(preserved.classification_source.as_deref(), Some("user"));
+        assert_eq!(preserved.classification_confidence, Some(1.0));
+    }
+
+    #[tokio::test]
+    async fn changed_message_evidence_requeues_and_rejects_an_in_flight_model_result() {
+        let store = Store::in_memory().await.unwrap();
+        store
+            .claim_classification_revision("test-owner", "test-model")
+            .await
+            .unwrap();
+        let mut original = message("Original subject", "original preview");
+        original.id = "changing-evidence".into();
+        original.category = Some("people".into());
+        original.classification_confidence = Some(0.9);
+        original.classification_source = Some("model".into());
+        store
+            .upsert_messages(std::slice::from_ref(&original))
+            .await
+            .unwrap();
+        let stale_update = ModelClassificationUpdate::from_message(
+            &store.message("changing-evidence").await.unwrap().unwrap(),
+            "people".into(),
+            Some(0.9),
+            false,
+            "test-owner",
+            "test-model",
+        );
+
+        original.subject = "Dispatched: replacement order".into();
+        original.snippet = "Your replacement has shipped.".into();
+        store.upsert_messages(&[original]).await.unwrap();
+        store
+            .apply_model_classifications(&[stale_update])
+            .await
+            .unwrap();
+
+        let changed = store.message("changing-evidence").await.unwrap().unwrap();
+        assert_eq!(changed.subject, "Dispatched: replacement order");
+        assert_eq!(changed.classification_source, None);
+        assert_eq!(changed.classification_confidence, None);
+    }
+
+    #[tokio::test]
+    async fn known_correspondent_evidence_is_account_scoped_and_rfc_parsed() {
+        let store = Store::in_memory().await.unwrap();
+        store
+            .claim_classification_revision("test-owner", "test-model")
+            .await
+            .unwrap();
+        let account_id = uuid::Uuid::new_v4().to_string();
+        let other_account_id = uuid::Uuid::new_v4().to_string();
+        let mut incoming = message("Re: Project", "A real follow-up");
+        incoming.id = "known-correspondence".into();
+        incoming.account_id = account_id.clone();
+        incoming.thread_id = "shared-thread-name".into();
+        incoming.category = Some("other".into());
+        incoming.classification_source = Some("model".into());
+        incoming.classification_confidence = Some(0.7);
+        let mut sent = message("Re: Project", "My prior reply");
+        sent.id = "sent-member".into();
+        sent.account_id = account_id;
+        sent.thread_id = "older-independent-thread".into();
+        sent.mailbox = "Sent::Sent Messages".into();
+        sent.uid = 2;
+        sent.to_addresses = incoming.from_address.clone();
+        let mut wrong_sender = message("Re: Project", "A forged thread member");
+        wrong_sender.id = "wrong-sender".into();
+        wrong_sender.account_id = sent.account_id.clone();
+        wrong_sender.thread_id = incoming.thread_id.clone();
+        wrong_sender.from_address = "bulk-sender@example.test".into();
+        wrong_sender.uid = 3;
+        wrong_sender.category = Some("other".into());
+        wrong_sender.classification_source = Some("model".into());
+        wrong_sender.classification_confidence = Some(0.7);
+        let mut display_name_spoof = message("Unrelated sender", "Not a correspondent");
+        display_name_spoof.id = "display-name-spoof".into();
+        display_name_spoof.account_id = sent.account_id.clone();
+        display_name_spoof.from_address = "victim@example.com".into();
+        display_name_spoof.uid = 4;
+        let mut sent_with_address_in_display_name = message("Prior sent", "A different recipient");
+        sent_with_address_in_display_name.id = "sent-display-name".into();
+        sent_with_address_in_display_name.account_id = sent.account_id.clone();
+        sent_with_address_in_display_name.mailbox = "Sent::Sent Messages".into();
+        sent_with_address_in_display_name.uid = 4;
+        sent_with_address_in_display_name.to_addresses =
+            "\"victim@example.com\" <actual@example.net>".into();
+        let mut cross_account = message("Re: Unrelated", "Not my correspondent");
+        cross_account.id = "cross-account".into();
+        cross_account.account_id = other_account_id;
+        cross_account.thread_id = incoming.thread_id.clone();
+        let stale_update = ModelClassificationUpdate::from_message(
+            &incoming,
+            "other".into(),
+            Some(0.7),
+            false,
+            "test-owner",
+            "test-model",
+        );
+        store
+            .upsert_messages(&[
+                incoming.clone(),
+                sent.clone(),
+                wrong_sender.clone(),
+                display_name_spoof.clone(),
+                sent_with_address_in_display_name,
+                cross_account.clone(),
+            ])
+            .await
+            .unwrap();
+
+        let known = store
+            .messages_from_known_correspondents(&[
+                incoming,
+                wrong_sender,
+                display_name_spoof,
+                cross_account,
+            ])
+            .await
+            .unwrap();
+        assert_eq!(known, HashSet::from(["known-correspondence".into()]));
+        store
+            .apply_model_classifications(&[stale_update])
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .message("known-correspondence")
+                .await
+                .unwrap()
+                .unwrap()
+                .classification_source,
+            None
+        );
+        assert_eq!(
+            store
+                .message("wrong-sender")
+                .await
+                .unwrap()
+                .unwrap()
+                .classification_source
+                .as_deref(),
+            Some("model")
+        );
+
+        let current = store
+            .message("known-correspondence")
+            .await
+            .unwrap()
+            .unwrap();
+        store
+            .apply_model_classifications(&[ModelClassificationUpdate::from_message(
+                &current,
+                "people".into(),
+                None,
+                true,
+                "test-owner",
+                "test-model",
+            )])
+            .await
+            .unwrap();
+        store.upsert_messages(&[sent]).await.unwrap();
+        assert_eq!(
+            store
+                .message("known-correspondence")
+                .await
+                .unwrap()
+                .unwrap()
+                .classification_source
+                .as_deref(),
+            Some("model"),
+            "refreshing an already-indexed Sent message must not requeue history"
+        );
     }
 
     fn cached_content(body_text: &str) -> CachedMessageContent {
@@ -7503,7 +8302,17 @@ mod tests {
             .execute(&pool)
             .await
             .unwrap();
+        sqlx::query("INSERT INTO mailboxes(id, accountId, path, uidValidity) VALUES ('sent', ?, 'Sent', 43)")
+            .bind(account_id.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
         sqlx::query("INSERT INTO messages(id, accountId, mailboxId, threadId, uid, messageId, inReplyTo, referencesJson, fromAddress, toAddresses, subject, date, flags, snippet) VALUES ('legacy-message', ?, 'inbox', NULL, 5, '<legacy@example.test>', NULL, '[]', 'sender@example.test', 'person@example.test', 'Legacy subject', 'Mon, 01 Jan 2024 12:00:00 +0000', '[\"\\\\Seen\"]', 'Legacy preview')")
+            .bind(account_id.to_string())
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO messages(id, accountId, mailboxId, threadId, uid, messageId, inReplyTo, referencesJson, fromAddress, toAddresses, subject, date, flags, snippet) VALUES ('legacy-sent', ?, 'sent', NULL, 6, '<legacy-sent@example.test>', NULL, '[]', 'person@example.test', 'Sender <sender@example.test>', 'Prior reply', 'Mon, 01 Jan 2024 13:00:00 +0000', '[\"\\\\Seen\"]', 'My reply')")
             .bind(account_id.to_string())
             .execute(&pool)
             .await
@@ -7527,6 +8336,13 @@ mod tests {
         assert_eq!(messages[0].id, "legacy-message");
         assert_eq!(messages[0].content_state, "headers_only");
         assert!(messages[0].is_read);
+        assert_eq!(
+            store
+                .messages_from_known_correspondents(&messages)
+                .await
+                .unwrap(),
+            HashSet::from(["legacy-message".into()])
+        );
         let state = store
             .mailbox_catalog_state(account_id, "INBOX")
             .await
@@ -8419,6 +9235,7 @@ mod tests {
             "mailbox_catalog_state",
             "mail_rebuild_jobs",
             "mailbox_action_tombstones",
+            "sent_correspondents",
         ] {
             let count: i64 = sqlx::query_scalar(&format!(
                 "SELECT COUNT(*) FROM {table} WHERE account_id = ?"
@@ -8507,6 +9324,11 @@ mod tests {
             .execute(&initial.pool)
             .await
             .unwrap();
+        sqlx::query("INSERT INTO sent_correspondents(account_id, address) VALUES (?, 'orphan@example.test')")
+            .bind(orphan_id.to_string())
+            .execute(&initial.pool)
+            .await
+            .unwrap();
         sqlx::query("INSERT INTO attachments(id, message_id, filename, mime_type, size_bytes, is_inline, is_potentially_unsafe, data) VALUES ('orphan-attachment', ?, 'old.txt', 'text/plain', 3, 0, 0, X'6f6c64')")
             .bind(&orphan.id)
             .execute(&initial.pool)
@@ -8544,6 +9366,7 @@ mod tests {
             "mailbox_catalog_state",
             "mail_rebuild_jobs",
             "mailbox_action_tombstones",
+            "sent_correspondents",
         ] {
             let count: i64 = sqlx::query_scalar(&format!(
                 "SELECT COUNT(*) FROM {table} WHERE account_id = ?"

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -230,6 +230,18 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,
     "the immutable Actions cache must not store the entire target directory",
   );
+  for (const testName of [
+    "local_model_and_policy_classify_the_production_regression_corpus",
+    "model_and_policy_preserve_representative_categories",
+  ]) {
+    assert.match(
+      workflow,
+      new RegExp(
+        `--skip classification::model_integration_tests::${testName}`,
+      ),
+      `the LFS-free PR lane must skip ${testName}`,
+    );
+  }
   for (const action of workflow.matchAll(/uses:\s*[^@\s]+@([^\s#]+)/g)) {
     assert.match(action[1], /^[a-f0-9]{40}$/, `unpinned action: ${action[0]}`);
   }


### PR DESCRIPTION
## Summary

- Correct people categorization behavior in the shared core mail and classification logic
- Update storage and public exports to support the fix
- Align desktop and CLI integrations with the corrected categorization flow

## Testing

Not run (not requested)