### PR TITLE
Add Send again action for sent messages

### DIFF
--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -1937,6 +1937,8 @@ describe("App read state", () => {
       from_name: "Me",
       from_address: "me@example.com",
       to_addresses: "sender-a@example.com",
+      cc_addresses: "peer@example.com",
+      bcc_addresses: "hidden@example.com",
       message_id: "<sent-b@example.com>",
       reference_ids: "<received-a@example.com>",
       received_at: "2026-07-19T10:00:00Z",
@@ -1954,11 +1956,26 @@ describe("App read state", () => {
       conversations: groupMessages([receivedA, sentB, receivedC]),
       nextCursor: null,
     });
-    mocks.api.content.mockImplementation(async (messageId) => ({
-      body_text:
-        messageId === sentB.id ? "Sent B full body" : "Received message body",
-      attachments: [],
-    }));
+    mocks.api.content.mockImplementation(async (messageId) =>
+      messageId === sentB.id
+        ? {
+            body_text: "Sent B full body",
+            body_html: "<p>Sent B <strong>full body</strong></p>",
+            attachments: [
+              {
+                id: "sent-attachment",
+                message_id: "sent-b",
+                filename: "notes.pdf",
+                mime_type: "application/pdf",
+                size_bytes: 42,
+                is_inline: false,
+                is_potentially_unsafe: false,
+                presentation: "downloadable" as const,
+              },
+            ],
+          }
+        : { body_text: "Received message body", attachments: [] },
+    );
     render(
       <MantineProvider>
         <App />
@@ -1969,7 +1986,9 @@ describe("App read state", () => {
     fireEvent.click(
       await screen.findByRole("button", { name: "Expand message from Me" }),
     );
-    await screen.findByText("Sent B full body");
+    await waitFor(() =>
+      expect(mocks.api.content).toHaveBeenCalledWith("sent-b"),
+    );
 
     for (const action of ["Quick reply", "Reply all"]) {
       mocks.openComposeWindow.mockClear();
@@ -1990,6 +2009,26 @@ describe("App read state", () => {
       );
       expect(mocks.api.content).toHaveBeenCalledWith("sent-b");
     }
+
+    mocks.openComposeWindow.mockClear();
+    mocks.api.content.mockClear();
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Send again" }),
+    );
+    await waitFor(() =>
+      expect(mocks.openComposeWindow).toHaveBeenCalledWith({
+        accountId: "account-1",
+        to: "sender-a@example.com",
+        cc: "peer@example.com",
+        bcc: "hidden@example.com",
+        subject: "Sent B",
+        body: "Sent B full body",
+        bodyHtml: "<p>Sent B <strong>full body</strong></p>",
+        forwardMessageId: "sent-b",
+      }),
+    );
+    expect(mocks.api.content).toHaveBeenCalledWith("sent-b");
   });
 
   it("opens Reply All with Reply-To and deduplicated non-self Cc recipients", async () => {

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -381,14 +381,21 @@ describe("App read state", () => {
       </MantineProvider>,
     );
 
-    fireEvent.click(await screen.findByRole("button", { name: "Feedback" }));
+    const feedback = await screen.findByRole("button", { name: "Feedback" });
+    await waitFor(() => expect(feedback).toBeEnabled());
+    await waitFor(() => expect(mocks.openAccountWindow).toHaveBeenCalled());
+    mocks.openAccountWindow.mockClear();
 
-    await waitFor(() => expect(mocks.openAccountWindow).toHaveBeenCalledOnce());
-    expect(mocks.showNativeMessage).toHaveBeenCalledWith(
-      "New message",
-      "Connect an account before composing.",
-      "warning",
+    fireEvent.click(feedback);
+
+    await waitFor(() =>
+      expect(mocks.showNativeMessage).toHaveBeenCalledWith(
+        "New message",
+        "Connect an account before composing.",
+        "warning",
+      ),
     );
+    expect(mocks.openAccountWindow).toHaveBeenCalledOnce();
     expect(mocks.createFeedbackComposeSeed).not.toHaveBeenCalled();
     expect(mocks.openComposeWindow).not.toHaveBeenCalled();
   });

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -1604,6 +1604,31 @@ export default function App() {
   const openThreadForward = async (
     thread: MailThread | undefined = activeThread,
   ) => openForwardForMessage(thread?.latest);
+  const openSendAgainForMessage = async (message: MailSummary) => {
+    try {
+      const content = await api.content(message.id);
+      openComposeWindow({
+        accountId: message.account_id,
+        to: message.to_addresses,
+        ...(message.cc_addresses ? { cc: message.cc_addresses } : {}),
+        ...(message.bcc_addresses ? { bcc: message.bcc_addresses } : {}),
+        subject: message.subject,
+        body: content.body_text,
+        ...(content.body_html ? { bodyHtml: content.body_html } : {}),
+        forwardMessageId: content.attachments.some(
+          (attachment) => attachment.presentation !== "embedded",
+        )
+          ? message.id
+          : undefined,
+      });
+    } catch (error) {
+      await showNativeMessage(
+        t("reader.sendAgainErrorTitle"),
+        error instanceof Error ? error.message : String(error),
+        "error",
+      );
+    }
+  };
   const toggleThreadStar = async (thread: MailThread, flagged: boolean) => {
     if (actionBusyRef.current) return;
     actionBusyRef.current = true;
@@ -2332,6 +2357,7 @@ export default function App() {
         onReply={(message) => void openReplyForMessage(message)}
         onReplyAll={(message) => void openReplyForMessage(message, true)}
         onForward={(message) => void openForwardForMessage(message)}
+        onSendAgain={(message) => void openSendAgainForMessage(message)}
         onToggleRead={(read) =>
           activeThread ? void setThreadReadState(activeThread, read) : undefined
         }

--- a/apps/desktop/src/ComposeApp.tsx
+++ b/apps/desktop/src/ComposeApp.tsx
@@ -38,7 +38,10 @@ export function ComposeApp() {
     Promise.all([
       api.accounts(),
       seed.forwardMessageId
-        ? api.forwardAttachments(seed.forwardMessageId)
+        ? api.forwardAttachments(seed.forwardMessageId).catch((error) => {
+            showError(error, t("attachments.loadError"));
+            return [];
+          })
         : Promise.resolve([]),
     ])
       .then(([nextAccounts, attachments]) => {
@@ -47,7 +50,7 @@ export function ComposeApp() {
           setSeed((current) => ({ ...current, attachments }));
         }
       })
-      .catch((error) => showError(error, t("reader.forwardErrorTitle")))
+      .catch((error) => showError(error))
       .finally(() => setLoading(false));
   }, []);
 

--- a/apps/desktop/src/ReaderWindowApp.test.tsx
+++ b/apps/desktop/src/ReaderWindowApp.test.tsx
@@ -60,6 +60,7 @@ vi.mock("./components/Reader", () => ({
     onComposeTo,
     onAddressContextMenu,
     onPermanentDelete,
+    onSendAgain,
   }: {
     message?: MailSummary;
     messages?: MailSummary[];
@@ -67,12 +68,16 @@ vi.mock("./components/Reader", () => ({
     onComposeTo: (message: MailSummary, address: string) => void;
     onAddressContextMenu: (message: MailSummary, address: string) => void;
     onPermanentDelete: (message: MailSummary) => void;
+    onSendAgain: (message: MailSummary) => void;
   }) => (
     <div>
       <span data-testid="focused-message">{message?.id}</span>
       <span data-testid="conversation-count">{messages?.length}</span>
       <button type="button" onClick={onArchive}>
         Archive
+      </button>
+      <button type="button" onClick={() => message && onSendAgain(message)}>
+        Send again
       </button>
       <button
         type="button"
@@ -327,6 +332,45 @@ describe("ReaderWindowApp", () => {
         "errors.copyFailed",
         "error",
       ),
+    );
+  });
+
+  it("opens a clean editable copy when sending a message again", async () => {
+    mocks.api.content.mockResolvedValue({
+      body_text: "Exact original body",
+      body_html: "<p>Exact <strong>original</strong> body</p>",
+      attachments: [
+        {
+          id: "attachment-1",
+          message_id: "message-1",
+          filename: "report.pdf",
+          mime_type: "application/pdf",
+          size_bytes: 42,
+          is_inline: false,
+          is_potentially_unsafe: false,
+          presentation: "downloadable",
+        },
+      ],
+    });
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+    await screen.findByTestId("focused-message");
+
+    fireEvent.click(screen.getByRole("button", { name: "Send again" }));
+
+    await waitFor(() =>
+      expect(mocks.openComposeWindow).toHaveBeenCalledWith({
+        accountId: "account-1",
+        to: "alex@example.com",
+        subject: "Project",
+        body: "Exact original body",
+        bodyHtml: "<p>Exact <strong>original</strong> body</p>",
+        forwardMessageId: "message-1",
+      }),
     );
   });
 

--- a/apps/desktop/src/ReaderWindowApp.tsx
+++ b/apps/desktop/src/ReaderWindowApp.tsx
@@ -428,6 +428,28 @@ export function ReaderWindowApp() {
     }
   };
 
+  const sendAgain = async (message: MailSummary) => {
+    try {
+      const content = await readerApi.content(message.id);
+      openComposeWindow({
+        accountId: message.account_id,
+        to: message.to_addresses,
+        ...(message.cc_addresses ? { cc: message.cc_addresses } : {}),
+        ...(message.bcc_addresses ? { bcc: message.bcc_addresses } : {}),
+        subject: message.subject,
+        body: content.body_text,
+        ...(content.body_html ? { bodyHtml: content.body_html } : {}),
+        forwardMessageId: content.attachments.some(
+          (attachment) => attachment.presentation !== "embedded",
+        )
+          ? message.id
+          : undefined,
+      });
+    } catch (error) {
+      showError(error, t("reader.sendAgainErrorTitle"));
+    }
+  };
+
   const unsubscribe = async (message: MailSummary) => {
     if (unsubscribeLoading) return;
     setUnsubscribeLoading(true);
@@ -525,6 +547,7 @@ export function ReaderWindowApp() {
         onReply={(message) => void reply(message)}
         onReplyAll={(message) => void reply(message, true)}
         onForward={(message) => void forward(message)}
+        onSendAgain={(message) => void sendAgain(message)}
         onToggleRead={(read) => void toggleRead(read)}
         onSummarize={() => void summarize()}
         onCopyAi={() =>

--- a/apps/desktop/src/components/Composer.test.tsx
+++ b/apps/desktop/src/components/Composer.test.tsx
@@ -294,23 +294,47 @@ describe("Composer send feedback", () => {
     expect(screen.getByLabelText("Write your message…").innerHTML).toBe("");
   });
 
-  it("initializes and sends Reply All Cc recipients from the compose seed", () => {
+  it("falls back to the plain body when sanitizing seeded HTML removes everything", () => {
+    render(
+      <Composer
+        {...props}
+        seed={{
+          to: "recipient@example.com",
+          body: "Accessible image description",
+          bodyHtml: '<img src="cid:chart" alt="Accessible image description">',
+        }}
+        sendState="idle"
+      />,
+    );
+
+    expect(screen.getByLabelText("Write your message…")).toHaveTextContent(
+      "Accessible image description",
+    );
+  });
+
+  it("initializes and sends Cc and Bcc recipients from the compose seed", () => {
     const onSend = vi.fn();
     render(
       <Composer
         {...props}
-        seed={{ to: "sender@example.com", cc: "peer@example.com" }}
+        seed={{
+          to: "sender@example.com",
+          cc: "peer@example.com",
+          bcc: "hidden@example.com",
+        }}
         onSend={onSend}
         sendState="idle"
       />,
     );
 
     expect(screen.getByLabelText("Cc")).toHaveValue("peer@example.com");
+    expect(screen.getByLabelText("Bcc")).toHaveValue("hidden@example.com");
     fireEvent.click(screen.getByRole("button", { name: /^Send/ }));
     expect(onSend).toHaveBeenCalledWith(
       expect.objectContaining({
         to: ["sender@example.com"],
         cc: ["peer@example.com"],
+        bcc: ["hidden@example.com"],
       }),
     );
   });

--- a/apps/desktop/src/components/Composer.tsx
+++ b/apps/desktop/src/components/Composer.tsx
@@ -51,12 +51,18 @@ export function Composer({
   );
   const [to, setTo] = useState(seed?.to ?? "");
   const [cc, setCc] = useState(seed?.cc ?? "");
-  const [bcc, setBcc] = useState("");
+  const [bcc, setBcc] = useState(seed?.bcc ?? "");
   const [subject, setSubject] = useState(seed?.subject ?? "");
-  const [bodyHtml, setBodyHtml] = useState(() =>
-    sanitizeRichText(seed?.bodyHtml ?? richTextFromPlainText(seed?.body ?? "")),
-  );
-  const [showCopies, setShowCopies] = useState(Boolean(seed?.cc));
+  const [bodyHtml, setBodyHtml] = useState(() => {
+    if (seed?.bodyHtml === undefined) {
+      return richTextFromPlainText(seed?.body ?? "");
+    }
+    const sanitizedHtml = sanitizeRichText(seed?.bodyHtml ?? "");
+    return seed.bodyHtml && isRichTextEmpty(sanitizedHtml)
+      ? richTextFromPlainText(seed?.body ?? "")
+      : sanitizedHtml;
+  });
+  const [showCopies, setShowCopies] = useState(Boolean(seed?.cc || seed?.bcc));
   const [aiLoading, setAiLoading] = useState(false);
   const [attachments, setAttachments] = useState<ComposeAttachment[]>(
     seed?.attachments ?? [],

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -1,5 +1,6 @@
 import {
   act,
+  cleanup,
   createEvent,
   fireEvent,
   render,
@@ -62,6 +63,7 @@ const props = {
   onReply: vi.fn(),
   onReplyAll: vi.fn(),
   onForward: vi.fn(),
+  onSendAgain: vi.fn(),
   onToggleRead: vi.fn(),
   onSummarize: vi.fn(),
   onCopyAi: vi.fn(),
@@ -248,6 +250,60 @@ describe("Reader unsubscribe action", () => {
     fireEvent.click(await screen.findByRole("menuitem", { name: "Forward" }));
     expect(props.onForward).toHaveBeenCalledOnce();
     expect(props.onForward).toHaveBeenCalledWith(message);
+  });
+
+  it("offers send again only for sent messages", async () => {
+    const sentMessage = {
+      ...message,
+      mailbox: "Sent",
+      from_address: "me@example.com",
+      to_addresses: "recipient@example.com",
+    };
+    render(
+      <MantineProvider>
+        <Reader
+          {...props}
+          accountEmail="me@example.com"
+          message={sentMessage}
+        />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    fireEvent.click(
+      await screen.findByRole("menuitem", { name: "Send again" }),
+    );
+    expect(props.onSendAgain).toHaveBeenCalledWith(sentMessage);
+
+    cleanup();
+    render(
+      <MantineProvider>
+        <Reader {...props} accountEmail="me@example.com" message={message} />
+      </MantineProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    expect(
+      screen.queryByRole("menuitem", { name: "Send again" }),
+    ).not.toBeInTheDocument();
+
+    cleanup();
+    render(
+      <MantineProvider>
+        <Reader
+          {...props}
+          accountEmail="me@example.com"
+          message={{
+            ...sentMessage,
+            id: "outbox-message",
+            mailbox: "Outbox",
+          }}
+        />
+      </MantineProvider>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "More actions" }));
+    expect(
+      screen.queryByRole("menuitem", { name: "Send again" }),
+    ).not.toBeInTheDocument();
   });
 
   it("exports the selected message once and reports the saved path", async () => {

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -168,10 +168,14 @@ describe("Reader unsubscribe action", () => {
     const documentRole = await screen.findByRole("document", {
       name: "Weekly notes",
     });
-    const surface = documentRole.shadowRoot?.firstElementChild as HTMLElement;
-    const anchor = surface.shadowRoot?.querySelector("a");
-    expect(anchor).not.toBeNull();
-    fireEvent.click(anchor!);
+    const anchor = await waitFor(() => {
+      const surface = documentRole.shadowRoot?.firstElementChild as
+        HTMLElement | undefined;
+      const nextAnchor = surface?.shadowRoot?.querySelector("a");
+      expect(nextAnchor).not.toBeNull();
+      return nextAnchor!;
+    });
+    fireEvent.click(anchor);
 
     expect(props.onComposeLink).toHaveBeenCalledWith(message, {
       to: "juhan+tamm@example.com",

--- a/apps/desktop/src/components/Reader.tsx
+++ b/apps/desktop/src/components/Reader.tsx
@@ -17,6 +17,7 @@ import {
   IconFile,
   IconFiles,
   IconMailForward,
+  IconRepeat,
   IconLanguage,
   IconMail,
   IconPaperclip,
@@ -83,6 +84,7 @@ type Props = {
   onReply: (message: MailSummary) => void;
   onReplyAll: (message: MailSummary) => void;
   onForward: (message: MailSummary) => void;
+  onSendAgain: (message: MailSummary) => void;
   onToggleRead: (read: boolean) => void;
   onSummarize: () => void;
   onCopyAi: () => void;
@@ -109,6 +111,7 @@ export function Reader({
   onReply,
   onReplyAll,
   onForward,
+  onSendAgain,
   onToggleRead,
   onSummarize,
   onCopyAi,
@@ -559,6 +562,7 @@ export function Reader({
             message={threadMessage}
             isSent={
               Boolean(accountEmail) &&
+              threadMessage.mailbox !== "Outbox" &&
               threadMessage.from_address.toLowerCase() ===
                 accountEmail?.toLowerCase()
             }
@@ -574,6 +578,7 @@ export function Reader({
             onReply={() => onReply(threadMessage)}
             onReplyAll={() => onReplyAll(threadMessage)}
             onForward={() => onForward(threadMessage)}
+            onSendAgain={() => onSendAgain(threadMessage)}
             onComposeTo={(address) => onComposeTo(threadMessage, address)}
             onAddressContextMenu={(address) =>
               onAddressContextMenu(threadMessage, address)
@@ -606,6 +611,7 @@ function ThreadMessage({
   onReply,
   onReplyAll,
   onForward,
+  onSendAgain,
   onComposeTo,
   onAddressContextMenu,
   threadUnread,
@@ -629,6 +635,7 @@ function ThreadMessage({
   onReply: () => void;
   onReplyAll: () => void;
   onForward: () => void;
+  onSendAgain: () => void;
   onComposeTo: (address: string) => void;
   onAddressContextMenu: (address: string) => void;
   threadUnread: boolean;
@@ -956,6 +963,14 @@ function ThreadMessage({
             >
               {t("actions.forward")}
             </Menu.Item>
+            {isSent ? (
+              <Menu.Item
+                leftSection={<IconRepeat size={16} />}
+                onClick={onSendAgain}
+              >
+                {t("actions.sendAgain")}
+              </Menu.Item>
+            ) : null}
             <Menu.Item
               leftSection={
                 exporting ? <Loader size={16} /> : <IconDownload size={16} />

--- a/apps/desktop/src/composeWindow.ts
+++ b/apps/desktop/src/composeWindow.ts
@@ -7,6 +7,7 @@ export type ComposeSeed = {
   accountId?: string;
   to?: string;
   cc?: string;
+  bcc?: string;
   subject?: string;
   body?: string;
   bodyHtml?: string;

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -43,6 +43,7 @@ export const en = {
       reply: "Reply",
       replyAll: "Reply all",
       forward: "Forward",
+      sendAgain: "Send again",
       exportMessage: "Export message (.eml)",
       more: "More actions",
       star: "Star conversation",
@@ -139,6 +140,7 @@ export const en = {
       date: "Date",
       replyErrorTitle: "Could not reply to message",
       forwardErrorTitle: "Could not forward message",
+      sendAgainErrorTitle: "Could not prepare message",
       permanentDeleteTitle: "Permanently delete this message?",
       permanentDeleteBody:
         "Dakia will request deletion of this message without moving it to Trash. It cannot be undone in Dakia; your email provider controls the final IMAP disposition.",
@@ -187,7 +189,8 @@ export const en = {
       saved_one: "Saved 1 attachment to Downloads",
       saved_other: "Saved {{count}} attachments to Downloads",
       saveError: "Could not save the attachment to Downloads",
-      loadError: "Could not load attachment details",
+      loadError:
+        "Could not load the original attachments. You can still edit and send this message.",
       unsafe:
         "This file may run software. Only open it if you trust the sender.",
     },


### PR DESCRIPTION
## Summary

- Add a Send again action for sent messages in the reader and thread views.
- Prefill recipients, subject, plain/HTML body, and original attachments in a new compose window.
- Preserve Cc/Bcc recipients and fall back to the plain body when sanitized HTML is empty.
- Restrict the action to sent messages, excluding Outbox items.
- Show user-facing errors when message content or attachments cannot be loaded.

## Testing

- Added App, ReaderWindowApp, Reader, and Composer coverage for Send again visibility, compose seeding, recipients, HTML fallback, and attachment handling.