### PR TITLE
Make archive and read mutations optimistic

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,14 @@ Git LFS classifier assets, the macOS ONNX Runtime, and the debug CLI sidecar.
 Always rely on unit and integration tests as the primary form of verification.
 Do UI testing only after exhausting those layers, at the very end.
 
+## Optimistic mutations
+
+All user-facing mutations must use optimistic updates. Reflect the intended
+result in local UI state immediately, without blocking unrelated or subsequent
+mutations on the network request. Reconcile with the authoritative result in
+the background, and restore the affected state with clear error feedback when
+the mutation fails.
+
 Write regression tests from the actual failing input and user-visible outcome,
 not merely from the current helper implementation. When a bug comes from email
 markup, protocol data, database state, or another structured external input:

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -381,14 +381,19 @@ describe("App read state", () => {
       </MantineProvider>,
     );
 
+    await waitFor(() => expect(mocks.openAccountWindow).toHaveBeenCalledOnce());
+    mocks.openAccountWindow.mockClear();
+    mocks.showNativeMessage.mockClear();
     fireEvent.click(await screen.findByRole("button", { name: "Feedback" }));
 
-    await waitFor(() => expect(mocks.openAccountWindow).toHaveBeenCalledOnce());
-    expect(mocks.showNativeMessage).toHaveBeenCalledWith(
-      "New message",
-      "Connect an account before composing.",
-      "warning",
+    await waitFor(() =>
+      expect(mocks.showNativeMessage).toHaveBeenCalledWith(
+        "New message",
+        "Connect an account before composing.",
+        "warning",
+      ),
     );
+    await waitFor(() => expect(mocks.openAccountWindow).toHaveBeenCalledOnce());
     expect(mocks.createFeedbackComposeSeed).not.toHaveBeenCalled();
     expect(mocks.openComposeWindow).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -493,6 +493,100 @@ describe("App read state", () => {
     );
   });
 
+  it("shows mark-as-read immediately while the server mutation is pending", async () => {
+    let finishRead: (() => void) | undefined;
+    mocks.api.setRead.mockImplementationOnce(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishRead = () => resolve(undefined);
+        }),
+    );
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const row = (await screen.findByText("Unread thread")).closest("button")!;
+    fireEvent.click(row);
+
+    await waitFor(() => expect(row).toHaveAttribute("data-unread", "false"));
+    expect(finishRead).toBeTypeOf("function");
+    act(() => finishRead?.());
+  });
+
+  it("archives consecutive conversations immediately without waiting for the network", async () => {
+    const messages = [1, 2, 3].map((uid) => ({
+      ...mocks.message,
+      id: `message-${uid}`,
+      uid,
+      thread_id: `thread-${uid}`,
+      subject: `Conversation ${uid}`,
+      received_at: `2026-07-19T1${3 - uid}:00:00Z`,
+    }));
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages(messages),
+      nextCursor: null,
+    });
+    const finishActions: Array<() => void> = [];
+    mocks.api.action.mockImplementation(
+      () =>
+        new Promise<undefined>((resolve) => {
+          finishActions.push(() => resolve(undefined));
+        }),
+    );
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(
+      (await screen.findByText("Conversation 1")).closest("button")!,
+    );
+    fireEvent.keyDown(document.documentElement, { key: "e" });
+    await waitFor(() =>
+      expect(screen.queryByText("Conversation 1")).not.toBeInTheDocument(),
+    );
+    const searchesBeforeRefresh = mocks.api.search.mock.calls.length;
+    act(() => mocks.mailChangedHandlers.at(-1)?.());
+    await waitFor(() =>
+      expect(mocks.api.search.mock.calls.length).toBeGreaterThan(
+        searchesBeforeRefresh,
+      ),
+    );
+    expect(screen.queryByText("Conversation 1")).not.toBeInTheDocument();
+
+    fireEvent.keyDown(document.documentElement, { key: "e" });
+    await waitFor(() =>
+      expect(screen.queryByText("Conversation 2")).not.toBeInTheDocument(),
+    );
+    fireEvent.keyDown(document.documentElement, { key: "e" });
+
+    await waitFor(() => {
+      expect(screen.queryByText("Conversation 3")).not.toBeInTheDocument();
+      expect(mocks.api.action).toHaveBeenCalledTimes(3);
+    });
+    expect(
+      (mocks.api.action.mock.calls as unknown[][]).map((call) => call[2]),
+    ).toEqual([1, 2, 3]);
+    expect(finishActions).toHaveLength(3);
+
+    mocks.api.search.mockResolvedValue({ conversations: [], nextCursor: null });
+    const searchesBeforeSettlement = mocks.api.search.mock.calls.length;
+    await act(async () => {
+      finishActions[0]();
+      await Promise.resolve();
+    });
+    expect(mocks.api.search).toHaveBeenCalledTimes(searchesBeforeSettlement);
+    act(() => finishActions.slice(1).forEach((finish) => finish()));
+    await waitFor(() =>
+      expect(mocks.api.search.mock.calls.length).toBeGreaterThan(
+        searchesBeforeSettlement,
+      ),
+    );
+  });
+
   it("opens a new composer for the selected header mailbox", async () => {
     const selectedAddress = "selected+header@example.com";
     mocks.api.search.mockResolvedValue({

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -191,6 +191,10 @@ export default function App() {
   const searchRef = useRef<HTMLInputElement>(null);
   const statusId = useRef(0);
   const actionBusyRef = useRef(false);
+  const mailboxActionsInFlightRef = useRef(0);
+  const mailboxActionThreadIdsRef = useRef(new Set<string>());
+  const readMutationGenerationRef = useRef(0);
+  const readMutationByMessageRef = useRef(new Map<string, number>());
   const loadRequestIdRef = useRef(0);
   const smartLoadRequestIdRef = useRef(0);
   const starredCountRequestIdRef = useRef(0);
@@ -438,7 +442,10 @@ export default function App() {
             for (const section of page.sections) {
               next[section.id] = {
                 id: section.id,
-                threads: section.conversations,
+                threads: excludeThreads(
+                  section.conversations,
+                  mailboxActionThreadIdsRef.current,
+                ),
                 nextCursor: section.nextCursor,
                 loadingMore: false,
               };
@@ -471,7 +478,9 @@ export default function App() {
         sameMailView(currentView, currentViewRef.current)
       ) {
         nextCursorRef.current = page.nextCursor;
-        setThreads(page.conversations);
+        setThreads(
+          excludeThreads(page.conversations, mailboxActionThreadIdsRef.current),
+        );
         setHasMore(page.nextCursor !== null);
       }
       if (currentView.query.trim()) {
@@ -494,10 +503,13 @@ export default function App() {
               if (!merged.has(thread.id)) merged.set(thread.id, thread);
             }
             setThreads(
-              [...merged.values()].sort(
-                (left, right) =>
-                  new Date(right.latest.received_at).getTime() -
-                  new Date(left.latest.received_at).getTime(),
+              excludeThreads(
+                [...merged.values()].sort(
+                  (left, right) =>
+                    new Date(right.latest.received_at).getTime() -
+                    new Date(left.latest.received_at).getTime(),
+                ),
+                mailboxActionThreadIdsRef.current,
               ),
             );
           }
@@ -1202,7 +1214,6 @@ export default function App() {
       setSyncStatus(undefined);
     }
   };
-  const actionBusy = Object.keys(pendingActions).length > 0;
   const applyAction = async (
     action: MailAction,
     explicitThreads: MailThread[] = targetThreads,
@@ -1213,8 +1224,8 @@ export default function App() {
         messages: conversationActionMessages(thread, mailbox, action),
       }))
       .filter((target) => target.messages.length > 0);
-    if (!actionThreads.length || actionBusyRef.current) return;
-    actionBusyRef.current = true;
+    if (!actionThreads.length) return;
+    mailboxActionsInFlightRef.current += 1;
     // An open/read transition may already be refreshing Smart sections with
     // the pre-action INBOX row. Make that result stale before moving the row.
     loadRequestIdRef.current += 1;
@@ -1227,13 +1238,10 @@ export default function App() {
     const targetThreadIds = new Set(
       actionThreads.map((target) => target.thread.id),
     );
+    for (const id of targetThreadIds) mailboxActionThreadIdsRef.current.add(id);
     const reducedMotion = window.matchMedia(
       "(prefers-reduced-motion: reduce)",
     ).matches;
-    const maxDelay = reducedMotion
-      ? 0
-      : Math.min((actionTargets.length - 1) * 24, 144);
-
     setPendingActions((current) => {
       const next = { ...current };
       actionTargets.forEach((message, index) => {
@@ -1263,21 +1271,9 @@ export default function App() {
       setActiveThreadSnapshot(next);
     }
 
-    const resultsPromise = Promise.allSettled(
-      actionThreads.map(({ messages }) =>
-        Promise.all(
-          messages.map((message) =>
-            api.action(
-              message.account_id,
-              message.mailbox,
-              message.uid,
-              action,
-            ),
-          ),
-        ),
-      ),
-    );
-    await wait(reducedMotion ? 0 : 210 + maxDelay);
+    // Remove the affected conversations in the same render as the action.
+    // Network work continues independently so the next visible conversation
+    // can be acted on immediately.
     setThreads((current) =>
       current.filter((thread) => !targetThreadIds.has(thread.id)),
     );
@@ -1300,6 +1296,21 @@ export default function App() {
       for (const id of targetThreadIds) next.delete(id);
       return next;
     });
+
+    const resultsPromise = Promise.allSettled(
+      actionThreads.map(({ messages }) =>
+        Promise.all(
+          messages.map((message) =>
+            api.action(
+              message.account_id,
+              message.mailbox,
+              message.uid,
+              action,
+            ),
+          ),
+        ),
+      ),
+    );
     const results = await resultsPromise;
     const failedThreadIds = new Set(
       actionThreads
@@ -1367,8 +1378,10 @@ export default function App() {
       for (const id of targetIds) delete next[id];
       return next;
     });
-    actionBusyRef.current = false;
-    await loadMessages();
+    mailboxActionsInFlightRef.current -= 1;
+    for (const id of targetThreadIds)
+      mailboxActionThreadIdsRef.current.delete(id);
+    if (mailboxActionsInFlightRef.current === 0) await loadMessages();
   };
   const permanentlyDeleteMessage = async (message: MailSummary) => {
     if (actionBusyRef.current) return;
@@ -1730,10 +1743,19 @@ export default function App() {
       is_read: message.is_read,
     }));
     const ids = new Set(previous.map((message) => message.id));
+    const mutationGeneration = ++readMutationGenerationRef.current;
+    for (const id of ids)
+      readMutationByMessageRef.current.set(id, mutationGeneration);
+    const previousThreads = threads;
     const previousSmartSections = smartSections;
-    setThreads((current) =>
-      current.map((item) => updateThreadReadState(item, ids, read)),
-    );
+    setThreads((current) => {
+      const updated = current.map((item) =>
+        updateThreadReadState(item, ids, read),
+      );
+      return read && mailbox === "unread"
+        ? updated.filter((item) => item.id !== thread.id)
+        : updated;
+    });
     setSmartSections(
       (current) =>
         Object.fromEntries(
@@ -1780,13 +1802,40 @@ export default function App() {
     );
     const failed = new Set(
       results.flatMap((result, index) =>
-        result.status === "rejected" ? [previous[index].id] : [],
+        result.status === "rejected" &&
+        readMutationByMessageRef.current.get(previous[index].id) ===
+          mutationGeneration
+          ? [previous[index].id]
+          : [],
       ),
     );
     if (failed.size) {
       const prior = new Map(previous.map((item) => [item.id, item.is_read]));
+      const failedThreadIds = new Set(
+        Object.values(previousSmartSections)
+          .flatMap((section) => section.threads)
+          .filter((item) =>
+            concreteThreadMessages(item).some((message) =>
+              failed.has(message.id),
+            ),
+          )
+          .map((item) => item.id)
+          .filter((id) => !mailboxActionThreadIdsRef.current.has(id)),
+      );
+      const failedRegularThreadIds = new Set(
+        previousThreads
+          .filter((item) =>
+            concreteThreadMessages(item).some((message) =>
+              failed.has(message.id),
+            ),
+          )
+          .map((item) => item.id)
+          .filter((id) => !mailboxActionThreadIdsRef.current.has(id)),
+      );
       setThreads((current) =>
-        current.map((item) => restoreThreadReadState(item, failed, prior)),
+        restoreThreads(current, previousThreads, failedRegularThreadIds).map(
+          (item) => restoreThreadReadState(item, failed, prior),
+        ),
       );
       setActive((current) =>
         current ? restoreMessageReadState(current, failed, prior) : current,
@@ -1794,7 +1843,22 @@ export default function App() {
       setActiveThreadSnapshot((current) =>
         current ? restoreThreadReadState(current, failed, prior) : current,
       );
-      setSmartSections(previousSmartSections);
+      setSmartSections(
+        (current) =>
+          Object.fromEntries(
+            smartSectionIds.map((id) => [
+              id,
+              {
+                ...current[id],
+                threads: restoreThreads(
+                  current[id].threads,
+                  previousSmartSections[id].threads,
+                  failedThreadIds,
+                ).map((item) => restoreThreadReadState(item, failed, prior)),
+              },
+            ]),
+          ) as Record<SmartSectionId, SmartSection>,
+      );
       if (!silent) {
         showStatus(
           t(read ? "feedback.readFailed" : "feedback.unreadFailed", {
@@ -1803,10 +1867,18 @@ export default function App() {
           "error",
         );
       }
+      for (const id of ids) {
+        if (readMutationByMessageRef.current.get(id) === mutationGeneration)
+          readMutationByMessageRef.current.delete(id);
+      }
       return;
     }
     if (!silent) {
       showStatus(t(read ? "feedback.readSuccess" : "feedback.unreadSuccess"));
+    }
+    for (const id of ids) {
+      if (readMutationByMessageRef.current.get(id) === mutationGeneration)
+        readMutationByMessageRef.current.delete(id);
     }
     if (smartInboxActive) await loadMessages();
   };
@@ -2308,7 +2380,7 @@ export default function App() {
         onLoadMore={() => void loadMoreMessages()}
         onLoadMoreSmart={(id) => void loadMoreSmartSection(id)}
         pendingActions={pendingActions}
-        actionsDisabled={actionBusy || permanentDeleteLoading}
+        actionsDisabled={permanentDeleteLoading}
         searchRef={searchRef}
       />
       <Reader
@@ -2320,7 +2392,7 @@ export default function App() {
         aiResult={aiResult}
         aiLoading={aiLoading}
         aiConnected={aiConnected}
-        actionsDisabled={actionBusy || permanentDeleteLoading}
+        actionsDisabled={permanentDeleteLoading}
         onArchive={() => void applyAction("archive")}
         onSpam={() =>
           void applyAction(
@@ -2415,6 +2487,10 @@ function mergeThreads(current: MailThread[], incoming: MailThread[]) {
       new Date(right.latest.received_at).getTime() -
       new Date(left.latest.received_at).getTime(),
   );
+}
+
+function excludeThreads(threads: MailThread[], excludedIds: Set<string>) {
+  return threads.filter((thread) => !excludedIds.has(thread.id));
 }
 
 function updateMessageReadState(

--- a/apps/desktop/src/mailActions.test.ts
+++ b/apps/desktop/src/mailActions.test.ts
@@ -210,4 +210,24 @@ describe("mail action state", () => {
       restoreThreads([second], [first, second], new Set(["first"])),
     ).toEqual([first, second]);
   });
+
+  it("preserves list order when concurrent failures restore from different snapshots", () => {
+    const threads = ["first", "second", "third"].map((id, index) => ({
+      id,
+      messages: [message(String(index + 1))],
+      latest: message(String(index + 1)),
+      unread: true,
+      hasAttachments: false,
+      participants: [],
+    })) satisfies MailThread[];
+
+    const afterFirstFailure = restoreThreads(
+      [threads[2]],
+      threads,
+      new Set(["first"]),
+    );
+    expect(
+      restoreThreads(afterFirstFailure, threads.slice(1), new Set(["second"])),
+    ).toEqual(threads);
+  });
 });

--- a/apps/desktop/src/mailActions.ts
+++ b/apps/desktop/src/mailActions.ts
@@ -153,16 +153,35 @@ export function restoreThreads(
   original: MailThread[],
   restoredIds: Set<string>,
 ) {
-  const byId = new Map(current.map((thread) => [thread.id, thread]));
+  const next = [...current];
+  const originalIds = original.map((thread) => thread.id);
   for (const thread of original) {
-    if (restoredIds.has(thread.id)) byId.set(thread.id, thread);
+    if (!restoredIds.has(thread.id)) continue;
+    const existing = next.findIndex((item) => item.id === thread.id);
+    if (existing >= 0) {
+      next[existing] = thread;
+      continue;
+    }
+
+    const originalIndex = originalIds.indexOf(thread.id);
+    const successor = originalIds
+      .slice(originalIndex + 1)
+      .map((id) => next.findIndex((item) => item.id === id))
+      .find((index) => index >= 0);
+    if (successor !== undefined) {
+      next.splice(successor, 0, thread);
+      continue;
+    }
+    const predecessor = originalIds
+      .slice(0, originalIndex)
+      .reverse()
+      .map((id) => next.findIndex((item) => item.id === id))
+      .find((index) => index >= 0);
+    next.splice(
+      predecessor === undefined ? next.length : predecessor + 1,
+      0,
+      thread,
+    );
   }
-  const originalOrder = new Map(
-    original.map((thread, index) => [thread.id, index]),
-  );
-  return [...byId.values()].sort(
-    (left, right) =>
-      (originalOrder.get(left.id) ?? Number.MAX_SAFE_INTEGER) -
-      (originalOrder.get(right.id) ?? Number.MAX_SAFE_INTEGER),
-  );
+  return next;
 }

--- a/scripts/r2-release-state.behavior.node-test.mjs
+++ b/scripts/r2-release-state.behavior.node-test.mjs
@@ -2,9 +2,9 @@ import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
 import {
   chmodSync,
-  copyFileSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -81,8 +81,19 @@ function createHarness() {
     join(root, "apps", "desktop", "src-tauri", "tauri.conf.json"),
     "{}\n",
   );
-  copyFileSync(publisherSource, join(scripts, "publish-release-to-r2.sh"));
-  chmodSync(join(scripts, "publish-release-to-r2.sh"), 0o755);
+  const publisherFixture = join(scripts, "publish-release-to-r2.sh");
+  const publisher = readFileSync(publisherSource, "utf8");
+  const plistBuddyInvocation = "/usr/libexec/PlistBuddy";
+  assert.equal(
+    publisher.split(plistBuddyInvocation).length - 1,
+    1,
+    "publisher must contain exactly one trusted PlistBuddy invocation",
+  );
+  writeFileSync(
+    publisherFixture,
+    publisher.replace(plistBuddyInvocation, '"${DAKIA_TEST_PLIST_BUDDY}"'),
+  );
+  chmodSync(publisherFixture, 0o755);
   for (const verifier of [
     "verify-macos-release-dmg.sh",
     "verify-macos-release-app.sh",
@@ -222,7 +233,18 @@ mkdir -p "\$destination/Dakia.app/Contents"
 cp "\${MOCK_INFO_PLIST}" "\$destination/Dakia.app/Contents/Info.plist"
 `,
   );
-  return { fixture, root, scripts, bin, store, publicStore };
+  const plistBuddy = join(bin, "PlistBuddy");
+  executable(
+    plistBuddy,
+    `#!/usr/bin/env node
+const { readFileSync } = require("node:fs");
+const plist = readFileSync(process.argv.at(-1), "utf8");
+const version = plist.match(/<key>CFBundleShortVersionString<\\/key>\\s*<string>([^<]+)<\\/string>/)?.[1];
+if (!version) process.exit(1);
+process.stdout.write(version + "\\n");
+`,
+  );
+  return { fixture, root, scripts, bin, store, publicStore, plistBuddy };
 }
 
 function candidate(harness, version, bytes = `dmg-${version}\n`) {
@@ -271,6 +293,7 @@ function run(harness, release, mode = "normal", extraEnvironment = {}) {
         ...process.env,
         PATH: `${harness.bin}:${process.env.PATH}`,
         CLOUDFLARE_ACCOUNT_ID: "fixture-account",
+        DAKIA_TEST_PLIST_BUDDY: harness.plistBuddy,
         MOCK_INFO_PLIST: release.plist,
         MOCK_LATEST_MODE: mode,
         MOCK_PUBLIC_STORE: harness.publicStore,
@@ -289,6 +312,49 @@ function currentVersion(store) {
     readFileSync(objectPath(store, "macos/latest/latest.json"), "utf8"),
   ).version;
 }
+
+function assertStoresUntouched(harness) {
+  assert.deepEqual(readdirSync(harness.store), []);
+  assert.deepEqual(readdirSync(harness.publicStore), []);
+}
+
+test("publisher fails before R2 mutation when its configured PlistBuddy is unavailable", () => {
+  const harness = createHarness();
+  const release = candidate(harness, "0.4.1");
+  try {
+    const result = run(harness, release, "normal", {
+      DAKIA_TEST_PLIST_BUDDY: join(harness.bin, "missing-PlistBuddy"),
+    });
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /missing-PlistBuddy: No such file or directory/,
+    );
+    assertStoresUntouched(harness);
+  } finally {
+    rmSync(harness.fixture, { recursive: true, force: true });
+  }
+});
+
+test("publisher rejects an updater version mismatch before R2 mutation", () => {
+  const harness = createHarness();
+  const release = candidate(harness, "0.4.1");
+  try {
+    writeFileSync(
+      release.plist,
+      '<?xml version="1.0"?><plist><dict><key>CFBundleShortVersionString</key><string>9.9.9</string></dict></plist>',
+    );
+    const result = run(harness, release);
+    assert.notEqual(result.status, 0);
+    assert.match(
+      result.stderr,
+      /Updater app version '9\.9\.9' does not match '0\.4\.1'/,
+    );
+    assertStoresUntouched(harness);
+  } finally {
+    rmSync(harness.fixture, { recursive: true, force: true });
+  }
+});
 
 test("a competing candidate loses before either mutable release object changes", () => {
   const harness = createHarness();


### PR DESCRIPTION
## Summary

- Apply archive actions immediately so consecutive conversations can be handled without waiting for network responses.
- Preserve optimistic removals across refreshes and reconcile concurrent action failures safely.
- Optimistically update read state, including removing read threads from the unread view and restoring failed mutations without overwriting newer changes.
- Add regression coverage for pending read updates, consecutive archives, concurrent failures, and list-order restoration.
- Document the optimistic mutation requirement in `AGENTS.md`.

## Testing

- Added App integration tests and mail-action unit tests covering optimistic behavior and concurrent failure recovery.
- Not run (not requested)