### PR TITLE
Optimize CI caching and harden release validation boundaries

### DIFF
--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -77,10 +77,41 @@ jobs:
       - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
         with:
           node-version: 20.19.0
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install 1.89.0 --profile minimal
           rustup default 1.89.0
+      - name: Install Rust compiler cache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        with:
+          version: v0.17.0
+      - name: Export GitHub Actions cache credentials for sccache
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Configure target-specific Rust compiler cache
+        run: |
+          {
+            echo 'RUSTC_WRAPPER=sccache'
+            echo 'SCCACHE_GHA_ENABLED=on'
+            echo 'SCCACHE_GHA_VERSION=dakia-${{ matrix.target }}-rust-1.89.0-v1'
+          } >> "$GITHUB_ENV"
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-
       - name: Install JavaScript dependencies
         run: npm ci --ignore-scripts
       - name: Prepare packaged assets
@@ -179,13 +210,6 @@ jobs:
             $uninstaller = Join-Path $installDir 'uninstall.exe'
             if (Test-Path -PathType Leaf $uninstaller) { & $uninstaller /S }
           }
-      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        with:
-          name: hosted-build-measurement-${{ matrix.target }}-${{ github.run_id }}
-          path: ${{ matrix.artifact_glob }}
-          if-no-files-found: error
-          retention-days: 1
-          compression-level: 0
       - name: Explain measurement boundary
         run: |
           echo "Built an unsigned, non-publishing measurement package."

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -88,7 +88,7 @@ jobs:
           rustup toolchain install 1.89.0 --profile minimal
           rustup default 1.89.0
       - name: Install Rust compiler cache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
       - name: Export GitHub Actions cache credentials for sccache

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -171,6 +171,9 @@ jobs:
             --config apps/desktop/src-tauri/tauri.conf.json \
             --config "$RUNNER_TEMP/tauri-measurement.conf.json" \
             -- --locked
+      - name: Report Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats
       - name: Verify package exists and record checksum
         run: |
           shopt -s nullglob

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -125,6 +125,7 @@ jobs:
             echo 'RUSTC_WRAPPER=sccache'
             echo 'SCCACHE_GHA_ENABLED=on'
             echo 'SCCACHE_GHA_VERSION=dakia-${{ matrix.target }}-rust-1.89.0-v1'
+            echo 'SCCACHE_GHA_RW_MODE=READ_WRITE'
           } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -49,6 +49,8 @@ jobs:
             target: aarch64-apple-darwin
             bundles: dmg
             artifact_glob: target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            sccache_asset: sccache-v0.17.0-aarch64-apple-darwin.tar.gz
+            sccache_sha256: 0c560bfba31aef5bdfb4fb3d2677f6e61d71c5c00952f2a83344f47aa31f00f1
           - name: macOS Intel DMG
             runner: macos-15-intel
             platform: macos
@@ -57,6 +59,8 @@ jobs:
             target: x86_64-apple-darwin
             bundles: dmg
             artifact_glob: target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+            sccache_asset: sccache-v0.17.0-x86_64-apple-darwin.tar.gz
+            sccache_sha256: c2144cafbfe3d22e34ae637f9974ce53613543ac19477fdb287df22ea3668261
           - name: Windows x64 NSIS installer
             runner: windows-2025
             platform: windows
@@ -65,6 +69,8 @@ jobs:
             target: x86_64-pc-windows-msvc
             bundles: nsis
             artifact_glob: target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+            sccache_asset: sccache-v0.17.0-x86_64-pc-windows-msvc.tar.gz
+            sccache_sha256: caf1932d76a909c909b7a2e41443cdfe3c79a49a380da1a22fa422e1d00d3ca7
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     defaults:
@@ -87,6 +93,40 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal
           rustup default 1.89.0
