### PR TITLE
Fix HTML formatting in replies and forwards

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1821,6 +1821,8 @@ describe("App read state", () => {
     });
     mocks.api.content.mockResolvedValue({
       body_text: "Provider body\r\n> Nested history",
+      body_html:
+        '<table style="width: 600px"><tbody><tr><td><a href="https://example.com/settings">Manage budgets</a></td></tr></tbody></table>',
       attachments: [],
     });
     render(
@@ -1843,7 +1845,7 @@ describe("App read state", () => {
           subject: "Re: Unread thread",
           body: expect.stringContaining("> > Nested history"),
           bodyHtml: expect.stringContaining(
-            '<blockquote type="cite">Provider body<br>&gt; Nested history</blockquote>',
+            '<blockquote type="cite"><div data-dakia-quoted-email="true"><table',
           ),
         }),
       ),

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -33,7 +33,7 @@ import {
 import { replyRecipients } from "./recipients";
 import { confirmNativeAction, showNativeMessage } from "./nativeFeedback";
 import { concreteThreadMessages, groupMessages } from "./threads";
-import { forwardBody, forwardSubject } from "./forward";
+import { formatForwardHistory, forwardSubject } from "./forward";
 import { createFeedbackComposeSeed } from "./feedback";
 import { formatReplyHistory } from "./replyHistory";
 import {
@@ -1522,6 +1522,7 @@ export default function App() {
       const replyHistory = formatReplyHistory({
         message: replyMessage,
         bodyText: content.body_text,
+        bodyHtml: content.body_html,
         formatCitation: ({ date, sender }) =>
           t("reader.replyCitation", { date, sender }),
       });
@@ -1576,16 +1577,18 @@ export default function App() {
     if (!message) return;
     try {
       const content = await api.content(message.id);
+      const history = formatForwardHistory(message, content, {
+        originalMessage: t("reader.originalMessage"),
+        from: t("composer.from"),
+        date: t("reader.date"),
+        subject: t("composer.subject"),
+        to: t("composer.to"),
+      });
       openComposeWindow({
         accountId: message.account_id,
         subject: forwardSubject(message.subject, t("reader.forwardPrefix")),
-        body: forwardBody(message, content, {
-          originalMessage: t("reader.originalMessage"),
-          from: t("composer.from"),
-          date: t("reader.date"),
-          subject: t("composer.subject"),
-          to: t("composer.to"),
-        }),
+        body: history.body,
+        bodyHtml: history.bodyHtml,
         forwardMessageId: content.attachments.some(
           (attachment) => attachment.presentation !== "embedded",
         )

--- a/apps/desktop/src/ComposeApp.tsx
+++ b/apps/desktop/src/ComposeApp.tsx
@@ -4,6 +4,7 @@ import { api } from "./api";
 import {
   closeComposeWindow,
   notifyOutbox,
+  readDatabaseComposeSeed,
   readComposeSeed,
 } from "./composeWindow";
 import { Composer } from "./components/Composer";
@@ -35,12 +36,17 @@ export function ComposeApp() {
 
   useEffect(() => {
     document.title = t("composer.title");
-    Promise.all([
-      api.accounts(),
-      seed.forwardMessageId
-        ? api.forwardAttachments(seed.forwardMessageId)
-        : Promise.resolve([]),
-    ])
+    readDatabaseComposeSeed()
+      .then((databaseSeed) => {
+        const nextSeed = databaseSeed ?? seed;
+        if (databaseSeed) setSeed(databaseSeed);
+        return Promise.all([
+          api.accounts(),
+          nextSeed.forwardMessageId
+            ? api.forwardAttachments(nextSeed.forwardMessageId)
+            : Promise.resolve([]),
+        ]);
+      })
       .then(([nextAccounts, attachments]) => {
         setAccounts(nextAccounts);
         if (attachments.length) {

--- a/apps/desktop/src/ReaderWindowApp.tsx
+++ b/apps/desktop/src/ReaderWindowApp.tsx
@@ -6,7 +6,7 @@ import { openComposeWindow } from "./composeWindow";
 import { Reader } from "./components/Reader";
 import { parseEmailAddressMenuAction } from "./emailAddressMenu";
 import { AI_FEATURES_VISIBLE } from "./features";
-import { forwardBody, forwardSubject } from "./forward";
+import { formatForwardHistory, forwardSubject } from "./forward";
 import {
   conversationActionMessages,
   removeConcreteMessage,
@@ -379,6 +379,7 @@ export function ReaderWindowApp() {
       const history = formatReplyHistory({
         message,
         bodyText: content.body_text,
+        bodyHtml: content.body_html,
         formatCitation: ({ date, sender }) =>
           t("reader.replyCitation", { date, sender }),
       });
@@ -406,16 +407,18 @@ export function ReaderWindowApp() {
   const forward = async (message: MailSummary) => {
     try {
       const content = await readerApi.content(message.id);
+      const history = formatForwardHistory(message, content, {
+        originalMessage: t("reader.originalMessage"),
+        from: t("composer.from"),
+        date: t("reader.date"),
+        subject: t("composer.subject"),
+        to: t("composer.to"),
+      });
       openComposeWindow({
         accountId: message.account_id,
         subject: forwardSubject(message.subject, t("reader.forwardPrefix")),
-        body: forwardBody(message, content, {
-          originalMessage: t("reader.originalMessage"),
-          from: t("composer.from"),
-          date: t("reader.date"),
-          subject: t("composer.subject"),
-          to: t("composer.to"),
-        }),
+        body: history.body,
+        bodyHtml: history.bodyHtml,
         forwardMessageId: content.attachments.some(
           (attachment) => attachment.presentation !== "embedded",
         )

--- a/apps/desktop/src/components/Composer.test.tsx
+++ b/apps/desktop/src/components/Composer.test.tsx
@@ -236,6 +236,48 @@ describe("Composer send feedback", () => {
     );
   });
 
+  it("renders and sends safe table and image layout in quoted rich email history", () => {
+    const onSend = vi.fn();
+    const bodyHtml = [
+      "<p><br></p>",
+      '<div class="moz-cite-prefix">GitHub wrote:</div>',
+      '<blockquote type="cite"><div data-dakia-quoted-email="true">',
+      '<table width="600" style="width: 600px; background-color: rgb(255, 255, 255)"><tbody><tr>',
+      '<td align="center" style="padding: 24px"><img alt="GitHub" width="32" src="https://example.com/github.png">',
+      '<a href="https://example.com/settings" style="display: inline-block; background-color: rgb(22, 136, 63); padding: 12px; color: white">Manage budgets</a></td>',
+      "</tr></tbody></table></div></blockquote>",
+    ].join("");
+    render(
+      <Composer
+        {...props}
+        seed={{ to: "sender@example.com", bodyHtml }}
+        onSend={onSend}
+        sendState="idle"
+      />,
+    );
+
+    const editor = screen.getByLabelText("Write your message…");
+    expect(editor.innerHTML).toContain('<table width="600"');
+    expect(editor.innerHTML).toContain('<img alt="GitHub" width="32"');
+    expect(editor.innerHTML).toContain("background-color: rgb(255, 255, 255)");
+    expect(editor.innerHTML).toContain("background-color: rgb(22, 136, 63)");
+
+    editor.innerHTML = `<p>Authored text</p>${editor.innerHTML}`;
+    fireEvent.input(editor);
+    fireEvent.click(screen.getByRole("button", { name: /^Send/ }));
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body_html: expect.stringContaining('<table width="600"'),
+        body_text: expect.stringContaining("Authored text"),
+      }),
+    );
+    expect(onSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        body_text: expect.stringContaining("Manage budgets"),
+      }),
+    );
+  });
+
   it("sanitizes a hostile seeded reply before rendering and sends that unchanged sanitized HTML", () => {
     const onSend = vi.fn();
     const bodyHtml = [

--- a/apps/desktop/src/components/Composer.tsx
+++ b/apps/desktop/src/components/Composer.tsx
@@ -54,7 +54,12 @@ export function Composer({
   const [bcc, setBcc] = useState("");
   const [subject, setSubject] = useState(seed?.subject ?? "");
   const [bodyHtml, setBodyHtml] = useState(() =>
-    sanitizeRichText(seed?.bodyHtml ?? richTextFromPlainText(seed?.body ?? "")),
+    sanitizeRichText(
+      seed?.bodyHtml ?? richTextFromPlainText(seed?.body ?? ""),
+      {
+        preserveQuotedEmail: true,
+      },
+    ),
   );
   const [showCopies, setShowCopies] = useState(Boolean(seed?.cc));
   const [aiLoading, setAiLoading] = useState(false);

--- a/apps/desktop/src/components/RichTextEditor.tsx
+++ b/apps/desktop/src/components/RichTextEditor.tsx
@@ -54,7 +54,9 @@ export function RichTextEditor({ value, disabled = false, onChange }: Props) {
   const publish = () => {
     const editor = editorRef.current;
     if (!editor) return;
-    const html = sanitizeRichText(editor.innerHTML);
+    const html = sanitizeRichText(editor.innerHTML, {
+      preserveQuotedEmail: true,
+    });
     if (html !== editor.innerHTML) editor.innerHTML = html;
     latestValue.current = html;
     onChange(html);

--- a/apps/desktop/src/components/richText.test.ts
+++ b/apps/desktop/src/components/richText.test.ts
@@ -38,12 +38,50 @@ describe("rich text conversion", () => {
     ).toBe("<div>Citation</div><blockquote>Original</blockquote>");
   });
 
+  it("preserves safe rich email layout only inside generated quoted history", () => {
+    const quoted = [
+      '<div data-dakia-quoted-email="true">',
+      '<table width="600" cellpadding="0" style="width: 600px; background-color: rgb(255, 255, 255); position: fixed">',
+      '<tbody><tr><td align="center" style="padding: 24px; color: rgb(36, 48, 44)">',
+      '<img alt="GitHub" width="32" src="https://example.com/github.png" onerror="alert(1)">',
+      '<a href="https://example.com/settings" style="display: inline-block; background-color: rgb(22, 136, 63); padding: 12px; color: white; position: fixed" onclick="alert(1)">Manage budgets</a>',
+      "</td></tr></tbody></table><script>alert(1)</script></div>",
+    ].join("");
+
+    const sanitized = sanitizeRichText(quoted, {
+      preserveQuotedEmail: true,
+    });
+    expect(sanitized).toContain('<table width="600" cellpadding="0"');
+    expect(sanitized).toContain("background-color: rgb(255, 255, 255)");
+    expect(sanitized).toContain(
+      '<img alt="GitHub" width="32" src="https://example.com/github.png">',
+    );
+    expect(sanitized).toContain(
+      'style="display: inline-block; background-color: rgb(22, 136, 63);',
+    );
+    expect(sanitized).toContain(
+      'href="https://example.com/settings" rel="noreferrer noopener">Manage budgets</a>',
+    );
+    expect(sanitized).not.toContain("position");
+    expect(sanitized).not.toContain("onerror");
+    expect(sanitized).not.toContain("script");
+
+    expect(sanitizeRichText(quoted)).toBe(
+      '<div><a href="https://example.com/settings" rel="noreferrer noopener">Manage budgets</a></div>',
+    );
+  });
+
   it("creates a readable text alternative for structured content", () => {
     expect(
       plainTextFromRichText(
         "<p>Hello <strong>there</strong></p><ul><li>One</li><li>Two</li></ul><blockquote>Thanks</blockquote>",
       ),
     ).toBe("Hello there\n• One\n• Two\n> Thanks");
+    expect(
+      plainTextFromRichText(
+        '<div data-dakia-quoted-email="true"><table><tbody><tr><td>Plan</td><td>0.5 GB</td></tr></tbody></table></div>',
+      ),
+    ).toBe("Plan\n0.5 GB");
   });
 
   it("prefixes non-empty lines within nested blockquotes by quote depth", () => {

--- a/apps/desktop/src/components/richText.ts
+++ b/apps/desktop/src/components/richText.ts
@@ -37,16 +37,110 @@ const DISCARD_TAGS = new Set([
   "video",
 ]);
 
-const BLOCK_TAGS = new Set(["blockquote", "div", "h1", "h2", "h3", "p", "pre"]);
+const BLOCK_TAGS = new Set([
+  "blockquote",
+  "div",
+  "h1",
+  "h2",
+  "h3",
+  "p",
+  "pre",
+  "table",
+  "tr",
+]);
+
+const QUOTED_EMAIL_TAGS = new Set([
+  ...ALLOWED_TAGS,
+  "caption",
+  "col",
+  "colgroup",
+  "font",
+  "h4",
+  "h5",
+  "h6",
+  "img",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "tr",
+]);
+
+const QUOTED_EMAIL_ATTRIBUTES = new Set([
+  "align",
+  "alt",
+  "bgcolor",
+  "border",
+  "cellpadding",
+  "cellspacing",
+  "colspan",
+  "height",
+  "role",
+  "rowspan",
+  "title",
+  "valign",
+  "width",
+]);
+
+const SAFE_QUOTED_STYLE_PROPERTIES = new Set([
+  "background",
+  "background-color",
+  "border",
+  "border-bottom",
+  "border-color",
+  "border-left",
+  "border-radius",
+  "border-right",
+  "border-style",
+  "border-top",
+  "border-width",
+  "box-sizing",
+  "color",
+  "display",
+  "font-family",
+  "font-size",
+  "font-style",
+  "font-weight",
+  "height",
+  "letter-spacing",
+  "line-height",
+  "margin",
+  "margin-bottom",
+  "margin-left",
+  "margin-right",
+  "margin-top",
+  "max-width",
+  "min-width",
+  "padding",
+  "padding-bottom",
+  "padding-left",
+  "padding-right",
+  "padding-top",
+  "text-align",
+  "text-decoration",
+  "text-decoration-line",
+  "text-indent",
+  "text-transform",
+  "vertical-align",
+  "white-space",
+  "width",
+  "word-break",
+  "word-wrap",
+]);
 
 /**
- * Keeps the outgoing HTML intentionally small and email-safe. In particular,
- * images and their data URLs are excluded until inline attachments are built
- * as proper MIME related parts.
+ * Keeps authored outgoing HTML intentionally small and email-safe. Generated
+ * quoted-history wrappers may retain a larger, separately sanitized subset of
+ * email layout markup so replies and forwards do not flatten the original.
  */
-export function sanitizeRichText(html: string) {
+export function sanitizeRichText(
+  html: string,
+  options: { preserveQuotedEmail?: boolean } = {},
+) {
   const document = new DOMParser().parseFromString(html, "text/html");
-  sanitizeChildren(document.body);
+  sanitizeChildren(document.body, options.preserveQuotedEmail === true);
   return document.body.innerHTML;
 }
 
@@ -63,7 +157,7 @@ export function richTextFromPlainText(text: string) {
 
 export function plainTextFromRichText(html: string) {
   const document = new DOMParser().parseFromString(
-    sanitizeRichText(html),
+    sanitizeRichText(html, { preserveQuotedEmail: true }),
     "text/html",
   );
   let output = "";
@@ -111,6 +205,14 @@ export function plainTextFromRichText(html: string) {
       addBreak();
       return;
     }
+    if (tag === "td" || tag === "th") {
+      addBreak();
+      element.childNodes.forEach((child) => {
+        visit(child, quoteDepth);
+      });
+      addBreak();
+      return;
+    }
     if (BLOCK_TAGS.has(tag)) addBreak();
     element.childNodes.forEach((child) => {
       visit(child, quoteDepth);
@@ -128,27 +230,40 @@ export function isRichTextEmpty(html: string) {
   return !plainTextFromRichText(html).trim();
 }
 
-function sanitizeChildren(parent: Element) {
+function sanitizeChildren(parent: Element, preserveQuotedEmail: boolean) {
   for (const node of [...parent.childNodes]) {
     if (node.nodeType !== Node.ELEMENT_NODE) continue;
     const element = node as HTMLElement;
     const tag = element.tagName.toLowerCase();
 
-    if (DISCARD_TAGS.has(tag)) {
+    const quotedRoot =
+      preserveQuotedEmail &&
+      tag === "div" &&
+      element.getAttribute("data-dakia-quoted-email") === "true";
+    const insideQuotedEmail =
+      preserveQuotedEmail &&
+      (quotedRoot ||
+        parent.closest("[data-dakia-quoted-email='true']") !== null);
+
+    if (DISCARD_TAGS.has(tag) && !(insideQuotedEmail && tag === "img")) {
       element.remove();
       continue;
     }
 
-    sanitizeChildren(element);
-    if (!ALLOWED_TAGS.has(tag)) {
+    sanitizeChildren(element, preserveQuotedEmail);
+    if (!(insideQuotedEmail ? QUOTED_EMAIL_TAGS : ALLOWED_TAGS).has(tag)) {
       element.replaceWith(...[...element.childNodes]);
       continue;
     }
 
     if (tag === "a") {
       const href = safeHref(node as HTMLAnchorElement);
-      for (const attribute of [...element.attributes]) {
-        element.removeAttribute(attribute.name);
+      if (insideQuotedEmail) {
+        sanitizeQuotedEmailElement(element, tag, quotedRoot);
+      } else {
+        for (const attribute of [...element.attributes]) {
+          element.removeAttribute(attribute.name);
+        }
       }
       if (href) {
         element.setAttribute("href", href);
@@ -156,6 +271,8 @@ function sanitizeChildren(parent: Element) {
       } else {
         element.replaceWith(...[...element.childNodes]);
       }
+    } else if (insideQuotedEmail) {
+      sanitizeQuotedEmailElement(element, tag, quotedRoot);
     } else {
       const citePrefix =
         tag === "div" && element.getAttribute("class") === "moz-cite-prefix";
@@ -170,6 +287,54 @@ function sanitizeChildren(parent: Element) {
       if (citeBlock) element.setAttribute("type", "cite");
     }
   }
+}
+
+function sanitizeQuotedEmailElement(
+  element: HTMLElement,
+  tag: string,
+  quotedRoot: boolean,
+) {
+  const attributes = [...element.attributes];
+  for (const attribute of attributes) {
+    const name = attribute.name.toLowerCase();
+    if (name === "style") continue;
+    if (quotedRoot && name === "data-dakia-quoted-email") continue;
+    if (QUOTED_EMAIL_ATTRIBUTES.has(name)) continue;
+    if (tag === "img" && name === "src" && safeImageSource(attribute.value)) {
+      continue;
+    }
+    element.removeAttribute(attribute.name);
+  }
+  const style = safeQuotedEmailStyle(element.getAttribute("style") ?? "");
+  if (style) element.setAttribute("style", style);
+  else element.removeAttribute("style");
+}
+
+function safeQuotedEmailStyle(style: string) {
+  const source = document.createElement("span");
+  source.setAttribute("style", style);
+  const declarations: string[] = [];
+  for (const property of [...source.style]) {
+    const normalized = property.toLowerCase();
+    const value = source.style.getPropertyValue(property).trim();
+    if (
+      SAFE_QUOTED_STYLE_PROPERTIES.has(normalized) &&
+      value &&
+      !/(?:expression\s*\(|javascript\s*:|behavior\s*:|-moz-binding|url\s*\()/i.test(
+        value,
+      )
+    ) {
+      declarations.push(`${normalized}: ${value}`);
+    }
+  }
+  return declarations.join("; ");
+}
+
+function safeImageSource(value: string) {
+  const normalized = value.trim().replace(/[\u0000-\u001f\u007f\s]+/g, "");
+  return /^(?:https?:|data:image\/(?:png|gif|jpe?g|webp|svg\+xml);)/i.test(
+    normalized,
+  );
 }
 
 function safeStyle(element: HTMLElement) {

--- a/apps/desktop/src/composeWindow.ts
+++ b/apps/desktop/src/composeWindow.ts
@@ -19,6 +19,8 @@ export type ComposeSeed = {
 
 const isTauri = () => "__TAURI_INTERNALS__" in window;
 const composeSeedStoragePrefix = "dakia.compose-seed.";
+const composeSeedDatabase = "dakia-compose-seeds";
+const composeSeedStore = "seeds";
 
 function parseComposeSeed(value: string | null): ComposeSeed | undefined {
   if (!value) return undefined;
@@ -63,13 +65,41 @@ export function readComposeSeed(): ComposeSeed {
   return parseComposeSeed(params.get("seed")) ?? {};
 }
 
+export async function readDatabaseComposeSeed() {
+  const token = new URLSearchParams(window.location.search).get("seedDbKey");
+  if (!token || !globalThis.indexedDB) return undefined;
+  const database = await openComposeSeedDatabase();
+  return new Promise<ComposeSeed | undefined>((resolve, reject) => {
+    const transaction = database.transaction(composeSeedStore, "readwrite");
+    const store = transaction.objectStore(composeSeedStore);
+    const request = store.get(token);
+    request.onsuccess = () => {
+      const seed = request.result as ComposeSeed | undefined;
+      store.delete(token);
+      resolve(seed);
+    };
+    request.onerror = () => reject(request.error);
+    transaction.oncomplete = () => database.close();
+  });
+}
+
 export function openComposeWindow(seed: ComposeSeed) {
   const params = new URLSearchParams({ view: "compose" });
   const storedSeedToken = storeComposeSeed(seed);
   if (storedSeedToken) params.set("seedKey", storedSeedToken);
-  else params.set("seed", JSON.stringify(seed));
-  const url = `/?${params.toString()}`;
+  else if (isTauri() && globalThis.indexedDB) {
+    void storeDatabaseComposeSeed(seed)
+      .then((token) => {
+        params.set("seedDbKey", token);
+        createComposeWindow(`/?${params.toString()}`);
+      })
+      .catch((error) => console.error("Could not store compose seed", error));
+    return;
+  } else params.set("seed", JSON.stringify(seed));
+  createComposeWindow(`/?${params.toString()}`);
+}
 
+function createComposeWindow(url: string) {
   if (!isTauri()) {
     window.open(
       url,
@@ -96,6 +126,33 @@ export function openComposeWindow(seed: ComposeSeed) {
   });
   composeWindow.once("tauri://error", (event) => {
     console.error("Could not open compose window", event.payload);
+  });
+}
+
+async function storeDatabaseComposeSeed(seed: ComposeSeed) {
+  const database = await openComposeSeedDatabase();
+  const token = crypto.randomUUID();
+  return new Promise<string>((resolve, reject) => {
+    const transaction = database.transaction(composeSeedStore, "readwrite");
+    transaction.objectStore(composeSeedStore).put(seed, token);
+    transaction.oncomplete = () => {
+      database.close();
+      resolve(token);
+    };
+    transaction.onerror = () => reject(transaction.error);
+  });
+}
+
+function openComposeSeedDatabase() {
+  return new Promise<IDBDatabase>((resolve, reject) => {
+    const request = indexedDB.open(composeSeedDatabase, 1);
+    request.onupgradeneeded = () => {
+      if (!request.result.objectStoreNames.contains(composeSeedStore)) {
+        request.result.createObjectStore(composeSeedStore);
+      }
+    };
+    request.onsuccess = () => resolve(request.result);
+    request.onerror = () => reject(request.error);
   });
 }
 

--- a/apps/desktop/src/forward.test.ts
+++ b/apps/desktop/src/forward.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { MailSummary } from "./types";
-import { forwardBody, forwardSubject } from "./forward";
+import { formatForwardHistory, forwardSubject } from "./forward";
 
 const message: MailSummary = {
   id: "message-1",
@@ -29,7 +29,7 @@ describe("email forwarding", () => {
   });
 
   it("quotes the provider-loaded plain-text body with message metadata", () => {
-    const body = forwardBody(
+    const history = formatForwardHistory(
       message,
       { body_text: "Full original body", attachments: [] },
       {
@@ -40,10 +40,36 @@ describe("email forwarding", () => {
         to: "To",
       },
     );
-    expect(body).toContain("---------- Original message ----------");
-    expect(body).toContain("From: Mara <mara@example.com>");
-    expect(body).toContain("Subject: Release plan");
-    expect(body).toContain("Full original body");
-    expect(body).not.toContain("Cached preview");
+    expect(history.body).toContain("---------- Original message ----------");
+    expect(history.body).toContain("From: Mara <mara@example.com>");
+    expect(history.body).toContain("Subject: Release plan");
+    expect(history.body).toContain("Full original body");
+    expect(history.body).not.toContain("Cached preview");
+    expect(history.bodyHtml).toContain(
+      "---------- Original message ----------",
+    );
+  });
+
+  it("preserves the provider-loaded rich body in the HTML alternative", () => {
+    const history = formatForwardHistory(
+      message,
+      {
+        body_text: "GitHub Actions Usage Manage budgets",
+        body_html:
+          '<table style="width: 600px"><tbody><tr><td style="background-color: #ffffff"><img alt="GitHub" width="32" src="https://example.com/github.png"><a href="https://example.com/settings">Manage budgets</a></td></tr></tbody></table>',
+        attachments: [],
+      },
+      {
+        originalMessage: "Original message",
+        from: "From",
+        date: "Date",
+        subject: "Subject",
+        to: "To",
+      },
+    );
+
+    expect(history.bodyHtml).toContain('data-dakia-quoted-email="true"');
+    expect(history.bodyHtml).toContain('<table style="width: 600px">');
+    expect(history.bodyHtml).toContain("Manage budgets");
   });
 });

--- a/apps/desktop/src/forward.ts
+++ b/apps/desktop/src/forward.ts
@@ -7,7 +7,7 @@ export function forwardSubject(subject: string, prefix: string) {
     : `${prefix} ${trimmed}`.trim();
 }
 
-export function forwardBody(
+export function formatForwardHistory(
   message: MailSummary,
   content: MessageContent,
   labels: {
@@ -18,21 +18,37 @@ export function forwardBody(
     to: string;
   },
 ) {
-  return [
-    "",
-    "",
+  const headerLines = [
     `---------- ${labels.originalMessage} ----------`,
     `${labels.from}: ${formatSender(message)}`,
     `${labels.date}: ${new Date(message.received_at).toLocaleString()}`,
     `${labels.subject}: ${message.subject}`,
     `${labels.to}: ${message.to_addresses}`,
-    "",
-    content.body_text,
-  ].join("\n");
+  ];
+  return {
+    body: ["", "", ...headerLines, "", content.body_text].join("\n"),
+    bodyHtml: [
+      "<p><br></p>",
+      `<div>${headerLines.map(escapeHtml).join("<br>")}</div>`,
+      "<br>",
+      content.body_html
+        ? `<div data-dakia-quoted-email="true">${content.body_html}</div>`
+        : `<div>${escapeHtml(content.body_text).replace(/\r\n?/g, "\n").replaceAll("\n", "<br>")}</div>`,
+    ].join(""),
+  };
 }
 
 function formatSender(message: MailSummary) {
   return message.from_name
     ? `${message.from_name} <${message.from_address}>`
     : message.from_address;
+}
+
+function escapeHtml(value: string) {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
 }

--- a/apps/desktop/src/replyHistory.test.ts
+++ b/apps/desktop/src/replyHistory.test.ts
@@ -57,4 +57,21 @@ describe("reply history", () => {
     expect(quote.body).toContain("Citation: mara@example.com");
     expect(quote.bodyHtml).toContain("Citation: mara@example.com");
   });
+
+  it("quotes the original rich HTML without replacing it with flattened text", () => {
+    const quote = formatReplyHistory({
+      message,
+      bodyText: "GitHub Actions Usage Manage budgets",
+      bodyHtml:
+        '<table style="width: 600px"><tbody><tr><td><img alt="GitHub" src="https://example.com/github.png"><a href="https://example.com/settings">Manage budgets</a></td></tr></tbody></table>',
+      formatCitation: ({ sender }) => `${sender} wrote:`,
+    });
+
+    expect(quote.body).toContain("> GitHub Actions Usage Manage budgets");
+    expect(quote.bodyHtml).toContain(
+      '<blockquote type="cite"><div data-dakia-quoted-email="true"><table',
+    );
+    expect(quote.bodyHtml).toContain("Manage budgets</a>");
+    expect(quote.bodyHtml).not.toContain("> GitHub Actions Usage");
+  });
 });

--- a/apps/desktop/src/replyHistory.ts
+++ b/apps/desktop/src/replyHistory.ts
@@ -11,12 +11,14 @@ type ReplyHistoryInput = {
     "from_address" | "from_name" | "received_at"
   >;
   readonly bodyText: string;
+  readonly bodyHtml?: string | null;
   readonly formatCitation: (citation: ReplyCitation) => string;
 };
 
 export function formatReplyHistory({
   message,
   bodyText,
+  bodyHtml,
   formatCitation,
 }: ReplyHistoryInput) {
   const citation = formatCitation({
@@ -31,7 +33,11 @@ export function formatReplyHistory({
     bodyHtml: [
       "<p><br></p>",
       `<div class="moz-cite-prefix">${escapeHtml(citation)}</div>`,
-      `<blockquote type="cite">${escapeHtml(normalizedBody).replaceAll("\n", "<br>")}</blockquote>`,
+      `<blockquote type="cite">${
+        bodyHtml
+          ? `<div data-dakia-quoted-email="true">${bodyHtml}</div>`
+          : escapeHtml(normalizedBody).replaceAll("\n", "<br>")
+      }</blockquote>`,
     ].join(""),
   };
 }

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -1924,18 +1924,41 @@ fn build_compose_message(account: &Account, draft: &ComposeMessage) -> Result<Me
     if let Some(references) = &draft.references {
         builder = builder.references(references.clone());
     }
-    let body = if let Some(html) = &draft.body_html {
-        MultiPart::alternative()
-            .singlepart(SinglePart::plain(draft.body_text.clone()))
-            .singlepart(
-                SinglePart::builder()
-                    .header(ContentType::TEXT_HTML)
-                    .body(html.clone()),
-            )
+    let (body, inline_images) = if let Some(html) = &draft.body_html {
+        let (html, inline_images) = decode_outbound_inline_images(html)?;
+        let html = SinglePart::builder()
+            .header(ContentType::TEXT_HTML)
+            .body(html);
+        let alternative =
+            MultiPart::alternative().singlepart(SinglePart::plain(draft.body_text.clone()));
+        let alternative = if inline_images.is_empty() {
+            alternative.singlepart(html)
+        } else {
+            let related = inline_images.iter().fold(
+                MultiPart::related().singlepart(html),
+                |related, image| {
+                    related.singlepart(
+                        LettreAttachment::new_inline(image.content_id.clone())
+                            .body(image.bytes.clone(), image.content_type.clone()),
+                    )
+                },
+            );
+            alternative.multipart(related)
+        };
+        (alternative, inline_images)
     } else {
-        MultiPart::alternative().singlepart(SinglePart::plain(draft.body_text.clone()))
+        (
+            MultiPart::alternative().singlepart(SinglePart::plain(draft.body_text.clone())),
+            Vec::new(),
+        )
     };
-    let attachments = decode_outbound_attachments(&draft.attachments)?;
+    let inline_bytes = inline_images.iter().try_fold(0usize, |total, image| {
+        total
+            .checked_add(image.bytes.len())
+            .context("attachment bytes overflowed the safety limit")
+    })?;
+    let attachments =
+        decode_outbound_attachments(&draft.attachments, inline_images.len(), inline_bytes)?;
     let body =
         attachments
             .into_iter()
@@ -2128,13 +2151,23 @@ struct DecodedComposeAttachment {
     content_type: ContentType,
 }
 
+struct DecodedInlineImage {
+    content_id: String,
+    bytes: Vec<u8>,
+    content_type: ContentType,
+}
+
 fn decode_outbound_attachments(
     input: &[ComposeAttachment],
+    existing_count: usize,
+    mut total: usize,
 ) -> Result<Vec<DecodedComposeAttachment>> {
-    if input.len() > MAX_ATTACHMENT_COUNT {
+    if existing_count
+        .checked_add(input.len())
+        .is_none_or(|count| count > MAX_ATTACHMENT_COUNT)
+    {
         bail!("a message can include at most {MAX_ATTACHMENT_COUNT} attachments");
     }
-    let mut total = 0usize;
     input
         .iter()
         .enumerate()
@@ -2165,6 +2198,128 @@ fn decode_outbound_attachments(
             })
         })
         .collect()
+}
+
+fn decode_outbound_inline_images(html: &str) -> Result<(String, Vec<DecodedInlineImage>)> {
+    let mut data_urls = BTreeMap::new();
+    let mut ambiguous = false;
+    let mut cursor = 0;
+    while let Some(offset) = html[cursor..].find('<') {
+        let start = cursor + offset;
+        if html[start..].starts_with("<!--") {
+            cursor = html[start + 4..]
+                .find("-->")
+                .map_or(html.len(), |offset| start + 4 + offset + 3);
+            continue;
+        }
+        let Some(end) = html_tag_end(html, start) else {
+            break;
+        };
+        collect_html_tag_resource_ranges(&html[start..end], |_, value| {
+            if value
+                .get(..11)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:image/"))
+            {
+                let key = value.to_ascii_lowercase();
+                if let Some(existing) = data_urls.get(&key) {
+                    if existing != value {
+                        // Resource-reference rewriting is intentionally case-insensitive for
+                        // CID and Content-Location values. Base64 is not case-insensitive, so
+                        // refuse an ambiguous pair instead of attaching the wrong image bytes.
+                        ambiguous = true;
+                    }
+                } else {
+                    data_urls.insert(key, value.to_owned());
+                }
+            }
+        });
+        cursor = raw_text_element_end(html, start, end).unwrap_or(end);
+    }
+    if ambiguous {
+        bail!("ambiguous inline image data URLs");
+    }
+
+    if data_urls.len() > MAX_ATTACHMENT_COUNT {
+        bail!("a message can include at most {MAX_ATTACHMENT_COUNT} attachments");
+    }
+
+    let mut total = 0usize;
+    let mut replacements = BTreeMap::new();
+    let mut images = Vec::with_capacity(data_urls.len());
+    for (index, (key, data_url)) in data_urls.into_iter().enumerate() {
+        let (mime_type, bytes) = decode_inline_image_data_url(&data_url)?;
+        if bytes.len() > MAX_OUTBOUND_ATTACHMENT_BYTES {
+            bail!(
+                "inline image exceeds the {} MiB attachment limit",
+                MAX_OUTBOUND_ATTACHMENT_BYTES / 1024 / 1024
+            );
+        }
+        total = total
+            .checked_add(bytes.len())
+            .context("attachment bytes overflowed the safety limit")?;
+        if total > MAX_OUTBOUND_ATTACHMENT_TOTAL_BYTES {
+            bail!(
+                "attachments exceed the {} MiB total limit",
+                MAX_OUTBOUND_ATTACHMENT_TOTAL_BYTES / 1024 / 1024
+            );
+        }
+        let content_id = format!(
+            "dakia-inline-{}-{}@dakia.local",
+            uuid::Uuid::new_v4(),
+            index
+        );
+        replacements.insert(key, format!("cid:{content_id}"));
+        images.push(DecodedInlineImage {
+            content_id,
+            bytes,
+            content_type: ContentType::parse(&mime_type).expect("validated image MIME type"),
+        });
+    }
+    Ok((
+        rewrite_html_resource_references(html, &replacements)?,
+        images,
+    ))
+}
+
+fn decode_inline_image_data_url(value: &str) -> Result<(String, Vec<u8>)> {
+    let data = value
+        .get(..5)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("data:"))
+        .then_some(&value[5..])
+        .context("inline image is not a data URL")?;
+    let (metadata, encoded) = data
+        .split_once(',')
+        .context("inline image data URL is missing its payload")?;
+    let mut metadata = metadata.split(';');
+    let mime_type = metadata.next().unwrap_or_default();
+    let safe_mime_type = safe_mime_type(mime_type);
+    if !mime_type.eq_ignore_ascii_case(&safe_mime_type) || !safe_mime_type.starts_with("image/") {
+        bail!("inline image data URL has an unsafe MIME type");
+    }
+    let is_base64 = metadata.any(|parameter| parameter.eq_ignore_ascii_case("base64"));
+    let max_encoded = if is_base64 {
+        MAX_OUTBOUND_ATTACHMENT_BYTES
+            .checked_add(2)
+            .and_then(|bytes| bytes.checked_div(3))
+            .and_then(|groups| groups.checked_mul(4))
+    } else {
+        MAX_OUTBOUND_ATTACHMENT_BYTES.checked_mul(3)
+    }
+    .context("inline image size limit overflowed")?;
+    if encoded.len() > max_encoded {
+        bail!(
+            "inline image exceeds the {} MiB attachment limit",
+            MAX_OUTBOUND_ATTACHMENT_BYTES / 1024 / 1024
+        );
+    }
+    let bytes = if is_base64 {
+        STANDARD
+            .decode(encoded)
+            .context("inline image data is not valid base64")?
+    } else {
+        percent_decode_str(encoded).collect::<Vec<_>>()
+    };
+    Ok((safe_mime_type, bytes))
 }
 struct ImapClient<S = TlsStream<TcpStream>> {
     reader: BufReader<S>,
@@ -10172,6 +10327,53 @@ For you, Alex =E2=80=94 related to your saved topic."
         assert!(source.contains("<p>Hello <strong>there</strong></p>"));
         assert!(source.contains("In-Reply-To: <parent@example.com>"));
         assert!(source.contains("References: <root@example.com> <parent@example.com>"));
+    }
+
+    #[test]
+    fn sends_data_url_images_as_related_cid_parts() {
+        let account = test_account();
+        let draft = ComposeMessage {
+            account_id: account.id,
+            to: vec!["recipient@example.com".into()],
+            cc: vec![],
+            bcc: vec![],
+            subject: "Inline image".into(),
+            body_text: "Image reply history".into(),
+            body_html: Some(
+                "<p>Image reply history</p><img src=\"data:image/png;base64,aW1hZ2U=\"><img src=\"data:image/svg+xml;charset=utf-8,%3Csvg%3Eicon%3C/svg%3E\">".into(),
+            ),
+            in_reply_to: None,
+            references: None,
+            attachments: vec![ComposeAttachment {
+                filename: "invoice.pdf".into(),
+                mime_type: "application/pdf".into(),
+                content_base64: "cGRm".into(),
+            }],
+        };
+
+        let source =
+            String::from_utf8(build_compose_message(&account, &draft).unwrap().formatted())
+                .unwrap();
+        let content_id = source
+            .lines()
+            .find_map(|line| line.strip_prefix("Content-ID: <"))
+            .and_then(|line| line.strip_suffix('>'))
+            .expect("inline image Content-ID");
+        let parsed = parse_complete_message(source.as_bytes()).unwrap();
+
+        assert!(source.contains("multipart/mixed"));
+        assert!(source.contains("multipart/alternative"));
+        assert!(source.contains("multipart/related"));
+        assert!(source.contains("Content-Type: image/png"));
+        assert!(source.contains("Content-Type: image/svg+xml"));
+        assert!(source.contains("Content-Disposition: inline"));
+        assert!(source.contains("\r\n\r\nimage\r\n--"));
+        assert!(source.contains("Content-Disposition: attachment; filename=\"invoice.pdf\""));
+        let decoded_html = extract_html(&parsed).unwrap();
+        assert!(decoded_html.contains(&format!("src=\"cid:{content_id}\"")));
+        assert_eq!(decoded_html.matches("src=\"cid:").count(), 2);
+        assert!(!source.contains("data:image/png;base64"));
+        assert!(!source.contains("data:image/svg+xml"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve rich-text formatting when replying to and forwarding HTML emails
- Improve composer, reader-window, and compose-window handling of reply history and forwarded content
- Update core mail formatting behavior and add coverage for rich-text conversion and compose flows

## Testing

- Added and updated unit and integration tests across the composer, app, forwarding, reply history, and rich-text modules
- Not run (not requested)