+      - name: Install verified Rust compiler cache
+        run: |
+          archive="$RUNNER_TEMP/${{ matrix.sccache_asset }}"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            "https://github.com/mozilla/sccache/releases/download/v0.17.0/${{ matrix.sccache_asset }}" \
+            --output "$archive"
+          if command -v shasum >/dev/null; then
+            echo "${{ matrix.sccache_sha256 }}  $archive" | shasum -a 256 -c -
+          else
+            echo "${{ matrix.sccache_sha256 }}  $archive" | sha256sum --check -
+          fi
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          if [[ "${{ matrix.platform }}" == windows ]]; then
+            "$install_dir/sccache.exe" --version
+          else
+            "$install_dir/sccache" --version
+          fi
+      - name: Export GitHub Actions cache credentials for sccache
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Configure target-specific Rust compiler cache
+        run: |
+          {
+            echo 'RUSTC_WRAPPER=sccache'
+            echo 'SCCACHE_GHA_ENABLED=on'
+            echo 'SCCACHE_GHA_VERSION=dakia-${{ matrix.target }}-rust-1.89.0-v1'
+            echo 'SCCACHE_GHA_RW_MODE=READ_WRITE'
+          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
@@ -132,6 +172,9 @@ jobs:
             --config apps/desktop/src-tauri/tauri.conf.json \
             --config "$RUNNER_TEMP/tauri-measurement.conf.json" \
             -- --locked
+      - name: Report Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats
       - name: Verify package exists and record checksum
         run: |
           shopt -s nullglob

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -87,10 +87,15 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal
           rustup default 1.89.0
-      - name: Install Rust compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      - name: Restore sccache binary
+        id: sccache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          version: v0.17.0
+          path: ~/.cargo/bin/sccache
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-0.17.0
+      - name: Install Rust compiler cache
+        if: steps.sccache.outputs.cache-hit != 'true'
+        run: cargo install sccache --version 0.17.0 --locked
       - name: Export GitHub Actions cache credentials for sccache
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -49,6 +49,8 @@ jobs:
             target: aarch64-apple-darwin
             bundles: dmg
             artifact_glob: target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
+            sccache_asset: sccache-v0.17.0-aarch64-apple-darwin.tar.gz
+            sccache_sha256: 0c560bfba31aef5bdfb4fb3d2677f6e61d71c5c00952f2a83344f47aa31f00f1
           - name: macOS Intel DMG
             runner: macos-15-intel
             platform: macos
@@ -57,6 +59,8 @@ jobs:
             target: x86_64-apple-darwin
             bundles: dmg
             artifact_glob: target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
+            sccache_asset: sccache-v0.17.0-x86_64-apple-darwin.tar.gz
+            sccache_sha256: c2144cafbfe3d22e34ae637f9974ce53613543ac19477fdb287df22ea3668261
           - name: Windows x64 NSIS installer
             runner: windows-2025
             platform: windows
@@ -65,6 +69,8 @@ jobs:
             target: x86_64-pc-windows-msvc
             bundles: nsis
             artifact_glob: target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
+            sccache_asset: sccache-v0.17.0-x86_64-pc-windows-msvc.tar.gz
+            sccache_sha256: caf1932d76a909c909b7a2e41443cdfe3c79a49a380da1a22fa422e1d00d3ca7
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     defaults:
@@ -87,15 +93,26 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal
           rustup default 1.89.0
-      - name: Restore sccache binary
-        id: sccache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: ~/.cargo/bin/sccache
-          key: sccache-${{ runner.os }}-${{ runner.arch }}-0.17.0
-      - name: Install Rust compiler cache
-        if: steps.sccache.outputs.cache-hit != 'true'
-        run: cargo install sccache --version 0.17.0 --locked
+      - name: Install verified Rust compiler cache
+        run: |
+          archive="$RUNNER_TEMP/${{ matrix.sccache_asset }}"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            "https://github.com/mozilla/sccache/releases/download/v0.17.0/${{ matrix.sccache_asset }}" \
+            --output "$archive"
+          if command -v shasum >/dev/null; then
+            echo "${{ matrix.sccache_sha256 }}  $archive" | shasum -a 256 -c -
+          else
+            echo "${{ matrix.sccache_sha256 }}  $archive" | sha256sum --check -
+          fi
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          if [[ "${{ matrix.platform }}" == windows ]]; then
+            "$install_dir/sccache.exe" --version
+          else
+            "$install_dir/sccache" --version
+          fi
       - name: Export GitHub Actions cache credentials for sccache
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:

--- a/.github/workflows/hosted-build-measurement.yml
+++ b/.github/workflows/hosted-build-measurement.yml
@@ -49,8 +49,6 @@ jobs:
             target: aarch64-apple-darwin
             bundles: dmg
             artifact_glob: target/aarch64-apple-darwin/release/bundle/dmg/*.dmg
-            sccache_asset: sccache-v0.17.0-aarch64-apple-darwin.tar.gz
-            sccache_sha256: 0c560bfba31aef5bdfb4fb3d2677f6e61d71c5c00952f2a83344f47aa31f00f1
           - name: macOS Intel DMG
             runner: macos-15-intel
             platform: macos
@@ -59,8 +57,6 @@ jobs:
             target: x86_64-apple-darwin
             bundles: dmg
             artifact_glob: target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
-            sccache_asset: sccache-v0.17.0-x86_64-apple-darwin.tar.gz
-            sccache_sha256: c2144cafbfe3d22e34ae637f9974ce53613543ac19477fdb287df22ea3668261
           - name: Windows x64 NSIS installer
             runner: windows-2025
             platform: windows
@@ -69,8 +65,6 @@ jobs:
             target: x86_64-pc-windows-msvc
             bundles: nsis
             artifact_glob: target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe
-            sccache_asset: sccache-v0.17.0-x86_64-pc-windows-msvc.tar.gz
-            sccache_sha256: caf1932d76a909c909b7a2e41443cdfe3c79a49a380da1a22fa422e1d00d3ca7
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 45
     defaults:
@@ -93,40 +87,6 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal
           rustup default 1.89.0
-      - name: Install verified Rust compiler cache
-        run: |
-          archive="$RUNNER_TEMP/${{ matrix.sccache_asset }}"
-          install_dir="$RUNNER_TEMP/sccache-bin"
-          curl --fail --location --retry 3 --silent --show-error \
-            "https://github.com/mozilla/sccache/releases/download/v0.17.0/${{ matrix.sccache_asset }}" \
-            --output "$archive"
-          if command -v shasum >/dev/null; then
-            echo "${{ matrix.sccache_sha256 }}  $archive" | shasum -a 256 -c -
-          else
-            echo "${{ matrix.sccache_sha256 }}  $archive" | sha256sum --check -
-          fi
-          mkdir -p "$install_dir"
-          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
-          echo "$install_dir" >> "$GITHUB_PATH"
-          if [[ "${{ matrix.platform }}" == windows ]]; then
-            "$install_dir/sccache.exe" --version
-          else
-            "$install_dir/sccache" --version
-          fi
-      - name: Export GitHub Actions cache credentials for sccache
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-      - name: Configure target-specific Rust compiler cache
-        run: |
-          {
-            echo 'RUSTC_WRAPPER=sccache'
-            echo 'SCCACHE_GHA_ENABLED=on'
-            echo 'SCCACHE_GHA_VERSION=dakia-${{ matrix.target }}-rust-1.89.0-v1'
-            echo 'SCCACHE_GHA_RW_MODE=READ_WRITE'
-          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
@@ -172,9 +132,6 @@ jobs:
             --config apps/desktop/src-tauri/tauri.conf.json \
             --config "$RUNNER_TEMP/tauri-measurement.conf.json" \
             -- --locked
-      - name: Report Rust compiler cache statistics
-        if: always()
-        run: sccache --show-stats
       - name: Verify package exists and record checksum
         run: |
           shopt -s nullglob

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -69,7 +69,7 @@ jobs:
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
       - name: Install Rust compiler cache
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
       - name: Export GitHub Actions cache credentials for sccache

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -68,32 +68,6 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
-      - name: Install verified Rust compiler cache
-        run: |
-          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
-          install_dir="$RUNNER_TEMP/sccache-bin"
-          curl --fail --location --retry 3 --silent --show-error \
-            https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz \
-            --output "$archive"
-          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
-          mkdir -p "$install_dir"
-          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
-          echo "$install_dir" >> "$GITHUB_PATH"
-          "$install_dir/sccache" --version
-      - name: Export GitHub Actions cache credentials for sccache
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-      - name: Configure Rust compiler cache
-        run: |
-          {
-            echo 'RUSTC_WRAPPER=sccache'
-            echo 'SCCACHE_GHA_ENABLED=on'
-            echo 'SCCACHE_GHA_VERSION=dakia-rust-1.89.0-v1'
-            echo 'SCCACHE_GHA_RW_MODE=READ_WRITE'
-          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
@@ -118,10 +92,6 @@ jobs:
           npm run test -- --maxWorkers=1
           npm run test:release-scripts
           npm run build:web
-      - name: Report Rust compiler cache statistics
-        if: always()
-        run: sccache --show-stats
-
   coverage:
     name: Coverage baseline candidate
     needs: validate-request

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -68,10 +68,15 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
-      - name: Install Rust compiler cache
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+      - name: Restore sccache binary
+        id: sccache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          version: v0.17.0
+          path: ~/.cargo/bin/sccache
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-0.17.0
+      - name: Install Rust compiler cache
+        if: steps.sccache.outputs.cache-hit != 'true'
+        run: cargo install sccache --version 0.17.0 --locked
       - name: Export GitHub Actions cache credentials for sccache
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -62,17 +62,37 @@ jobs:
         with:
           path: ~/.npm
           key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-
       - name: Install pinned Rust toolchain
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
+      - name: Install Rust compiler cache
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        with:
+          version: v0.17.0
+      - name: Export GitHub Actions cache credentials for sccache
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Configure Rust compiler cache
+        run: |
+          {
+            echo 'RUSTC_WRAPPER=sccache'
+            echo 'SCCACHE_GHA_ENABLED=on'
+            echo 'SCCACHE_GHA_VERSION=dakia-rust-1.89.0-v1'
+          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
+          key: cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-
       - name: Install Linux dependencies for workspace tests
         run: |
           sudo apt-get update

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -51,6 +51,10 @@ jobs:
     if: inputs.lane == 'full-source'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # This environment holds a dedicated, bucket-scoped R2 credential. Its
+    # deployment-branch policy must admit only trusted refs; do not reuse it
+    # from pull_request, provider-smoke, or hosted packaging jobs.
+    environment: sccache-r2
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
@@ -68,6 +72,18 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
+      - name: Install verified Rust compiler cache
+        run: |
+          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz \
+            --output "$archive"
+          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/sccache" --version
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
@@ -82,7 +98,21 @@ jobs:
           sudo apt-get install --yes libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
       - run: npm ci --ignore-scripts
       - run: git lfs pull --include='apps/desktop/src-tauri/resources/email-classifier-v2/model.onnx,apps/desktop/src-tauri/resources/email-classifier-v2/tokenizer.json'
-      - run: |
+      - name: Run full source suite with private R2 compiler cache
+        env:
+          RUSTC_WRAPPER: sccache
+          # sccache cannot cache rustc incremental compilation outputs.
+          CARGO_INCREMENTAL: 0
+          SCCACHE_BUCKET: dakia-sccache
+          SCCACHE_ENDPOINT: https://b225fd2027198472b627795dd126aa15.r2.cloudflarestorage.com
+          SCCACHE_REGION: auto
+          SCCACHE_S3_KEY_PREFIX: dakia/linux-x64/rust-1.89.0/
+          SCCACHE_S3_RW_MODE: READ_WRITE
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+        run: |
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
           npm run bundle:cli:dev
           cargo fmt --all -- --check
           cargo clippy --workspace --all-targets -- -D warnings
@@ -92,6 +122,9 @@ jobs:
           npm run test -- --maxWorkers=1
           npm run test:release-scripts
           npm run build:web
+      - name: Report Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats
   coverage:
     name: Coverage baseline candidate
     needs: validate-request

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -92,6 +92,19 @@ jobs:
           key: cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
           restore-keys: |
             cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-
+      - name: Start private R2 compiler cache
+        env:
+          SCCACHE_BUCKET: dakia-sccache
+          SCCACHE_ENDPOINT: https://b225fd2027198472b627795dd126aa15.r2.cloudflarestorage.com
+          SCCACHE_REGION: auto
+          SCCACHE_S3_KEY_PREFIX: dakia/linux-x64/rust-1.89.0/
+          SCCACHE_S3_RW_MODE: READ_WRITE
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+        run: |
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          sccache --start-server
       - name: Install Linux dependencies for workspace tests
         run: |
           sudo apt-get update
@@ -103,16 +116,7 @@ jobs:
           RUSTC_WRAPPER: sccache
           # sccache cannot cache rustc incremental compilation outputs.
           CARGO_INCREMENTAL: 0
-          SCCACHE_BUCKET: dakia-sccache
-          SCCACHE_ENDPOINT: https://b225fd2027198472b627795dd126aa15.r2.cloudflarestorage.com
-          SCCACHE_REGION: auto
-          SCCACHE_S3_KEY_PREFIX: dakia/linux-x64/rust-1.89.0/
-          SCCACHE_S3_RW_MODE: READ_WRITE
-          AWS_ACCESS_KEY_ID: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
         run: |
-          test -n "$AWS_ACCESS_KEY_ID"
-          test -n "$AWS_SECRET_ACCESS_KEY"
           npm run bundle:cli:dev
           cargo fmt --all -- --check
           cargo clippy --workspace --all-targets -- -D warnings

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -92,6 +92,7 @@ jobs:
             echo 'RUSTC_WRAPPER=sccache'
             echo 'SCCACHE_GHA_ENABLED=on'
             echo 'SCCACHE_GHA_VERSION=dakia-rust-1.89.0-v1'
+            echo 'SCCACHE_GHA_RW_MODE=READ_WRITE'
           } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -68,6 +68,32 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
+      - name: Install verified Rust compiler cache
+        run: |
+          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz \
+            --output "$archive"
+          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/sccache" --version
+      - name: Export GitHub Actions cache credentials for sccache
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Configure Rust compiler cache
+        run: |
+          {
+            echo 'RUSTC_WRAPPER=sccache'
+            echo 'SCCACHE_GHA_ENABLED=on'
+            echo 'SCCACHE_GHA_VERSION=dakia-rust-1.89.0-v1'
+            echo 'SCCACHE_GHA_RW_MODE=READ_WRITE'
+          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
@@ -92,6 +118,10 @@ jobs:
           npm run test -- --maxWorkers=1
           npm run test:release-scripts
           npm run build:web
+      - name: Report Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats
+
   coverage:
     name: Coverage baseline candidate
     needs: validate-request

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -68,15 +68,18 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
-      - name: Restore sccache binary
-        id: sccache
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: ~/.cargo/bin/sccache
-          key: sccache-${{ runner.os }}-${{ runner.arch }}-0.17.0
-      - name: Install Rust compiler cache
-        if: steps.sccache.outputs.cache-hit != 'true'
-        run: cargo install sccache --version 0.17.0 --locked
+      - name: Install verified Rust compiler cache
+        run: |
+          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz \
+            --output "$archive"
+          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/sccache" --version
       - name: Export GitHub Actions cache credentials for sccache
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:

--- a/.github/workflows/manual-validation.yml
+++ b/.github/workflows/manual-validation.yml
@@ -117,6 +117,9 @@ jobs:
           npm run test -- --maxWorkers=1
           npm run test:release-scripts
           npm run build:web
+      - name: Report Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats
 
   coverage:
     name: Coverage baseline candidate

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -86,7 +86,7 @@ jobs:
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
       - name: Install Rust compiler cache
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
-        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         with:
           version: v0.17.0
       - name: Export GitHub Actions cache credentials for sccache

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -84,6 +84,35 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
+      - name: Install verified Rust compiler cache
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        run: |
+          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz \
+            --output "$archive"
+          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/sccache" --version
+      - name: Export GitHub Actions cache credentials for sccache
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Configure read-only Rust compiler cache
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        run: |
+          {
+            echo 'RUSTC_WRAPPER=sccache'
+            echo 'SCCACHE_GHA_ENABLED=on'
+            echo 'SCCACHE_GHA_VERSION=dakia-rust-1.89.0-v1'
+            echo 'SCCACHE_GHA_RW_MODE=READ_ONLY'
+          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         with:

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -84,35 +84,6 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
-      - name: Install verified Rust compiler cache
-        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
-        run: |
-          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
-          install_dir="$RUNNER_TEMP/sccache-bin"
-          curl --fail --location --retry 3 --silent --show-error \
-            https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz \
-            --output "$archive"
-          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
-          mkdir -p "$install_dir"
-          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
-          echo "$install_dir" >> "$GITHUB_PATH"
-          "$install_dir/sccache" --version
-      - name: Export GitHub Actions cache credentials for sccache
-        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
-        with:
-          script: |
-            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
-            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
-      - name: Configure read-only Rust compiler cache
-        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
-        run: |
-          {
-            echo 'RUSTC_WRAPPER=sccache'
-            echo 'SCCACHE_GHA_ENABLED=on'
-            echo 'SCCACHE_GHA_VERSION=dakia-rust-1.89.0-v1'
-            echo 'SCCACHE_GHA_RW_MODE=READ_ONLY'
-          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         with:

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -84,11 +84,16 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
-      - name: Install Rust compiler cache
+      - name: Restore sccache binary
+        id: sccache
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
-        uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
-          version: v0.17.0
+          path: ~/.cargo/bin/sccache
+          key: sccache-${{ runner.os }}-${{ runner.arch }}-0.17.0
+      - name: Install Rust compiler cache
+        if: (needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true') && steps.sccache.outputs.cache-hit != 'true'
+        run: cargo install sccache --version 0.17.0 --locked
       - name: Export GitHub Actions cache credentials for sccache
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -84,16 +84,19 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
-      - name: Restore sccache binary
-        id: sccache
+      - name: Install verified Rust compiler cache
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
-        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
-        with:
-          path: ~/.cargo/bin/sccache
-          key: sccache-${{ runner.os }}-${{ runner.arch }}-0.17.0
-      - name: Install Rust compiler cache
-        if: (needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true') && steps.sccache.outputs.cache-hit != 'true'
-        run: cargo install sccache --version 0.17.0 --locked
+        run: |
+          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error \
+            https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz \
+            --output "$archive"
+          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/sccache" --version
       - name: Export GitHub Actions cache credentials for sccache
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7

--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -65,6 +65,8 @@ jobs:
         with:
           path: ~/.npm
           key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-
       - name: Install JavaScript dependencies without lifecycle preparation
         if: needs.classify.outputs.frontend == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.release_only == 'true'
         run: npm ci --ignore-scripts
@@ -82,14 +84,36 @@ jobs:
         run: |
           rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
           echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
+      - name: Install Rust compiler cache
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        uses: mozilla-actions/sccache-action@fd02668681acd5f960e1372061bee5e3e987195c # v0.0.11
+        with:
+          version: v0.17.0
+      - name: Export GitHub Actions cache credentials for sccache
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            core.exportVariable('ACTIONS_RESULTS_URL', process.env.ACTIONS_RESULTS_URL || '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', process.env.ACTIONS_RUNTIME_TOKEN || '');
+      - name: Configure read-only Rust compiler cache
+        if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
+        run: |
+          {
+            echo 'RUSTC_WRAPPER=sccache'
+            echo 'SCCACHE_GHA_ENABLED=on'
+            echo 'SCCACHE_GHA_VERSION=dakia-rust-1.89.0-v1'
+            echo 'SCCACHE_GHA_RW_MODE=READ_ONLY'
+          } >> "$GITHUB_ENV"
       - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         if: needs.classify.outputs.rust_core == 'true' || needs.classify.outputs.mail_boundary == 'true' || needs.classify.outputs.tauri_boundary == 'true'
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
+          key: cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-
       - id: rust_core
         name: Validate Rust core scope
         if: needs.classify.outputs.rust_core == 'true'

--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -1976,20 +1976,21 @@ describe("Reader unsubscribe action", () => {
     const renderedMessage = await screen.findByRole("document", {
       name: "Weekly notes",
     });
-    const emailSurface = renderedMessage.shadowRoot
-      ?.firstElementChild as HTMLElement | null;
+    const currentEmailRoot = () =>
+      (renderedMessage.shadowRoot?.firstElementChild as HTMLElement | null)
+        ?.shadowRoot;
     expect(translationMocks.translate).toHaveBeenLastCalledWith(
       "et",
       "<p>Tere <strong>maailm</strong></p>",
       true,
     );
     await waitFor(() =>
-      expect(
-        emailSurface?.shadowRoot?.querySelector("strong")?.textContent,
-      ).toBe("world"),
+      expect(currentEmailRoot()?.querySelector("strong")?.textContent).toBe(
+        "world",
+      ),
     );
     expect(
-      emailSurface?.shadowRoot?.querySelector("script, iframe, form"),
+      currentEmailRoot()?.querySelector("script, iframe, form"),
     ).toBeNull();
   });
 

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -227,8 +227,15 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
   assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_ONLY/);
-  assert.match(workflow, /path: ~\/\.cargo\/bin\/sccache/);
-  assert.match(workflow, /cargo install sccache --version 0\.17\.0 --locked/);
+  assert.match(
+    workflow,
+    /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
+  );
+  assert.match(
+    workflow,
+    /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/,
+  );
+  assert.doesNotMatch(workflow, /cargo install sccache/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -224,7 +224,18 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
     workflow,
     /cargo-deps-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-rust-1\.89\.0-/,
   );
-  assert.doesNotMatch(workflow, /sccache/);
+  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
+  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_ONLY/);
+  assert.match(
+    workflow,
+    /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
+  );
+  assert.match(
+    workflow,
+    /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/,
+  );
+  assert.doesNotMatch(workflow, /cargo install sccache/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -216,6 +216,22 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
     /rustup toolchain install 1\.89\.0 --profile minimal --component rustfmt --component clippy/,
     "rustup requires one --component flag per requested component",
   );
+  assert.match(
+    workflow,
+    /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,
+  );
+  assert.match(
+    workflow,
+    /cargo-deps-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-rust-1\.89\.0-/,
+  );
+  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
+  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_ONLY/);
+  assert.doesNotMatch(
+    workflow,
+    /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,
+    "the immutable Actions cache must not store the entire target directory",
+  );
   for (const action of workflow.matchAll(/uses:\s*[^@\s]+@([^\s#]+)/g)) {
     assert.match(action[1], /^[a-f0-9]{40}$/, `unpinned action: ${action[0]}`);
   }

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -227,6 +227,8 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
   assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_ONLY/);
+  assert.match(workflow, /path: ~\/\.cargo\/bin\/sccache/);
+  assert.match(workflow, /cargo install sccache --version 0\.17\.0 --locked/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,

--- a/scripts/change-classifier.node-test.mjs
+++ b/scripts/change-classifier.node-test.mjs
@@ -224,18 +224,7 @@ test("ordinary pull-request workflow preserves the cost and release boundaries",
     workflow,
     /cargo-deps-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-rust-1\.89\.0-/,
   );
-  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
-  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
-  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_ONLY/);
-  assert.match(
-    workflow,
-    /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
-  );
-  assert.match(
-    workflow,
-    /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/,
-  );
-  assert.doesNotMatch(workflow, /cargo install sccache/);
+  assert.doesNotMatch(workflow, /sccache/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -40,8 +40,11 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /-- --locked/);
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
-  assert.match(workflow, /path: ~\/\.cargo\/bin\/sccache/);
-  assert.match(workflow, /cargo install sccache --version 0\.17\.0 --locked/);
+  assert.match(workflow, /sccache-v0\.17\.0-aarch64-apple-darwin\.tar\.gz/);
+  assert.match(workflow, /sccache-v0\.17\.0-x86_64-apple-darwin\.tar\.gz/);
+  assert.match(workflow, /sccache-v0\.17\.0-x86_64-pc-windows-msvc\.tar\.gz/);
+  assert.match(workflow, /sccache_sha256/);
+  assert.doesNotMatch(workflow, /cargo install sccache/);
   assert.match(
     workflow,
     /SCCACHE_GHA_VERSION=dakia-\$\{\{ matrix\.target \}\}-rust-1\.89\.0-v1/,

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -26,8 +26,11 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /x86_64-pc-windows-msvc/);
   assert.match(workflow, /createUpdaterArtifacts":false/);
   assert.match(workflow, /beforeBuildCommand":""/);
-  assert.match(workflow, /APPLE_SIGNING_IDENTITY: \$\{\{ matrix\.platform == 'macos' && '-' \|\| '' \}\}/);
-  assert.match(workflow, /retention-days: 1/);
+  assert.match(
+    workflow,
+    /APPLE_SIGNING_IDENTITY: \$\{\{ matrix\.platform == 'macos' && '-' \|\| '' \}\}/,
+  );
+  assert.doesNotMatch(workflow, /actions\/upload-artifact|retention-days:/);
   assert.match(workflow, /hdiutil attach/);
   assert.match(workflow, /NSIS installer failed/);
   assert.match(workflow, /Installed Dakia CLI sidecar is missing/);
@@ -35,7 +38,23 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /group: hosted-build-measurement/);
   assert.match(workflow, /bash \.\/scripts\/prepare-desktop-assets\.sh/);
   assert.match(workflow, /-- --locked/);
-  assert.doesNotMatch(workflow, /gh release|gh api|TAURI_SIGNING_PRIVATE_KEY|notary/i);
+  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
+  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(
+    workflow,
+    /SCCACHE_GHA_VERSION=dakia-\$\{\{ matrix\.target \}\}-rust-1\.89\.0-v1/,
+  );
+  assert.match(
+    workflow,
+    /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,
+  );
+  for (const action of workflow.matchAll(/uses:\s*[^@\s]+@([^\s#]+)/g)) {
+    assert.match(action[1], /^[a-f0-9]{40}$/, `unpinned action: ${action[0]}`);
+  }
+  assert.doesNotMatch(
+    workflow,
+    /gh release|gh api|TAURI_SIGNING_PRIVATE_KEY|notary/i,
+  );
 });
 
 test("Windows CLI sidecars are built for the MSVC target", () => {
@@ -43,6 +62,9 @@ test("Windows CLI sidecars are built for the MSVC target", () => {
   assert.match(cliBundler, /target="\$\{arch\}-pc-windows-msvc"/);
   assert.match(cliBundler, /executable=dakia\.exe/);
   assert.match(cliBundler, /destination="\$destination\.exe"/);
-  assert.match(cliBundler, /\$repo_root\/target\/\$target\/\$cargo_profile\/\$executable/);
+  assert.match(
+    cliBundler,
+    /\$repo_root\/target\/\$target\/\$cargo_profile\/\$executable/,
+  );
   assert.match(cliBundler, /cargo build --locked/);
 });

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -40,6 +40,10 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /-- --locked/);
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(
+    workflow,
+    /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,
+  );
   assert.match(workflow, /sccache-v0\.17\.0-aarch64-apple-darwin\.tar\.gz/);
   assert.match(workflow, /sccache-v0\.17\.0-x86_64-apple-darwin\.tar\.gz/);
   assert.match(workflow, /sccache-v0\.17\.0-x86_64-pc-windows-msvc\.tar\.gz/);

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -38,7 +38,22 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /group: hosted-build-measurement/);
   assert.match(workflow, /bash \.\/scripts\/prepare-desktop-assets\.sh/);
   assert.match(workflow, /-- --locked/);
-  assert.doesNotMatch(workflow, /sccache/);
+  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
+  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_WRITE/);
+  assert.match(
+    workflow,
+    /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,
+  );
+  assert.match(workflow, /sccache-v0\.17\.0-aarch64-apple-darwin\.tar\.gz/);
+  assert.match(workflow, /sccache-v0\.17\.0-x86_64-apple-darwin\.tar\.gz/);
+  assert.match(workflow, /sccache-v0\.17\.0-x86_64-pc-windows-msvc\.tar\.gz/);
+  assert.match(workflow, /sccache_sha256/);
+  assert.doesNotMatch(workflow, /cargo install sccache/);
+  assert.match(
+    workflow,
+    /SCCACHE_GHA_VERSION=dakia-\$\{\{ matrix\.target \}\}-rust-1\.89\.0-v1/,
+  );
   assert.match(
     workflow,
     /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -40,6 +40,8 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /-- --locked/);
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /path: ~\/\.cargo\/bin\/sccache/);
+  assert.match(workflow, /cargo install sccache --version 0\.17\.0 --locked/);
   assert.match(
     workflow,
     /SCCACHE_GHA_VERSION=dakia-\$\{\{ matrix\.target \}\}-rust-1\.89\.0-v1/,

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -40,6 +40,7 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /-- --locked/);
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_WRITE/);
   assert.match(
     workflow,
     /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,

--- a/scripts/hosted-build-measurement.node-test.mjs
+++ b/scripts/hosted-build-measurement.node-test.mjs
@@ -38,22 +38,7 @@ test("hosted build measurement covers both Macs and Windows without release writ
   assert.match(workflow, /group: hosted-build-measurement/);
   assert.match(workflow, /bash \.\/scripts\/prepare-desktop-assets\.sh/);
   assert.match(workflow, /-- --locked/);
-  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
-  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
-  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_WRITE/);
-  assert.match(
-    workflow,
-    /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,
-  );
-  assert.match(workflow, /sccache-v0\.17\.0-aarch64-apple-darwin\.tar\.gz/);
-  assert.match(workflow, /sccache-v0\.17\.0-x86_64-apple-darwin\.tar\.gz/);
-  assert.match(workflow, /sccache-v0\.17\.0-x86_64-pc-windows-msvc\.tar\.gz/);
-  assert.match(workflow, /sccache_sha256/);
-  assert.doesNotMatch(workflow, /cargo install sccache/);
-  assert.match(
-    workflow,
-    /SCCACHE_GHA_VERSION=dakia-\$\{\{ matrix\.target \}\}-rust-1\.89\.0-v1/,
-  );
+  assert.doesNotMatch(workflow, /sccache/);
   assert.match(
     workflow,
     /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -208,7 +208,42 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     workflow,
     /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,
   );
-  assert.doesNotMatch(workflow, /sccache/);
+  assert.match(workflow, /environment: sccache-r2/);
+  assert.match(workflow, /RUSTC_WRAPPER: sccache/);
+  assert.match(workflow, /CARGO_INCREMENTAL: 0/);
+  assert.match(workflow, /SCCACHE_BUCKET: dakia-sccache/);
+  assert.match(
+    workflow,
+    /SCCACHE_ENDPOINT: https:\/\/b225fd2027198472b627795dd126aa15\.r2\.cloudflarestorage\.com/,
+  );
+  assert.match(workflow, /SCCACHE_REGION: auto/);
+  assert.match(
+    workflow,
+    /SCCACHE_S3_KEY_PREFIX: dakia\/linux-x64\/rust-1\.89\.0\//,
+  );
+  assert.match(workflow, /SCCACHE_S3_RW_MODE: READ_WRITE/);
+  assert.match(
+    workflow,
+    /AWS_ACCESS_KEY_ID: \$\{\{ secrets\.R2_SCCACHE_ACCESS_KEY_ID \}\}/,
+  );
+  assert.match(
+    workflow,
+    /AWS_SECRET_ACCESS_KEY: \$\{\{ secrets\.R2_SCCACHE_SECRET_ACCESS_KEY \}\}/,
+  );
+  assert.match(
+    workflow,
+    /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,
+  );
+  assert.match(
+    workflow,
+    /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
+  );
+  assert.match(
+    workflow,
+    /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/,
+  );
+  assert.doesNotMatch(workflow, /SCCACHE_GHA_ENABLED|SCCACHE_GHA_RW_MODE/);
+  assert.doesNotMatch(workflow, /cargo install sccache/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,
@@ -220,6 +255,27 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     "rustup requires one --component flag per requested component",
   );
   const providerJob = workflow.slice(workflow.indexOf("\n  provider-smoke:"));
+  const fullSourceJob = workflow.slice(
+    workflow.indexOf("\n  full-source:"),
+    workflow.indexOf("\n  coverage:"),
+  );
+  assert.match(fullSourceJob, /environment: sccache-r2/);
+  assert.match(fullSourceJob, /RUSTC_WRAPPER: sccache/);
+  assert.match(fullSourceJob, /CARGO_INCREMENTAL: 0/);
+  assert.equal(
+    [
+      ...fullSourceJob.matchAll(
+        /R2_SCCACHE_(?:ACCESS_KEY_ID|SECRET_ACCESS_KEY)/g,
+      ),
+    ].length,
+    2,
+    "R2 credentials must be scoped to the one compiler-cache execution step",
+  );
+  assert.doesNotMatch(
+    workflow.slice(0, workflow.indexOf("\n  full-source:")),
+    /R2_SCCACHE_|RUSTC_WRAPPER: sccache/,
+  );
+  assert.doesNotMatch(providerJob, /R2_SCCACHE_|RUSTC_WRAPPER: sccache/);
   assert.match(
     providerJob,
     /cargo build --locked -p dakia-cli --bin dakia-provider-smoke/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -208,22 +208,7 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     workflow,
     /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,
   );
-  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
-  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
-  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_WRITE/);
-  assert.match(
-    workflow,
-    /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,
-  );
-  assert.match(
-    workflow,
-    /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
-  );
-  assert.match(
-    workflow,
-    /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/,
-  );
-  assert.doesNotMatch(workflow, /cargo install sccache/);
+  assert.doesNotMatch(workflow, /sccache/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,
@@ -254,7 +239,6 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     1,
     "the provider secret may be scoped only to the artifact execution step",
   );
-  assert.doesNotMatch(providerJob, /RUSTC_WRAPPER=sccache|SCCACHE_GHA_ENABLED/);
   assert.match(
     providerJob,
     /run: \|\n\s+node scripts\/provider-smoke-contract\.mjs\n\s+target\/debug\/dakia-provider-smoke/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -212,6 +212,10 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
   assert.match(
     workflow,
+    /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,
+  );
+  assert.match(
+    workflow,
     /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
   );
   assert.match(

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -210,8 +210,15 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   );
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
-  assert.match(workflow, /path: ~\/\.cargo\/bin\/sccache/);
-  assert.match(workflow, /cargo install sccache --version 0\.17\.0 --locked/);
+  assert.match(
+    workflow,
+    /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
+  );
+  assert.match(
+    workflow,
+    /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/,
+  );
+  assert.doesNotMatch(workflow, /cargo install sccache/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -210,6 +210,8 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   );
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /path: ~\/\.cargo\/bin\/sccache/);
+  assert.match(workflow, /cargo install sccache --version 0\.17\.0 --locked/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -210,6 +210,7 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   );
   assert.match(workflow, /RUSTC_WRAPPER=sccache/);
   assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_WRITE/);
   assert.match(
     workflow,
     /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -208,7 +208,22 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     workflow,
     /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,
   );
-  assert.doesNotMatch(workflow, /sccache/);
+  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
+  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.match(workflow, /SCCACHE_GHA_RW_MODE=READ_WRITE/);
+  assert.match(
+    workflow,
+    /name: Report Rust compiler cache statistics\n\s+if: always\(\)\n\s+run: sccache --show-stats/,
+  );
+  assert.match(
+    workflow,
+    /sccache-v0\.17\.0-x86_64-unknown-linux-musl\.tar\.gz/,
+  );
+  assert.match(
+    workflow,
+    /67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006/,
+  );
+  assert.doesNotMatch(workflow, /cargo install sccache/);
   assert.doesNotMatch(
     workflow,
     /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,
@@ -239,6 +254,7 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     1,
     "the provider secret may be scoped only to the artifact execution step",
   );
+  assert.doesNotMatch(providerJob, /RUSTC_WRAPPER=sccache|SCCACHE_GHA_ENABLED/);
   assert.match(
     providerJob,
     /run: \|\n\s+node scripts\/provider-smoke-contract\.mjs\n\s+target\/debug\/dakia-provider-smoke/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -158,21 +158,31 @@ test("provider smoke contract validates secrets without exposing them or connect
   assert.equal(result.status, 0, result.stderr);
   assert.doesNotMatch(`${result.stdout}${result.stderr}`, new RegExp(secret));
   assert.doesNotMatch(result.stdout, /smoke@example\.invalid/);
-  assert.doesNotMatch(result.stdout, /example-provider|imap\.example\.invalid|smtp\.example\.invalid/);
+  assert.doesNotMatch(
+    result.stdout,
+    /example-provider|imap\.example\.invalid|smtp\.example\.invalid/,
+  );
 
-  const rejected = spawnSync(process.execPath, ["scripts/provider-smoke-contract.mjs"], {
-    cwd: root,
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      PROVIDER_SMOKE_CONFIG: JSON.stringify({
-        ...providerConfig,
-        credentials: { accessToken: secret },
-      }),
+  const rejected = spawnSync(
+    process.execPath,
+    ["scripts/provider-smoke-contract.mjs"],
+    {
+      cwd: root,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        PROVIDER_SMOKE_CONFIG: JSON.stringify({
+          ...providerConfig,
+          credentials: { accessToken: secret },
+        }),
+      },
     },
-  });
+  );
   assert.notEqual(rejected.status, 0);
-  assert.doesNotMatch(`${rejected.stdout}${rejected.stderr}`, new RegExp(secret));
+  assert.doesNotMatch(
+    `${rejected.stdout}${rejected.stderr}`,
+    new RegExp(secret),
+  );
 });
 
 test("manual workflow remains dispatch-only and runs bounded infrastructure", () => {
@@ -196,6 +206,17 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   assert.match(workflow, /RUSTUP_TOOLCHAIN=1\.89\.0/);
   assert.match(
     workflow,
+    /restore-keys: \|\n\s+npm-\$\{\{ runner\.os \}\}-\$\{\{ runner\.arch \}\}-node-20\.19\.0-/,
+  );
+  assert.match(workflow, /RUSTC_WRAPPER=sccache/);
+  assert.match(workflow, /SCCACHE_GHA_ENABLED=on/);
+  assert.doesNotMatch(
+    workflow,
+    /path: \|\n\s+~\/\.cargo\/registry\n\s+~\/\.cargo\/git\n\s+target/,
+    "the immutable Actions cache must not store the entire target directory",
+  );
+  assert.match(
+    workflow,
     /rustup toolchain install 1\.89\.0 --profile minimal --component rustfmt --component clippy/,
     "rustup requires one --component flag per requested component",
   );
@@ -209,7 +230,9 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     /cargo run .*dakia-provider-smoke/,
     "the protected execution step must run the prebuilt artifact, never compile with a secret in scope",
   );
-  const buildIndex = providerJob.indexOf("cargo build --locked -p dakia-cli --bin dakia-provider-smoke");
+  const buildIndex = providerJob.indexOf(
+    "cargo build --locked -p dakia-cli --bin dakia-provider-smoke",
+  );
   const secretIndex = providerJob.indexOf("PROVIDER_SMOKE_CONFIG:");
   assert.ok(buildIndex >= 0 && secretIndex > buildIndex);
   assert.equal(
@@ -217,6 +240,7 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
     1,
     "the provider secret may be scoped only to the artifact execution step",
   );
+  assert.doesNotMatch(providerJob, /RUSTC_WRAPPER=sccache|SCCACHE_GHA_ENABLED/);
   assert.match(
     providerJob,
     /run: \|\n\s+node scripts\/provider-smoke-contract\.mjs\n\s+target\/debug\/dakia-provider-smoke/,

--- a/scripts/manual-validation.node-test.mjs
+++ b/scripts/manual-validation.node-test.mjs
@@ -262,6 +262,22 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
   assert.match(fullSourceJob, /environment: sccache-r2/);
   assert.match(fullSourceJob, /RUSTC_WRAPPER: sccache/);
   assert.match(fullSourceJob, /CARGO_INCREMENTAL: 0/);
+  const cacheStartStep = fullSourceJob.slice(
+    fullSourceJob.indexOf("- name: Start private R2 compiler cache"),
+    fullSourceJob.indexOf("- name: Install Linux dependencies"),
+  );
+  const fullSuiteStep = fullSourceJob.slice(
+    fullSourceJob.indexOf("- name: Run full source suite"),
+    fullSourceJob.indexOf("- name: Report Rust compiler cache statistics"),
+  );
+  assert.match(cacheStartStep, /sccache --start-server/);
+  assert.match(cacheStartStep, /AWS_ACCESS_KEY_ID:/);
+  assert.match(cacheStartStep, /AWS_SECRET_ACCESS_KEY:/);
+  assert.doesNotMatch(
+    fullSuiteStep,
+    /AWS_ACCESS_KEY_ID|AWS_SECRET_ACCESS_KEY|R2_SCCACHE_/,
+    "the source suite must connect to the cache server without inheriting R2 credentials",
+  );
   assert.equal(
     [
       ...fullSourceJob.matchAll(
@@ -269,7 +285,7 @@ test("manual workflow remains dispatch-only and runs bounded infrastructure", ()
       ),
     ].length,
     2,
-    "R2 credentials must be scoped to the one compiler-cache execution step",
+    "R2 credentials must be scoped to the cache-server startup step",
   );
   assert.doesNotMatch(
     workflow.slice(0, workflow.indexOf("\n  full-source:")),


### PR DESCRIPTION
## Summary

- Add npm and Rust dependency caching with restore keys across validation and measurement workflows.
- Add a verified, R2-backed `sccache` lane scoped to the full-source manual validation job.
- Remove hosted measurement artifact uploads and prevent compiler-cache credentials from reaching unrelated jobs.
- Strengthen workflow contract tests and release-publisher tests for pre-mutation failures.
- Update Reader test shadow-root traversal and apply formatting cleanup.

## Testing

- Added and updated workflow and release-state regression coverage.
- Not run (not requested).