### PR TITLE
GitHub-hosted production releases for macOS, Linux, and Windows

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -78,7 +78,7 @@ jobs:
           public_version="$(node - "$public_manifest" <<'NODE'
           const { readFileSync } = require('node:fs');
           const version = JSON.parse(readFileSync(process.argv[2], 'utf8')).version;
-          if (typeof version !== 'string' || !/^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$/.test(version)) {
+          if (typeof version !== 'string' || !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/.test(version)) {
             throw new Error(`Invalid public updater version: ${String(version)}`);
           }
           process.stdout.write(version);
@@ -552,7 +552,7 @@ jobs:
           # signature last even when no Windows certificate is configured.
           ./node_modules/.bin/tauri signer sign "$output/$expected"
           test -s "$output/$expected.sig"
-          (cd "$output" && shasum -a 256 "$expected" "$expected.sig" > SHA256SUMS.txt)
+          (cd "$output" && sha256sum "$expected" "$expected.sig" > SHA256SUMS.txt)
           node scripts/verify-updater-signature.mjs "$output/$expected" "$output/$expected.sig" apps/desktop/src-tauri/tauri.conf.json
       - name: Verify macOS release asset set
         if: matrix.platform == 'macos'

--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -1,0 +1,821 @@
+name: Production release
+
+on:
+  schedule:
+    - cron: '17 2 * * *'
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: Optional reason for this production release run
+        required: false
+        type: string
+      force:
+        description: Release even when no commits have landed since the public release
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: dakia-production-release
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  actions: read
+
+defaults:
+  run:
+    shell: bash
+
+env:
+  NODE_VERSION: 20.19.0
+  RUST_VERSION: 1.89.0
+  SCCACHE_VERSION: 0.17.0
+  SCCACHE_BUCKET: dakia-sccache
+  SCCACHE_ENDPOINT: https://b225fd2027198472b627795dd126aa15.r2.cloudflarestorage.com
+  SCCACHE_REGION: auto
+  RELEASE_ORIGIN: https://github.com/DakiaMail/dakia-desktop.git
+  DOWNLOAD_ORIGIN: https://downloads.dakiamail.com
+
+jobs:
+  decide:
+    name: Decide whether a release is eligible
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      should_release: ${{ steps.decide.outputs.should_release }}
+      public_version: ${{ steps.decide.outputs.public_version }}
+      version: ${{ steps.decide.outputs.version }}
+      tag: ${{ steps.decide.outputs.tag }}
+      release_commit: ${{ steps.decide.outputs.release_commit }}
+      bump_needed: ${{ steps.decide.outputs.bump_needed }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          fetch-depth: 0
+          lfs: false
+      - id: decide
+        name: Read public release and calculate candidate
+        env:
+          FORCE: ${{ inputs.force }}
+        run: |
+          set -euo pipefail
+          git fetch --force origin main --tags
+          live_main="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          cached_main="$(git rev-parse refs/remotes/origin/main)"
+          head="$(git rev-parse HEAD)"
+          if [[ "$head" != "$live_main" || "$cached_main" != "$live_main" ]]; then
+            echo "Workflow checkout is not the exact live origin/main state." >&2
+            exit 1
+          fi
+
+          public_manifest="$RUNNER_TEMP/public-latest.json"
+          curl --fail --silent --show-error --location --proto '=https' \
+            --connect-timeout 15 --max-time 90 --retry 3 \
+            "$DOWNLOAD_ORIGIN/macos/latest/latest.json" --output "$public_manifest"
+          public_version="$(node - "$public_manifest" <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const version = JSON.parse(readFileSync(process.argv[2], 'utf8')).version;
+          if (typeof version !== 'string' || !/^(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$/.test(version)) {
+            throw new Error(`Invalid public updater version: ${String(version)}`);
+          }
+          process.stdout.write(version);
+          NODE
+          )"
+          public_tag="v${public_version}"
+          if release_commit="$(git rev-parse --verify "${public_tag}^{commit}" 2>/dev/null)"; then
+            :
+          else
+            release_commit="$(git log -1 --format=%H -- "docs/releases/${public_tag}.md")"
+            if [[ -z "$release_commit" ]]; then
+              echo "Cannot locate the source commit for public release ${public_tag}." >&2
+              exit 1
+            fi
+          fi
+
+          commits_since="$(git rev-list --count "${release_commit}..HEAD")"
+          eligible=false
+          if [[ "$commits_since" -gt 0 || "$FORCE" == "true" ]]; then
+            eligible=true
+          fi
+          package_version="$(node -p "require('./package.json').version")"
+          bump_needed=false
+          version="$package_version"
+          tag="v${version}"
+
+          if [[ "$eligible" == true && "$package_version" == "$public_version" ]]; then
+            candidate="$(node scripts/prepare-nightly-release.mjs "$release_commit" --dry-run)"
+            tag="$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).tag)' "$candidate")"
+            version="${tag#v}"
+            # Parsing notes here proves the dry-run took the normal note-generation path.
+            node -e 'const value=JSON.parse(process.argv[1]); if (!value.notes?.trim()) throw new Error("Release notes are empty")' "$candidate"
+            bump_needed=true
+          elif [[ "$eligible" == true ]]; then
+            if [[ ! -s "docs/releases/${tag}.md" ]]; then
+              echo "Prepared release ${tag} is missing non-empty tracked release notes." >&2
+              exit 1
+            fi
+          fi
+
+          {
+            echo "should_release=$eligible"
+            echo "public_version=$public_version"
+            echo "version=$version"
+            echo "tag=$tag"
+            echo "release_commit=$release_commit"
+            echo "bump_needed=$bump_needed"
+          } >> "$GITHUB_OUTPUT"
+          if [[ "$eligible" == false ]]; then
+            echo "No commits since ${public_tag}; production release is a no-op."
+          fi
+
+  prepare:
+    name: Prepare next patch release
+    needs: decide
+    if: needs.decide.outputs.should_release == 'true' && needs.decide.outputs.bump_needed == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    outputs:
+      pushed_head: ${{ steps.push.outputs.pushed_head }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: main
+          fetch-depth: 0
+          lfs: false
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - name: Verify the live main tip before mutation
+        run: |
+          set -euo pipefail
+          git remote set-url origin "$RELEASE_ORIGIN"
+          git fetch --force origin main --tags
+          git switch -C main HEAD
+          live_main="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          test "$(git rev-parse HEAD)" = "$live_main"
+          test "$(git rev-parse refs/remotes/origin/main)" = "$live_main"
+          test "$(git branch --show-current)" = main
+      - name: Generate release version and notes
+        run: |
+          generated="$(node scripts/prepare-nightly-release.mjs "${{ needs.decide.outputs.release_commit }}")"
+          test "$(node -e 'process.stdout.write(JSON.parse(process.argv[1]).tag)' "$generated")" = "${{ needs.decide.outputs.tag }}"
+          test "$(node -p "require('./package.json').version")" = "${{ needs.decide.outputs.version }}"
+          test -s "docs/releases/${{ needs.decide.outputs.tag }}.md"
+      - name: Check generated release metadata
+        run: |
+          git diff --check
+          node --test scripts/prepare-nightly-release.node-test.mjs scripts/updater-manifest.node-test.mjs
+      - id: push
+        name: Commit and push prepared main
+        run: |
+          set -euo pipefail
+          git config user.name 'Dakia release bot'
+          git config user.email 'release-bot@dakiamail.com'
+          git add package.json package-lock.json Cargo.toml Cargo.lock \
+            apps/desktop/src-tauri/tauri.conf.json "docs/releases/${{ needs.decide.outputs.tag }}.md"
+          git commit -m "Prepare Dakia ${{ needs.decide.outputs.tag }} nightly release"
+          # A normal push is deliberately used: a concurrent main update is a hard stop.
+          git push origin HEAD:refs/heads/main
+          pushed_head="$(git rev-parse HEAD)"
+          live_main="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          test "$pushed_head" = "$live_main"
+          echo "pushed_head=$pushed_head" >> "$GITHUB_OUTPUT"
+
+  validate:
+    name: Full source suite before packaging
+    needs: [decide, prepare]
+    if: >-
+      always() && needs.decide.outputs.should_release == 'true' &&
+      (needs.prepare.result == 'success' || needs.prepare.result == 'skipped')
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: sccache-r2
+    permissions:
+      contents: read
+    outputs:
+      validated_commit: ${{ steps.commit.outputs.validated_commit }}
+      tag: ${{ needs.decide.outputs.tag }}
+      version: ${{ needs.decide.outputs.version }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.decide.outputs.bump_needed == 'true' && needs.prepare.outputs.pushed_head || 'main' }}
+          fetch-depth: 0
+          lfs: false
+      - name: Attach the exact release checkout to main
+        run: |
+          set -euo pipefail
+          git remote set-url origin "$RELEASE_ORIGIN"
+          git fetch --force origin main
+          git switch -C main HEAD
+          live_main="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          test "$(git rev-parse HEAD)" = "$live_main"
+          test "$(git rev-parse refs/remotes/origin/main)" = "$live_main"
+      - id: commit
+        run: echo "validated_commit=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.89.0 --profile minimal --component rustfmt --component clippy
+          echo 'RUSTUP_TOOLCHAIN=1.89.0' >> "$GITHUB_ENV"
+      - name: Install verified Rust compiler cache
+        run: |
+          archive="$RUNNER_TEMP/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error https://github.com/mozilla/sccache/releases/download/v0.17.0/sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz --output "$archive"
+          printf '%s  %s\n' '67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006' "$archive" | sha256sum --check -
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/sccache" --version
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-
+      - name: Start private R2 compiler cache
+        env:
+          SCCACHE_S3_KEY_PREFIX: dakia/linux-x64/rust-1.89.0/
+          SCCACHE_S3_RW_MODE: READ_WRITE
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+        run: |
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          sccache --start-server
+      - name: Install Linux dependencies for workspace tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: npm ci --ignore-scripts
+      - run: git lfs pull --include='apps/desktop/src-tauri/resources/email-classifier-v2/model.onnx,apps/desktop/src-tauri/resources/email-classifier-v2/tokenizer.json'
+      - name: Run full source suite with private R2 compiler cache
+        env:
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: 0
+        run: |
+          npm run bundle:cli:dev
+          cargo fmt --all -- --check
+          cargo clippy --workspace --all-targets -- -D warnings
+          cargo test --workspace
+          npm run typecheck
+          npm run format:check
+          npm run test -- --maxWorkers=1
+          npm run test:release-scripts
+          npm run build:web
+      - name: Report Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats
+
+  build:
+    name: Build ${{ matrix.name }}
+    needs: [decide, validate]
+    if: needs.decide.outputs.should_release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS Apple Silicon
+            runner: macos-15
+            platform: macos
+            updater_platform: darwin-aarch64
+            endpoint: https://downloads.dakiamail.com/macos/latest/latest.json
+            arch: aarch64
+            target: aarch64-apple-darwin
+            bundles: dmg
+            cache_prefix: dakia/macos-arm64/rust-1.89.0/
+            sccache_archive: sccache-v0.17.0-aarch64-apple-darwin.tar.gz
+            sccache_sha256: 0c560bfba31aef5bdfb4fb3d2677f6e61d71c5c00952f2a83344f47aa31f00f1
+          - name: Linux x64
+            runner: ubuntu-24.04
+            platform: linux
+            updater_platform: linux-x86_64
+            endpoint: https://downloads.dakiamail.com/linux/latest/latest.json
+            arch: x86_64
+            target: x86_64-unknown-linux-gnu
+            bundles: appimage
+            cache_prefix: dakia/linux-x64/rust-1.89.0/
+            sccache_archive: sccache-v0.17.0-x86_64-unknown-linux-musl.tar.gz
+            sccache_sha256: 67c4a96dd237c1f518f6b36083f270f9976d516f1e57fce891755ea782e50006
+          - name: Windows x64
+            runner: windows-2025
+            platform: windows
+            updater_platform: windows-x86_64
+            endpoint: https://downloads.dakiamail.com/windows/latest/latest.json
+            arch: x86_64
+            target: x86_64-pc-windows-msvc
+            bundles: nsis
+            cache_prefix: dakia/windows-x64/rust-1.89.0/
+            sccache_archive: sccache-v0.17.0-x86_64-pc-windows-msvc.tar.gz
+            sccache_sha256: caf1932d76a909c909b7a2e41443cdfe3c79a49a380da1a22fa422e1d00d3ca7
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 60
+    # A GitHub job can bind one deployment environment. This one is limited to
+    # the shared compiler-cache credentials; production signing secrets must
+    # therefore be repository/org scoped. The publish job owns production-release.
+    environment: sccache-r2
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.validate.outputs.validated_commit }}
+          fetch-depth: 0
+          lfs: true
+      - name: Attach the validated source to main and prove it remains live
+        run: |
+          set -euo pipefail
+          git remote set-url origin "$RELEASE_ORIGIN"
+          git fetch --force origin main
+          git switch -C main HEAD
+          live_main="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          test "$(git rev-parse HEAD)" = "${{ needs.validate.outputs.validated_commit }}"
+          test "$(git rev-parse HEAD)" = "$live_main"
+          test "$(git rev-parse refs/remotes/origin/main)" = "$live_main"
+      - uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4
+        with:
+          node-version: 20.19.0
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.npm
+          key: npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            npm-${{ runner.os }}-${{ runner.arch }}-node-20.19.0-
+      - name: Install pinned Rust toolchain
+        run: |
+          rustup toolchain install 1.89.0 --profile minimal${{ matrix.platform != 'windows' && ' --component rustfmt --component clippy' || '' }}
+          rustup default 1.89.0
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-${{ hashFiles('Cargo.lock') }}
+          restore-keys: |
+            cargo-deps-${{ runner.os }}-${{ runner.arch }}-rust-1.89.0-
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        if: matrix.platform == 'macos'
+        with:
+          path: apps/desktop/src-tauri/frameworks
+          key: onnx-runtime-macos-arm64-${{ hashFiles('scripts/prepare-onnx-runtime.sh', 'apps/desktop/src-tauri/Cargo.lock', 'Cargo.lock') }}
+      - name: Install verified Rust compiler cache
+        run: |
+          archive="$RUNNER_TEMP/${{ matrix.sccache_archive }}"
+          install_dir="$RUNNER_TEMP/sccache-bin"
+          curl --fail --location --retry 3 --silent --show-error "https://github.com/mozilla/sccache/releases/download/v0.17.0/${{ matrix.sccache_archive }}" --output "$archive"
+          if [[ "${{ matrix.platform }}" == macos ]]; then
+            printf '%s  %s\n' '${{ matrix.sccache_sha256 }}' "$archive" | shasum -a 256 -c -
+          else
+            printf '%s  %s\n' '${{ matrix.sccache_sha256 }}' "$archive" | sha256sum --check -
+          fi
+          mkdir -p "$install_dir"
+          tar -xzf "$archive" --strip-components=1 -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
+          "$install_dir/sccache" --version
+      - name: Start private R2 compiler cache
+        env:
+          SCCACHE_S3_KEY_PREFIX: ${{ matrix.cache_prefix }}
+          SCCACHE_S3_RW_MODE: READ_WRITE
+          AWS_ACCESS_KEY_ID: ${{ secrets.R2_SCCACHE_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SCCACHE_SECRET_ACCESS_KEY }}
+        run: |
+          test -n "$AWS_ACCESS_KEY_ID"
+          test -n "$AWS_SECRET_ACCESS_KEY"
+          sccache --start-server
+      - name: Install Linux packaging dependencies
+        if: matrix.platform == 'linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+      - run: npm ci --ignore-scripts
+      - name: Prepare packaged assets
+        run: bash ./scripts/prepare-desktop-assets.sh
+      - name: Build target-specific CLI sidecar
+        env:
+          TAURI_ENV_PLATFORM: ${{ matrix.platform }}
+          TAURI_ENV_ARCH: ${{ matrix.arch }}
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: 0
+        run: |
+          if [[ "${{ matrix.platform }}" == macos ]]; then
+            export ORT_LIB_LOCATION="$GITHUB_WORKSPACE/apps/desktop/src-tauri/frameworks"
+            export ORT_PREFER_DYNAMIC_LINK=1
+          else
+            unset ORT_LIB_LOCATION ORT_PREFER_DYNAMIC_LINK
+          fi
+          bash ./scripts/bundle-cli.sh release
+      - name: Build the web frontend
+        run: npm run build:web
+      - name: Configure macOS signing and notarization
+        if: matrix.platform == 'macos'
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_ISSUER_ID: ${{ secrets.APPLE_ISSUER_ID }}
+        run: |
+          set -euo pipefail
+          test -n "$APPLE_CERTIFICATE"; test -n "$APPLE_CERTIFICATE_PASSWORD"
+          test -n "$APPLE_API_KEY"; test -n "$APPLE_API_KEY_ID"; test -n "$APPLE_ISSUER_ID"
+          keychain="$RUNNER_TEMP/dakia-release.keychain-db"
+          certificate="$RUNNER_TEMP/dakia-release.p12"
+          api_key="$RUNNER_TEMP/AuthKey_${APPLE_API_KEY_ID}.p8"
+          printf '%s' "$APPLE_CERTIFICATE" | base64 --decode > "$certificate"
+          printf '%s' "$APPLE_API_KEY" | base64 --decode > "$api_key"
+          security create-keychain -p '' "$keychain"
+          security set-keychain-settings -lut 21600 "$keychain"
+          security unlock-keychain -p '' "$keychain"
+          security import "$certificate" -k "$keychain" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k '' "$keychain"
+          security list-keychain -d user -s "$keychain"
+          security default-keychain -d user -s "$keychain"
+          xcrun notarytool store-credentials dakia-notary --key "$api_key" --key-id "$APPLE_API_KEY_ID" --issuer "$APPLE_ISSUER_ID"
+      - name: Build signed and notarized macOS release assets
+        if: matrix.platform == 'macos'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+          APPLE_NOTARY_PROFILE: dakia-notary
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          DAKIA_GOOGLE_CLIENT_ID: ${{ secrets.DAKIA_GOOGLE_CLIENT_ID }}
+          DAKIA_GOOGLE_CLIENT_SECRET: ${{ secrets.DAKIA_GOOGLE_CLIENT_SECRET }}
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: 0
+        run: |
+          test -n "$APPLE_SIGNING_IDENTITY"; test -n "$TAURI_SIGNING_PRIVATE_KEY"
+          test -n "$DAKIA_GOOGLE_CLIENT_ID"; test -n "$DAKIA_GOOGLE_CLIENT_SECRET"
+          npm run release:build -- "${{ needs.validate.outputs.tag }}"
+      - name: Write platform updater endpoint overlay
+        if: matrix.platform != 'macos'
+        run: |
+          printf '{"build":{"beforeBuildCommand":""},"plugins":{"updater":{"endpoints":["%s"]}}}\n' \
+            '${{ matrix.endpoint }}' > "$RUNNER_TEMP/tauri-production-overlay.json"
+      - name: Build Linux updater AppImage
+        if: matrix.platform == 'linux'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          DAKIA_GOOGLE_CLIENT_ID: ${{ secrets.DAKIA_GOOGLE_CLIENT_ID }}
+          DAKIA_GOOGLE_CLIENT_SECRET: ${{ secrets.DAKIA_GOOGLE_CLIENT_SECRET }}
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: 0
+        run: |
+          source scripts/local-release-env.sh
+          dakia_require_google_oauth_environment
+          dakia_prepare_google_oauth_compiler_environment
+          trap 'dakia_clear_google_oauth_compiler_environment' EXIT HUP INT TERM
+          ./node_modules/.bin/tauri build --target x86_64-unknown-linux-gnu --bundles appimage \
+            --config apps/desktop/src-tauri/tauri.conf.json --config "$RUNNER_TEMP/tauri-production-overlay.json" -- --locked
+      - name: Build Windows updater installer
+        if: matrix.platform == 'windows'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          DAKIA_GOOGLE_CLIENT_ID: ${{ secrets.DAKIA_GOOGLE_CLIENT_ID }}
+          DAKIA_GOOGLE_CLIENT_SECRET: ${{ secrets.DAKIA_GOOGLE_CLIENT_SECRET }}
+          RUSTC_WRAPPER: sccache
+          CARGO_INCREMENTAL: 0
+        run: |
+          source scripts/local-release-env.sh
+          dakia_require_google_oauth_environment
+          dakia_prepare_google_oauth_compiler_environment
+          trap 'dakia_clear_google_oauth_compiler_environment' EXIT HUP INT TERM
+          ./node_modules/.bin/tauri build --target x86_64-pc-windows-msvc --bundles nsis \
+            --config apps/desktop/src-tauri/tauri.conf.json --config "$RUNNER_TEMP/tauri-production-overlay.json" -- --locked
+      - name: Assemble and verify Linux release assets
+        if: matrix.platform == 'linux'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+        run: |
+          set -euo pipefail
+          version='${{ needs.validate.outputs.version }}'
+          tag='${{ needs.validate.outputs.tag }}'
+          output="release-assets/$tag/linux"
+          expected="Dakia_${version}_amd64.AppImage"
+          mkdir -p "$output"
+          built=(target/x86_64-unknown-linux-gnu/release/bundle/appimage/*.AppImage)
+          test "${#built[@]}" = 1
+          if [[ "$(basename "${built[0]}")" != "$expected" ]]; then
+            mv "${built[0]}" "$output/$expected"
+            ./node_modules/.bin/tauri signer sign "$output/$expected"
+          else
+            cp "${built[0]}" "$output/$expected"
+            ./node_modules/.bin/tauri signer sign "$output/$expected"
+          fi
+          test -s "$output/$expected"; test -s "$output/$expected.sig"
+          (cd "$output" && shasum -a 256 "$expected" "$expected.sig" > SHA256SUMS.txt)
+          node scripts/verify-updater-signature.mjs "$output/$expected" "$output/$expected.sig" apps/desktop/src-tauri/tauri.conf.json
+          "$output/$expected" --appimage-extract >/dev/null
+      - name: Sign and assemble Windows release assets
+        if: matrix.platform == 'windows'
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          WINDOWS_CERT_PFX: ${{ secrets.WINDOWS_CERT_PFX }}
+          WINDOWS_CERT_PASSWORD: ${{ secrets.WINDOWS_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          version='${{ needs.validate.outputs.version }}'
+          tag='${{ needs.validate.outputs.tag }}'
+          output="release-assets/$tag/windows"
+          expected="Dakia_${version}_x64-setup.exe"
+          mkdir -p "$output"
+          built=(target/x86_64-pc-windows-msvc/release/bundle/nsis/*.exe)
+          test "${#built[@]}" = 1
+          cp "${built[0]}" "$output/$expected"
+          if [[ -n "$WINDOWS_CERT_PFX" || -n "$WINDOWS_CERT_PASSWORD" ]]; then
+            test -n "$WINDOWS_CERT_PFX"; test -n "$WINDOWS_CERT_PASSWORD"
+            pfx="$RUNNER_TEMP/dakia-windows-signing.pfx"
+            printf '%s' "$WINDOWS_CERT_PFX" | base64 --decode > "$pfx"
+            signtool.exe sign /fd SHA256 /f "$pfx" /p "$WINDOWS_CERT_PASSWORD" /tr http://timestamp.digicert.com /td SHA256 "$output/$expected"
+            signtool.exe verify /pa /v "$output/$expected"
+          fi
+          # Authenticode signing changes the installer bytes, so write the updater
+          # signature last even when no Windows certificate is configured.
+          ./node_modules/.bin/tauri signer sign "$output/$expected"
+          test -s "$output/$expected.sig"
+          (cd "$output" && shasum -a 256 "$expected" "$expected.sig" > SHA256SUMS.txt)
+          node scripts/verify-updater-signature.mjs "$output/$expected" "$output/$expected.sig" apps/desktop/src-tauri/tauri.conf.json
+      - name: Verify macOS release asset set
+        if: matrix.platform == 'macos'
+        run: |
+          assets="release-assets/${{ needs.validate.outputs.tag }}"
+          test -s "$assets/Dakia_${{ needs.validate.outputs.version }}_aarch64.dmg"
+          test -s "$assets/Dakia-aarch64.app.tar.gz"
+          test -s "$assets/Dakia-aarch64.app.tar.gz.sig"
+          test -s "$assets/SHA256SUMS.txt"
+          node - "$assets" "${{ needs.validate.outputs.tag }}" "${{ needs.validate.outputs.validated_commit }}" <<'NODE'
+          const { createHash } = require('node:crypto');
+          const { readFileSync, writeFileSync } = require('node:fs');
+          const { join } = require('node:path');
+          const [assets, tag, commit] = process.argv.slice(2);
+          const checksumFile = join(assets, 'SHA256SUMS.txt');
+          writeFileSync(join(assets, 'macos-ci-verification.json'), `${JSON.stringify({
+            tag,
+            source_commit: commit,
+            checksums_sha256: createHash('sha256').update(readFileSync(checksumFile)).digest('hex'),
+            verification: 'scripts/build-local-macos-release.sh completed',
+          }, null, 2)}\n`);
+          NODE
+      - uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
+        with:
+          name: release-${{ matrix.platform }}
+          path: release-assets/${{ needs.validate.outputs.tag }}/**
+          if-no-files-found: error
+          retention-days: 7
+      - name: Report Rust compiler cache statistics
+        if: always()
+        run: sccache --show-stats
+
+  publish:
+    name: Publish signed release
+    needs: [decide, validate, build]
+    if: needs.decide.outputs.should_release == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 30
+    environment: production-release
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.validate.outputs.validated_commit }}
+          fetch-depth: 0
+          lfs: false
+      - name: Attach the validated source to live main
+        run: |
+          set -euo pipefail
+          git remote set-url origin "$RELEASE_ORIGIN"
+          git fetch --force origin main --tags
+          git switch -C main HEAD
+          live_main="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+          test "$(git rev-parse HEAD)" = "${{ needs.validate.outputs.validated_commit }}"
+          test "$(git rev-parse HEAD)" = "$live_main"
+          test "$(git rev-parse refs/remotes/origin/main)" = "$live_main"
+      - name: Install AWS CLI v2
+        run: |
+          archive="$RUNNER_TEMP/awscliv2.zip"
+          curl --fail --silent --show-error --location https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip --output "$archive"
+          unzip -q "$archive" -d "$RUNNER_TEMP"
+          sudo "$RUNNER_TEMP/aws/install" --update
+          aws --version
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-macos
+          path: release-assets/${{ needs.validate.outputs.tag }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-linux
+          path: release-assets/${{ needs.validate.outputs.tag }}
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: release-windows
+          path: release-assets/${{ needs.validate.outputs.tag }}
+      - name: Verify downloaded updater artifacts before publishing
+        run: |
+          assets="release-assets/${{ needs.validate.outputs.tag }}"
+          node scripts/verify-updater-signature.mjs "$assets/Dakia-aarch64.app.tar.gz" "$assets/Dakia-aarch64.app.tar.gz.sig" apps/desktop/src-tauri/tauri.conf.json
+          node scripts/verify-updater-signature.mjs "$assets/linux/Dakia_${{ needs.validate.outputs.version }}_amd64.AppImage" "$assets/linux/Dakia_${{ needs.validate.outputs.version }}_amd64.AppImage.sig" apps/desktop/src-tauri/tauri.conf.json
+          node scripts/verify-updater-signature.mjs "$assets/windows/Dakia_${{ needs.validate.outputs.version }}_x64-setup.exe" "$assets/windows/Dakia_${{ needs.validate.outputs.version }}_x64-setup.exe.sig" apps/desktop/src-tauri/tauri.conf.json
+      - name: Create or verify the exact SSH-signed source tag
+        env:
+          DAKIA_SSH_SIGNING_KEY: ${{ secrets.DAKIA_SSH_SIGNING_KEY }}
+        run: |
+          set -euo pipefail
+          tag='${{ needs.validate.outputs.tag }}'
+          expected='${{ needs.validate.outputs.validated_commit }}'
+          if [[ -z "${DAKIA_SSH_SIGNING_KEY//[[:space:]]/}" ]]; then
+            echo 'DAKIA_SSH_SIGNING_KEY is required; refusing to create or trust an unsigned source tag.' >&2
+            exit 1
+          fi
+          key="$RUNNER_TEMP/dakia-release-signing-key"
+          allowed="$RUNNER_TEMP/dakia-release-allowed-signers"
+          umask 077
+          printf '%s\n' "$DAKIA_SSH_SIGNING_KEY" > "$key"
+          ssh-keygen -y -f "$key" > "$allowed.pub"
+          printf 'dakia-release %s\n' "$(<"$allowed.pub")" > "$allowed"
+          git config gpg.format ssh
+          git config user.signingkey "$key"
+          git config gpg.ssh.allowedSignersFile "$allowed"
+          git config commit.gpgsign false
+          git config tag.gpgSign true
+          git config user.name 'Dakia release bot'
+          git config user.email 'release-bot@dakiamail.com'
+          require_live_main() {
+            local live_main cached_main head
+            live_main="$(git ls-remote --exit-code origin refs/heads/main | awk '{print $1}')"
+            cached_main="$(git rev-parse refs/remotes/origin/main)"
+            head="$(git rev-parse HEAD)"
+            test "$head" = "$expected"
+            test "$cached_main" = "$expected"
+            test "$live_main" = "$expected"
+          }
+          remote_refs="$(git ls-remote --tags origin "refs/tags/$tag" "refs/tags/$tag^{}")"
+          remote_commit="$(awk -v tag="$tag" '$2 == "refs/tags/" tag "^{}" { print $1 }' <<<"$remote_refs")"
+          if [[ -n "$remote_commit" ]]; then
+            test "$remote_commit" = "$expected"
+            git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+          else
+            require_live_main
+            git tag -s "$tag" -m "Dakia $tag"
+            require_live_main
+            git push origin "refs/tags/$tag"
+            require_live_main
+          fi
+          test "$(git rev-parse "$tag^{commit}")" = "$expected"
+          git verify-tag "$tag"
+          local_tag_object="$(git rev-parse "refs/tags/$tag")"
+          remote_refs="$(git ls-remote --tags origin "refs/tags/$tag" "refs/tags/$tag^{}")"
+          remote_tag_object="$(awk -v tag="$tag" '$2 == "refs/tags/" tag { print $1 }' <<<"$remote_refs")"
+          remote_tag_commit="$(awk -v tag="$tag" '$2 == "refs/tags/" tag "^{}" { print $1 }' <<<"$remote_refs")"
+          test "$remote_tag_object" = "$local_tag_object"
+          test "$remote_tag_commit" = "$expected"
+      - name: Stage, publish to R2, then publish GitHub Release
+        env:
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          GH_TOKEN: ${{ github.token }}
+          DAKIA_MACOS_CI_VERIFICATION: release-assets/${{ needs.validate.outputs.tag }}/macos-ci-verification.json
+        run: |
+          set -euo pipefail
+          test -n "$R2_ACCESS_KEY_ID"; test -n "$R2_SECRET_ACCESS_KEY"; test -n "$CLOUDFLARE_ACCOUNT_ID"
+          assets="release-assets/${{ needs.validate.outputs.tag }}"
+          scripts/prepare-github-release-draft.sh '${{ needs.validate.outputs.tag }}' "$assets"
+          scripts/publish-release-to-r2.sh '${{ needs.validate.outputs.tag }}' "$assets"
+          scripts/publish-github-release.sh '${{ needs.validate.outputs.tag }}' "$assets"
+
+  verify-public:
+    name: Verify anonymous public release
+    needs: [decide, validate, publish]
+    if: needs.decide.outputs.should_release == 'true'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ needs.validate.outputs.validated_commit }}
+          fetch-depth: 0
+          lfs: false
+          persist-credentials: false
+      - name: Verify public feeds, immutable artifacts, provenance, and GitHub Release
+        run: |
+          set -Eeuo pipefail
+          tag='${{ needs.validate.outputs.tag }}'
+          version='${{ needs.validate.outputs.version }}'
+          previous='${{ needs.decide.outputs.public_version }}'
+          commit='${{ needs.validate.outputs.validated_commit }}'
+          work="$RUNNER_TEMP/public-release"
+          mkdir -p "$work"
+          trap 'status=$?; { echo "### FAIL: public verification for '"$tag"' exited with status $status"; echo "Checked feeds under '$DOWNLOAD_ORIGIN' and GitHub Release $tag."; } | tee -a "$GITHUB_STEP_SUMMARY"; exit $status' ERR
+          curl_args=(--fail --silent --show-error --location --proto '=https' --connect-timeout 15 --max-time 90 --retry 3)
+          for platform in macos linux windows; do
+            curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/$platform/latest/latest.json" --output "$work/$platform-latest.json"
+          done
+          node scripts/updater-manifest.mjs validate --platform darwin-aarch64 --manifest "$work/macos-latest.json" --tauri-config apps/desktop/src-tauri/tauri.conf.json
+          node scripts/updater-manifest.mjs validate --platform linux-x86_64 --manifest "$work/linux-latest.json" --tauri-config apps/desktop/src-tauri/tauri.conf.json
+          node scripts/updater-manifest.mjs validate --platform windows-x86_64 --manifest "$work/windows-latest.json" --tauri-config apps/desktop/src-tauri/tauri.conf.json
+          node - "$work" "$version" "$previous" <<'NODE'
+          const { readFileSync } = require('node:fs');
+          const [dir, version, previous] = process.argv.slice(2);
+          const versions = ['macos', 'linux', 'windows'].map((p) => JSON.parse(readFileSync(`${dir}/${p}-latest.json`, 'utf8')).version);
+          if (!versions.every((value) => value === version)) throw new Error(`Feeds disagree or do not contain ${version}: ${versions.join(', ')}`);
+          const parse = (value) => value.split(/[.+-]/).slice(0, 3).map(Number);
+          const [a,b,c] = parse(version), [x,y,z] = parse(previous);
+          if (a < x || (a === x && b < y) || (a === x && b === y && c <= z)) throw new Error(`Release ${version} is not newer than ${previous}`);
+          NODE
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/macos/$tag/Dakia-Apple-Silicon.dmg" --output "$work/Dakia-Apple-Silicon.dmg"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/macos/$tag/Dakia-aarch64.app.tar.gz" --output "$work/Dakia-aarch64.app.tar.gz"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/macos/$tag/Dakia-aarch64.app.tar.gz.sig" --output "$work/Dakia-aarch64.app.tar.gz.sig"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/macos/$tag/SHA256SUMS.txt" --output "$work/macos-SHA256SUMS.txt"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/linux/$tag/Dakia_${version}_amd64.AppImage" --output "$work/Dakia_${version}_amd64.AppImage"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/linux/$tag/Dakia_${version}_amd64.AppImage.sig" --output "$work/Dakia_${version}_amd64.AppImage.sig"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/linux/$tag/SHA256SUMS.txt" --output "$work/linux-SHA256SUMS.txt"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/windows/$tag/Dakia_${version}_x64-setup.exe" --output "$work/Dakia_${version}_x64-setup.exe"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/windows/$tag/Dakia_${version}_x64-setup.exe.sig" --output "$work/Dakia_${version}_x64-setup.exe.sig"
+          curl "${curl_args[@]}" "$DOWNLOAD_ORIGIN/windows/$tag/SHA256SUMS.txt" --output "$work/windows-SHA256SUMS.txt"
+          node - "$work" "$version" <<'NODE'
+          const { createHash } = require('node:crypto');
+          const { readFileSync } = require('node:fs');
+          const { join } = require('node:path');
+          const [dir, version] = process.argv.slice(2);
+          const digest = (file) => createHash('sha256').update(readFileSync(join(dir, file))).digest('hex');
+          const entries = (file) => new Map(readFileSync(join(dir, file), 'utf8').trim().split('\n').map((line) => {
+            const match = /^([0-9a-f]{64})  (.+)$/.exec(line);
+            if (!match) throw new Error(`Invalid checksum record in ${file}: ${line}`);
+            return [match[2], match[1]];
+          }));
+          const assert = (checksums, checksumName, localName) => {
+            if (checksums.get(checksumName) !== digest(localName)) throw new Error(`Checksum mismatch for ${localName} against ${checksumName}`);
+          };
+          const macos = entries('macos-SHA256SUMS.txt');
+          if (macos.size !== 3) throw new Error('macOS SHA256SUMS.txt must contain exactly three records');
+          assert(macos, `Dakia_${version}_aarch64.dmg`, 'Dakia-Apple-Silicon.dmg');
+          assert(macos, 'Dakia-aarch64.app.tar.gz', 'Dakia-aarch64.app.tar.gz');
+          assert(macos, 'Dakia-aarch64.app.tar.gz.sig', 'Dakia-aarch64.app.tar.gz.sig');
+          const linux = entries('linux-SHA256SUMS.txt');
+          if (linux.size !== 2) throw new Error('Linux SHA256SUMS.txt must contain exactly two records');
+          assert(linux, `Dakia_${version}_amd64.AppImage`, `Dakia_${version}_amd64.AppImage`);
+          assert(linux, `Dakia_${version}_amd64.AppImage.sig`, `Dakia_${version}_amd64.AppImage.sig`);
+          const windows = entries('windows-SHA256SUMS.txt');
+          if (windows.size !== 2) throw new Error('Windows SHA256SUMS.txt must contain exactly two records');
+          assert(windows, `Dakia_${version}_x64-setup.exe`, `Dakia_${version}_x64-setup.exe`);
+          assert(windows, `Dakia_${version}_x64-setup.exe.sig`, `Dakia_${version}_x64-setup.exe.sig`);
+          NODE
+          node scripts/verify-updater-signature.mjs "$work/Dakia-aarch64.app.tar.gz" "$work/Dakia-aarch64.app.tar.gz.sig" apps/desktop/src-tauri/tauri.conf.json
+          node scripts/verify-updater-signature.mjs "$work/Dakia_${version}_amd64.AppImage" "$work/Dakia_${version}_amd64.AppImage.sig" apps/desktop/src-tauri/tauri.conf.json
+          node scripts/verify-updater-signature.mjs "$work/Dakia_${version}_x64-setup.exe" "$work/Dakia_${version}_x64-setup.exe.sig" apps/desktop/src-tauri/tauri.conf.json
+          remote_tag="$(git ls-remote --tags origin "refs/tags/$tag" "refs/tags/$tag^{}" | awk -v tag="$tag" '$2 == "refs/tags/" tag "^{}" { print $1 }')"
+          test "$remote_tag" = "$commit"
+          git fetch --force origin "refs/tags/$tag:refs/tags/$tag"
+          git rev-parse --verify "$tag^{tag}" >/dev/null
+          test "$(git rev-parse "$tag^{commit}")" = "$commit"
+          github_api="https://api.github.com/repos/DakiaMail/dakia-desktop/releases/tags/$tag"
+          github_download="https://github.com/DakiaMail/dakia-desktop/releases/download/$tag"
+          release="$(curl "${curl_args[@]}" "$github_api")"
+          node - "$release" "$tag" "$commit" "$version" <<'NODE'
+          const [release, tag, commit, version] = process.argv.slice(2);
+          const value = JSON.parse(release);
+          const expected = [`Dakia_${version}_aarch64.dmg`, 'Dakia-aarch64.app.tar.gz', 'Dakia-aarch64.app.tar.gz.sig', 'SHA256SUMS.txt', `Dakia_${version}_amd64.AppImage`, `Dakia_${version}_amd64.AppImage.sig`, `Dakia_${version}_x64-setup.exe`, `Dakia_${version}_x64-setup.exe.sig`].sort();
+          const actual = value.assets.map((asset) => asset.name).sort();
+          if (value.tag_name !== tag || value.target_commitish !== commit || value.draft || actual.join('\n') !== expected.join('\n')) throw new Error('GitHub Release metadata or exact asset set is invalid.');
+          NODE
+          mkdir -p "$work/github"
+          curl "${curl_args[@]}" "$github_download/SHA256SUMS.txt" --output "$work/github/SHA256SUMS.txt"
+          cmp -s "$work/macos-SHA256SUMS.txt" "$work/github/SHA256SUMS.txt"
+          curl "${curl_args[@]}" "$github_download/Dakia-aarch64.app.tar.gz" --output "$work/github/Dakia-aarch64.app.tar.gz"
+          cmp -s "$work/Dakia-aarch64.app.tar.gz" "$work/github/Dakia-aarch64.app.tar.gz"
+          curl "${curl_args[@]}" "$github_download/Dakia_${version}_amd64.AppImage" --output "$work/github/Dakia_${version}_amd64.AppImage"
+          cmp -s "$work/Dakia_${version}_amd64.AppImage" "$work/github/Dakia_${version}_amd64.AppImage"
+          {
+            echo "### PASS: production release $tag"
+            echo "- $DOWNLOAD_ORIGIN/macos/$tag/Dakia-Apple-Silicon.dmg $(sha256sum "$work/Dakia-Apple-Silicon.dmg" | awk '{print $1}')"
+            echo "- $DOWNLOAD_ORIGIN/macos/$tag/Dakia-aarch64.app.tar.gz $(sha256sum "$work/Dakia-aarch64.app.tar.gz" | awk '{print $1}')"
+            echo "- $DOWNLOAD_ORIGIN/macos/$tag/Dakia-aarch64.app.tar.gz.sig $(sha256sum "$work/Dakia-aarch64.app.tar.gz.sig" | awk '{print $1}')"
+            echo "- $DOWNLOAD_ORIGIN/linux/$tag/Dakia_${version}_amd64.AppImage $(sha256sum "$work/Dakia_${version}_amd64.AppImage" | awk '{print $1}')"
+            echo "- $DOWNLOAD_ORIGIN/linux/$tag/Dakia_${version}_amd64.AppImage.sig $(sha256sum "$work/Dakia_${version}_amd64.AppImage.sig" | awk '{print $1}')"
+            echo "- $DOWNLOAD_ORIGIN/windows/$tag/Dakia_${version}_x64-setup.exe $(sha256sum "$work/Dakia_${version}_x64-setup.exe" | awk '{print $1}')"
+            echo "- $DOWNLOAD_ORIGIN/windows/$tag/Dakia_${version}_x64-setup.exe.sig $(sha256sum "$work/Dakia_${version}_x64-setup.exe.sig" | awk '{print $1}')"
+            echo "- $DOWNLOAD_ORIGIN/{macos,linux,windows}/latest/latest.json"
+            echo "- $github_api and $github_download/{SHA256SUMS.txt,Dakia-aarch64.app.tar.gz,Dakia_${version}_amd64.AppImage}"
+          } | tee -a "$GITHUB_STEP_SUMMARY"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,7 +975,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "dakia-cli"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -995,7 +995,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-core"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1029,7 +1029,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-desktop"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/DakiaMail/dakia-desktop"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dakia",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "identifier": "dev.dakia.mail",
   "build": {
     "beforeDevCommand": "npm run dev:desktop-web",

--- a/docs/publishing-macos-release.md
+++ b/docs/publishing-macos-release.md
@@ -1,24 +1,35 @@
 # Publishing a macOS Release
 
-Dakia releases are built, signed, notarized, and published from the trusted
-Apple Silicon release runner. R2 remains the production updater host. A GitHub
-Release mirrors the locally built assets for public downloads. The release path
-is Apple Silicon only.
+The normal production release path is the GitHub-hosted
+`production-release` workflow, scheduled for 02:17 UTC. It builds the macOS
+Apple Silicon release on `macos-15` after the complete verification suite has
+passed, imports the Developer ID identity, notarizes and staples the release,
+and publishes it alongside the Linux x64 and Windows x64 artifacts. It runs
+only from an exact live `origin/main` commit and creates an annotated
+SSH-signed source tag before publication.
 
-Every night at 02:17 local time, a Codex automation runs the release path on
-the primary Apple Silicon Mac from `main`, but only if `main` contains commits
-after the version in the public updater manifest. The local release Mac must
-have its Keychain identities, notarization profile, updater key, and R2
-credentials available. It creates the next patch version, writes a concise
-user-facing release note, verifies, publishes to R2, and then publishes the
-matching GitHub Release.
+The macOS updater remains R2-hosted at:
 
-Before a release, ensure the intended code is present and the version matches
-`package.json`, the Cargo workspace, and `apps/desktop/src-tauri/tauri.conf.json`.
-The release commands validate their required signing, notarization, OAuth, and
-R2 credentials directly, so there is no separate manual preflight checklist.
+```text
+https://downloads.dakiamail.com/macos/latest/latest.json
+```
 
-## Commands
+The workflow uploads immutable release objects beneath
+`https://downloads.dakiamail.com/macos/vX.Y.Z/`, writes `latest.json` only
+after the candidate has passed its checks, and makes the matching GitHub
+Release public only after R2 is publicly converged. The final workflow job
+performs anonymous public verification; a failed verification is not a
+successful release.
+
+## Manual Apple Silicon fallback
+
+Use this path only for an exceptional manual recovery/release on a trusted
+Apple Silicon Mac. It produces the macOS part of a release; the hosted
+workflow is the normal cross-platform producer. Start from a clean local
+`main` that exactly matches cached and live `origin/main` and has the required
+Developer ID identity, `dakia-notary` Keychain profile, updater signing key,
+Google Desktop OAuth values, R2 credentials, GitHub authentication, and the
+trusted SSH tag-signing key.
 
 ```bash
 npm run verify:local
@@ -31,77 +42,16 @@ npm run release:publish -- vX.Y.Z "$PWD/release-assets/vX.Y.Z"
 npm run release:github:publish -- vX.Y.Z "$PWD/release-assets/vX.Y.Z"
 ```
 
-The verification command runs Rust formatting, Clippy, Rust tests, TypeScript,
-formatting, frontend tests, release-script tests, and the frontend build. It no
-longer builds a separate packaged app: the release builder verifies the actual
-signed final artifact instead.
+`release:build` signs, notarizes, staples, and verifies the final application
+and DMG before it creates and Tauri-signs the updater archive. The local
+publisher refuses to replace immutable versioned objects, anonymously
+byte-verifies uploads, validates the updater manifest, and publishes the feed
+last. The GitHub scripts require an exact source tag and release assets; they
+create and verify a draft before R2 mutation, then publish that verified draft
+only after R2 confirms the candidate. They do not clobber assets or replace a
+release on mismatch.
 
-The builder:
-
-1. assembles, Developer ID signs, and verifies the Apple Silicon app;
-2. verifies the packaged app and CLI executables, Apple-Silicon architecture,
-   matching Developer ID ownership/version, classifier resources, legal
-   notices, and compiled Google OAuth configuration without runtime overrides;
-3. runs isolated packaged CLI and app startup checks on the release Mac;
-4. notarizes and staples the app;
-5. rebuilds, notarizes, staples, mounts, and verifies the DMG;
-6. archives that same final app, extracts and repeats the app/CLI acceptance
-   checks on the archive contents, then signs the exact archive bytes for Tauri.
-
-The publisher re-verifies the DMG, cryptographically verifies and extracts the
-updater archive, checks the archived app version and packaged-app acceptance,
-uses immutable versioned R2 paths, anonymously verifies the published bytes,
-validates the updater manifest, and publishes `latest.json` only after all
-artifact checks pass.
-
-## GitHub mirror order
-
-GitHub is a public download mirror, not the updater host. Create and verify its
-draft before any R2 mutation, so the exact signed local artifacts have already
-been checked by both services before the updater feed can move:
-
-```bash
-release_tag="vX.Y.Z"
-release_dir="$PWD/release-assets/$release_tag"
-git tag -s "$release_tag" -m "Dakia $release_tag"
-git verify-tag "$release_tag"
-git push origin "refs/tags/$release_tag"
-npm run release:github:draft -- "$release_tag" "$release_dir"
-npm run release:publish -- "$release_tag" "$release_dir"
-npm run release:github:publish -- "$release_tag" "$release_dir"
-```
-
-The draft stage requires a clean local `main` whose `HEAD`, cached
-`origin/main`, and live `git ls-remote origin refs/heads/main` all name the
-same commit, the explicit `DakiaMail/dakia-desktop` origin, a pushed annotated
-SSH-signed tag whose commit exactly equals `HEAD`, and working GitHub
-authentication. It
-requires exactly the DMG, updater archive, detached signature, and
-`SHA256SUMS.txt`; verifies the local checksum file; creates a draft targeted at
-the exact commit; then downloads every draft asset and compares it byte-for-byte
-with the local input. The release title and body must also exactly match the
-candidate (`Dakia vX.Y.Z` and `release-notes.md`).
-
-Only after the R2 publisher has anonymously exposed an exact updater manifest
-for that version, archive URL, and updater signature may the final GitHub stage
-make the draft public. It rechecks every draft property and asset first, then
-downloads all four public GitHub assets and validates both their bytes and their
-downloaded `SHA256SUMS.txt`.
-
-Both stages are safe to retry: an existing GitHub draft is accepted only after
-the full exact comparison succeeds. An already-public release is accepted only
-as an exact R2 resume: public `latest.json` must already contain the candidate
-version, archive URL, signature, and notes, and the anonymous versioned updater
-archive, detached signature, and DMG must byte-match the local artifacts. A
-newer R2 candidate therefore requires a GitHub draft and stops before any R2
-mutation if its GitHub Release is already public. Each external release
-mutation repeats the live-main provenance check immediately beforehand. The
-scripts never use `--clobber`, delete a release, or replace assets. A mismatch
-is a hard stop; remediation or removal requires separate approval.
-
-The R2 publisher also invokes the draft verifier itself before its first remote
-mutation. This makes the required ordering fail closed even if an operator
-calls `release:publish` directly.
-
-For updater key custody and artifact details, see
-[Signed Desktop Updates](updater-release.md).
+The locally built macOS asset directory contains the Apple Silicon DMG,
+updater archive and detached signature, release notes, checksums, and source
+commit marker. Consult [Signed Desktop Updates](updater-release.md) for the
+cross-platform artifact layout and key-custody requirements.

--- a/docs/releases/SOURCE_PROVENANCE.md
+++ b/docs/releases/SOURCE_PROVENANCE.md
@@ -1,9 +1,20 @@
 # Release source provenance
 
-Production macOS releases are built locally from a clean `main` commit that
-exactly matches `origin/main`. Beginning with v0.4.1, the release path requires
-an annotated SSH-signed tag whose local and remote tag objects both target that
-exact commit before a GitHub draft or R2 object can be published.
+Production releases are built by the GitHub-hosted `production-release`
+workflow from a clean commit that exactly matches live `origin/main`. If the
+workflow prepares a patch version, it pushes that commit first and every later
+validation, build, publication, and verification job checks out that exact
+pushed commit.
+
+Before a GitHub Release draft or R2 object is published, the workflow requires
+an annotated SSH-signed `vX.Y.Z` tag whose tag object and peeled commit are on
+origin and whose commit exactly equals the release commit. It verifies an
+existing tag instead of replacing it, and fails rather than producing an
+unsigned source marker. The GitHub Release is a mirror of that tagged source
+and becomes public only after R2 artifact and feed verification succeeds.
+
+The manual Apple Silicon fallback follows the same provenance rule. It is not
+permitted to build or publish from an arbitrary local checkout.
 
 ## Transitional v0.4.0 baseline
 

--- a/docs/releases/v0.4.3.md
+++ b/docs/releases/v0.4.3.md
@@ -1,0 +1,14 @@
+# Dakia v0.4.3
+
+This update makes Dakia faster to use and better at organizing the people in your mailbox, and it adds privacy-preserving usage analytics.
+
+## What changed
+
+- **Resend sent messages.** Use the new Send again action to resend a message you have already sent.
+- **Faster archiving and read updates.** Archiving a message or marking it as read now updates instantly, with no wait on the network.
+- **Better people categorization.** People are now grouped more consistently across the desktop app, the CLI, and the core engine.
+- **Privacy-preserving usage analytics.** Dakia now collects minimal, privacy-preserving usage analytics to help guide development.
+
+## Download
+
+Dakia v0.4.3 is available for macOS, Linux, and Windows.

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,29 +1,40 @@
 # Releasing
 
-Nightly releases run automatically from `main` through the local Codex
-automation on the trusted Apple Silicon release Mac. They skip when there are
-no commits after the public updater release.
+The primary production path is the GitHub-hosted `production-release` workflow.
+It runs nightly at 02:17 UTC from the exact live `origin/main` state, or may be
+started manually with a reason and an explicit force option. A no-change run
+stops after its inexpensive decision job.
 
-For an exceptional manual release, run the same work on that runner:
+When a release is eligible, the workflow prepares a patch release if necessary,
+runs the complete source verification suite, and only then starts any platform
+build. In particular, the full suite is a gate before the Apple Silicon build.
+It builds:
 
-```bash
-npm run verify:local
+- macOS Apple Silicon on `macos-15`, signed and notarized;
+- Linux x64 AppImage on `ubuntu-24.04`;
+- Windows x64 NSIS installer on `windows-2025` (signed when the Windows
+  certificate is configured).
+
+The job creates or verifies an annotated SSH-signed `vX.Y.Z` tag pointing at
+the exact release commit before it stages the GitHub Release. It publishes
+immutable versioned R2 objects under
+`https://downloads.dakiamail.com/{macos,linux,windows}/vX.Y.Z/`, moves each
+platform's `latest/latest.json` only after its candidate is verified, and makes
+the GitHub Release public only after R2 has converged. A final anonymous job
+checks the three feeds, published artifacts, provenance tag, and GitHub mirror.
+
+The installed application polls its platform-specific updater feed:
+
+```text
+https://downloads.dakiamail.com/macos/latest/latest.json
+https://downloads.dakiamail.com/linux/latest/latest.json
+https://downloads.dakiamail.com/windows/latest/latest.json
 ```
 
-For macOS, the primary Apple Silicon Mac builds the Apple Silicon release. R2
-hosts the versioned DMG, signed updater archive, stable download alias, and
-updater manifest. A GitHub Release mirrors those same locally built assets for
-public downloads.
+For an exceptional manual macOS recovery or release, retain the local Apple
+Silicon flow in [Publishing a macOS Release](publishing-macos-release.md). It
+uses the same provenance, artifact-verification, R2, and GitHub-release gates;
+it is a fallback, not the normal nightly path.
 
-The local Codex automation first creates and downloads-verifies an exact GitHub
-Release draft from the signed source tag and locally built artifacts. It then
-publishes the immutable R2 artifacts and `latest.json`. Only after the public
-updater manifest exactly matches that candidate does it make the verified GitHub
-draft public and independently byte-compare the public GitHub downloads.
-
-Follow:
-
-- [Publishing A macOS Release](publishing-macos-release.md) for local signing,
-  notarization, and publication;
-- [Signed Desktop Updates](updater-release.md) for key custody and the
-  production publication gate.
+See [Signed Desktop Updates](updater-release.md) for updater artifacts, key
+custody, and publication guarantees.

--- a/docs/updater-release.md
+++ b/docs/updater-release.md
@@ -1,110 +1,68 @@
 # Signed Desktop Updates
 
-Dakia publishes signed Apple Silicon updates through Tauri's native updater.
-The installed app downloads over the native transport, verifies the archive
-with its embedded public key, and installs only after the user chooses
-**Install and Restart**. GitHub Releases mirror the locally built assets for
-public downloads, but they do not replace the R2 updater feed. GitHub Actions,
-staging channels, and Intel builds are not part of this release path.
+Dakia's hosted production workflow publishes one signed updater candidate for
+each supported platform: macOS Apple Silicon, Linux x64, and Windows x64. The
+installed app downloads its own platform feed over HTTPS and Tauri verifies the
+artifact with the embedded updater public key before an update is installed.
+GitHub Releases are public mirrors, never the updater host.
 
-## Local trust material
+## Feeds and versioned objects
+
+Each platform has an independent feed and immutable versioned-object prefix:
+
+| Platform | Feed | Versioned prefix |
+| --- | --- | --- |
+| macOS Apple Silicon | `macos/latest/latest.json` | `macos/vX.Y.Z/` |
+| Linux x64 | `linux/latest/latest.json` | `linux/vX.Y.Z/` |
+| Windows x64 | `windows/latest/latest.json` | `windows/vX.Y.Z/` |
+
+All paths are rooted at `https://downloads.dakiamail.com/`. The feeds carry
+the same release version, but only the single updater platform appropriate to
+that operating system. Versioned artifacts are immutable; `latest.json` is the
+only moving updater pointer and is written after the platform candidate is
+fully checked.
+
+The release artifacts are:
+
+- macOS: `Dakia_<version>_aarch64.dmg`, `Dakia-aarch64.app.tar.gz`, and
+  `Dakia-aarch64.app.tar.gz.sig`;
+- Linux: `Dakia_<version>_amd64.AppImage` and its `.sig`;
+- Windows: `Dakia_<version>_x64-setup.exe` and its `.sig`.
+
+Each platform directory also has a `SHA256SUMS.txt` for its distributable
+files. macOS release inputs additionally contain `release-notes.md` and
+`source-commit.txt` for publication/provenance checks.
+
+## Hosted release gate
+
+`production-release` first decides whether commits exist after the current
+public version. If a version bump is needed, it prepares and pushes it to
+`main`, then checks out that exact pushed commit for every later job. The
+complete Rust and frontend verification suite must pass before any platform
+build begins. The macOS builder signs, notarizes, staples, and verifies its
+final updater archive; Linux and Windows build their native updater installers
+with platform-specific feed configuration. Windows signing is conditional on
+the configured Windows certificate.
+
+Before external publication, the workflow creates or verifies an annotated
+SSH-signed `vX.Y.Z` tag that points exactly to the release commit. It stages a
+GitHub Release, publishes and anonymously verifies immutable R2 objects and
+all three manifests, then makes the verified GitHub Release public. An
+anonymous final job checks manifests, checksums, updater signatures,
+versioned-object bytes, tag provenance, and GitHub Release assets. Any failed
+gate leaves the workflow unsuccessful and does not assert a completed release.
+
+## Key custody and manual fallback
 
 The permanent updater public key is embedded in
-`apps/desktop/src-tauri/tauri.conf.json`. Its private key stays on the primary
-release Mac at `~/.tauri/dakia-updater.key` with mode `0600`; store its password
-in the login Keychain:
+`apps/desktop/src-tauri/tauri.conf.json`; its private counterpart must remain
+restricted to the production release environment and the trusted local
+Apple Silicon fallback machine. The hosted macOS job also needs its Developer
+ID certificate and notarization API credentials. Store only the necessary
+values as environment-scoped GitHub secrets; never commit signing keys,
+certificate material, OAuth client secrets, or R2 credentials.
 
-```bash
-./scripts/store-local-release-secret.sh updater-password
-```
-
-Keep an encrypted offline backup of both values. Losing them permanently breaks
-updates for installed builds that trust this key.
-
-The release Mac also needs a valid Developer ID Application certificate, a
-working `dakia-notary` Keychain profile, the Google Desktop OAuth client secret,
-and R2 credentials scoped to the `dakia-releases` bucket. Store the latter
-without adding them to shell history:
-
-```bash
-./scripts/store-local-release-secret.sh google-oauth-client-secret
-./scripts/store-local-release-secret.sh r2-access-key-id
-./scripts/store-local-release-secret.sh r2-secret-access-key
-```
-
-Release scripts read these Keychain items only into their own process. The OAuth
-secret is supplied only to the Dakia Rust compiler process that needs it.
-
-## Artifacts and publication
-
-The production updater endpoint is:
-
-```text
-https://downloads.dakiamail.com/macos/latest/latest.json
-```
-
-Local artifacts live under the ignored `release-assets/` directory:
-
-```text
-Dakia_<version>_aarch64.dmg
-Dakia-aarch64.app.tar.gz
-Dakia-aarch64.app.tar.gz.sig
-release-notes.md
-SHA256SUMS.txt
-source-commit.txt (local provenance marker; not uploaded)
-```
-
-The updater archive is made from the final Developer ID signed, notarized, and
-stapled app, including the CLI sidecar, ONNX Runtime, classifier resources, and
-required notices.
-
-## Release sequence
-
-```bash
-npm run verify:local
-npm run release:build -- vX.Y.Z
-git tag -s vX.Y.Z -m "Dakia vX.Y.Z"
-git verify-tag vX.Y.Z
-git push origin refs/tags/vX.Y.Z
-npm run release:github:draft -- vX.Y.Z "$PWD/release-assets/vX.Y.Z"
-npm run release:publish -- vX.Y.Z "$PWD/release-assets/vX.Y.Z"
-npm run release:github:publish -- vX.Y.Z "$PWD/release-assets/vX.Y.Z"
-```
-
-`verify:local` runs the repository's Rust and frontend checks without producing
-a redundant packaged app. `release:build` builds the Apple Silicon app, signs
-and verifies it, notarizes and staples it, rebuilds and verifies the DMG, then
-creates the final updater archive. The extracted archive must pass the same
-Apple-Silicon app and isolated bundled-CLI artifact checks before the archive is
-Tauri-signed. This is artifact acceptance, not an installed-client
-update/relaunch test.
-
-`release:publish` verifies the final DMG, refuses to overwrite versioned R2
-objects, uploads the immutable DMG/archive/signature, and anonymously downloads
-and byte-compares each. It generates and validates the Apple-Silicon-only Tauri
-manifest, updates the stable DMG alias, and writes `latest.json` last. Therefore
-a failed upload or public-byte check leaves installed clients on the previous
-release.
-
-There is no staging update feed or installed-client acceptance harness in this
-early-development workflow. Unit tests cover the updater interface and manifest
-structure; a real update/install/relaunch test should be restored before relying
-on automatic updates for broad distribution.
-
-Existing Intel installs are no longer supported and will not receive a matching
-entry in future updater manifests. The public website links only to the Apple
-Silicon download.
-
-## Source-control marker
-
-After the local build is proven, push a signed `vX.Y.Z` Git tag as the immutable
-source marker. It does not trigger a build. Each release mutation rechecks that
-`HEAD`, cached `origin/main`, and live `git ls-remote origin refs/heads/main`
-are identical. Create and byte-verify the GitHub Release draft from that
-verified tag before any R2 mutation, then publish R2 and finally make the
-already-verified GitHub draft public. An already-public GitHub Release can only
-resume when public `latest.json` is already the exact same updater candidate;
-the anonymous versioned updater archive, signature, and DMG must also
-byte-match the local artifacts. The scripts repeat live-main provenance before
-each external release mutation; otherwise the release stops. Never rebuild
-assets on GitHub.
+For an exceptional manual macOS release, use the commands and preconditions in
+[Publishing a macOS Release](publishing-macos-release.md). That fallback must
+keep the same signed-tag provenance and GitHub-draft → R2 → public-GitHub
+ordering. It does not replace the hosted cross-platform nightly path.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dakia",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dakia",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@browsermt/bergamot-translator": "^0.4.9",
         "@mantine/core": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dakia",
   "private": true,
-  "version": "0.4.2",
+  "version": "0.4.3",
   "type": "module",
   "scripts": {
     "dev": "./scripts/dev.sh",

--- a/scripts/github-release-stage.behavior.node-test.mjs
+++ b/scripts/github-release-stage.behavior.node-test.mjs
@@ -62,6 +62,7 @@ function createHarness({
   releaseState = "draft",
   manifestNotes = "Release notes",
   gitScenario = "valid",
+  optionalPlatforms = false,
 } = {}) {
   const fixtureRoot = mkdtempSync(
     join(tmpdir(), "dakia-github-release-behavior-"),
@@ -97,6 +98,42 @@ function createHarness({
       .join("\n") + "\n",
   );
 
+  const optionalAssets = optionalPlatforms
+    ? [
+        ["linux", `Dakia_${version}_amd64.AppImage`, "linux updater bytes\n"],
+        [
+          "windows",
+          `Dakia_${version}_x64-setup.exe`,
+          "windows updater bytes\n",
+        ],
+      ]
+    : [];
+  for (const [platform, installer, bytes] of optionalAssets) {
+    const platformDir = join(assets, platform);
+    mkdirSync(platformDir);
+    writeFileSync(join(platformDir, installer), bytes);
+    writeFileSync(join(platformDir, `${installer}.sig`), updaterSignature());
+    writeFileSync(
+      join(platformDir, "SHA256SUMS.txt"),
+      [installer, `${installer}.sig`]
+        .map(
+          (filename) =>
+            `${sha256(readFileSync(join(platformDir, filename)))}  ${filename}`,
+        )
+        .join("\n") + "\n",
+    );
+  }
+  const releaseAssetNames = [
+    filenames.dmg,
+    filenames.update,
+    filenames.signature,
+    filenames.checksums,
+    ...optionalAssets.flatMap(([, installer]) => [
+      installer,
+      `${installer}.sig`,
+    ]),
+  ];
+
   const manifest = {
     version,
     pub_date: "2026-08-27T00:00:00Z",
@@ -106,15 +143,57 @@ function createHarness({
         url: `https://downloads.dakiamail.com/macos/${tag}/${filenames.update}`,
         signature: content[filenames.signature].toString().trim(),
       },
+      ...(optionalPlatforms
+        ? {
+            "linux-x86_64": {
+              url: `https://downloads.dakiamail.com/linux/${tag}/Dakia_${version}_amd64.AppImage`,
+              signature: updaterSignature().toString().trim(),
+            },
+            "windows-x86_64": {
+              url: `https://downloads.dakiamail.com/windows/${tag}/Dakia_${version}_x64-setup.exe`,
+              signature: updaterSignature().toString().trim(),
+            },
+          }
+        : {}),
     },
   };
   const manifestPath = join(fixtureRoot, "latest.json");
+  const linuxManifestPath = join(fixtureRoot, "linux-latest.json");
+  const windowsManifestPath = join(fixtureRoot, "windows-latest.json");
   const statePath = join(fixtureRoot, "release-state");
   const editLog = join(fixtureRoot, "edit.log");
   const liveMainCalls = join(fixtureRoot, "live-main-calls");
   const allowedSigners = join(fixtureRoot, "allowed-signers");
   const signingKey = join(fixtureRoot, "release-signing-key.pub");
-  writeFileSync(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  writeFileSync(
+    manifestPath,
+    `${JSON.stringify(
+      {
+        ...manifest,
+        platforms: { "darwin-aarch64": manifest.platforms["darwin-aarch64"] },
+      },
+      null,
+      2,
+    )}\n`,
+  );
+  if (optionalPlatforms) {
+    for (const [platform, platformKey, destination] of [
+      ["linux", "linux-x86_64", linuxManifestPath],
+      ["windows", "windows-x86_64", windowsManifestPath],
+    ]) {
+      writeFileSync(
+        destination,
+        `${JSON.stringify(
+          {
+            ...manifest,
+            platforms: { [platformKey]: manifest.platforms[platformKey] },
+          },
+          null,
+          2,
+        )}\n`,
+      );
+    }
+  }
   writeFileSync(liveMainCalls, "0");
   writeFileSync(statePath, `${releaseState}\n`);
   writeFileSync(allowedSigners, "release@example.test ssh-ed25519 AAAA\n");
@@ -186,6 +265,29 @@ printf '%s\n' '256 SHA256:kN9R3QFJZbrE5i2HjEpp+ns5ZNxBTuFySvFx8Ldf/gE release@ex
   );
 
   writeExecutable(
+    join(bin, "jq"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const values = {};
+for (let index = 0; index < args.length; index += 1) {
+  if (args[index] === "--arg") values[args[index + 1]] = args[index + 2];
+}
+const filter = args.find((value) => value.startsWith(".")) ?? "";
+const file = args.find((value) => value.startsWith("/") && fs.existsSync(value));
+const data = JSON.parse(file ? fs.readFileSync(file, "utf8") : fs.readFileSync(0, "utf8"));
+if (args.includes("-e")) {
+  const platform = values.platform ?? "darwin-aarch64";
+  const entry = data.platforms?.[platform];
+  process.exit(data.version === values.version && data.notes === values.notes && entry?.url === values.url && entry?.signature === values.signature ? 0 : 1);
+}
+if (filter === ".assets[].name") process.stdout.write(data.assets.map((asset) => asset.name).join("\\n") + "\\n");
+else if (filter === ".body") process.stdout.write(data.body);
+else process.stdout.write(String(data[filter.slice(1)]) + "\\n");
+`,
+  );
+
+  writeExecutable(
     join(bin, "gh"),
     `#!/bin/bash
 set -euo pipefail
@@ -198,12 +300,7 @@ case "\${1:-} \${2:-}" in
 const fs = require("node:fs");
 const path = require("node:path");
 const draft = process.argv[2] === "true";
-const names = [
-  "Dakia_${version}_aarch64.dmg",
-  "Dakia-aarch64.app.tar.gz",
-  "Dakia-aarch64.app.tar.gz.sig",
-  "SHA256SUMS.txt",
-];
+const names = ${JSON.stringify(releaseAssetNames)};
 process.stdout.write(JSON.stringify({
   tagName: "${tag}",
   targetCommitish: "${commit}",
@@ -224,7 +321,10 @@ NODE
         *) shift ;;
       esac
     done
-    cp "\${MOCK_ASSET_DIR}/\$pattern" "\$destination/\$pattern"
+    source="\${MOCK_ASSET_DIR}/\$pattern"
+    [[ -e "\$source" ]] || source="\${MOCK_ASSET_DIR}/linux/\$pattern"
+    [[ -e "\$source" ]] || source="\${MOCK_ASSET_DIR}/windows/\$pattern"
+    cp "\$source" "\$destination/\$pattern"
     ;;
   'release edit')
     printf 'edit\n' >> "\${MOCK_EDIT_LOG}"
@@ -251,9 +351,16 @@ while [[ "\$#" -gt 0 ]]; do
 done
 if [[ "\$url" == *'/macos/latest/latest.json?'* ]]; then
   cp "\${MOCK_MANIFEST}" "\$output"
+elif [[ "\$url" == *'/linux/latest/latest.json?'* ]]; then
+  cp "\${MOCK_LINUX_MANIFEST}" "\$output"
+elif [[ "\$url" == *'/windows/latest/latest.json?'* ]]; then
+  cp "\${MOCK_WINDOWS_MANIFEST}" "\$output"
 else
   artifact="\${url##*/}"
-  cp "\${MOCK_ASSET_DIR}/\$artifact" "\$output"
+  source="\${MOCK_ASSET_DIR}/\$artifact"
+  [[ -e "\$source" ]] || source="\${MOCK_ASSET_DIR}/linux/\$artifact"
+  [[ -e "\$source" ]] || source="\${MOCK_ASSET_DIR}/windows/\$artifact"
+  cp "\$source" "\$output"
 fi
 printf '200'
 `,
@@ -268,8 +375,10 @@ printf '200'
     MOCK_GIT_SCENARIO: gitScenario,
     MOCK_LIVE_MAIN_CALLS: liveMainCalls,
     MOCK_MANIFEST: manifestPath,
+    MOCK_LINUX_MANIFEST: linuxManifestPath,
     MOCK_RELEASE_STATE: statePath,
     MOCK_SIGNING_KEY: signingKey,
+    MOCK_WINDOWS_MANIFEST: windowsManifestPath,
   };
   return { fixtureRoot, assets, editLog, env };
 }
@@ -328,6 +437,23 @@ test("an already-public exact release is verified without another edit", () => {
   }
 });
 
+test("Linux and Windows installers and signatures are byte-verified before publication", () => {
+  const harness = runHarness({ optionalPlatforms: true });
+  try {
+    assert.equal(
+      harness.result.status,
+      0,
+      JSON.stringify({
+        stdout: harness.result.stdout,
+        stderr: harness.result.stderr,
+      }),
+    );
+    assert.equal(harness.edits, 1);
+  } finally {
+    rmSync(harness.fixtureRoot, { recursive: true, force: true });
+  }
+});
+
 test("wrong public R2 notes fail before GitHub publication", () => {
   const harness = runHarness({ manifestNotes: "Stale release notes" });
   try {
@@ -355,7 +481,10 @@ test("a live origin/main mismatch fails before GitHub publication", () => {
   try {
     assert.notEqual(harness.result.status, 0);
     assert.equal(harness.edits, 0);
-    assert.match(harness.result.stderr, /HEAD, cached origin\/main, and live origin\/main must all match/);
+    assert.match(
+      harness.result.stderr,
+      /HEAD, cached origin\/main, and live origin\/main must all match/,
+    );
   } finally {
     rmSync(harness.fixtureRoot, { recursive: true, force: true });
   }
@@ -366,7 +495,10 @@ test("a moved live origin/main stops GitHub publication immediately before edit"
   try {
     assert.notEqual(harness.result.status, 0);
     assert.equal(harness.edits, 0);
-    assert.match(harness.result.stderr, /HEAD, cached origin\/main, and live origin\/main must all match/);
+    assert.match(
+      harness.result.stderr,
+      /HEAD, cached origin\/main, and live origin\/main must all match/,
+    );
   } finally {
     rmSync(harness.fixtureRoot, { recursive: true, force: true });
   }

--- a/scripts/github-release-stage.node-test.mjs
+++ b/scripts/github-release-stage.node-test.mjs
@@ -7,7 +7,9 @@ import test from "node:test";
 const root = new URL("..", import.meta.url).pathname;
 const draftScript = join(root, "scripts", "prepare-github-release-draft.sh");
 const publishScript = join(root, "scripts", "publish-github-release.sh");
-const packageJson = JSON.parse(readFileSync(join(root, "package.json"), "utf8"));
+const packageJson = JSON.parse(
+  readFileSync(join(root, "package.json"), "utf8"),
+);
 
 function script(path) {
   return readFileSync(path, "utf8");
@@ -29,10 +31,7 @@ test("draft staging is pinned to clean exact main provenance and an SSH-signed r
   assert.match(source, /local-release-env\.sh/);
   assert.match(source, /gpg\.format/);
   assert.match(source, /gpg\.ssh\.allowedSignersFile/);
-  assert.match(
-    source,
-    /SHA256:kN9R3QFJZbrE5i2HjEpp\+ns5ZNxBTuFySvFx8Ldf\/gE/,
-  );
+  assert.match(source, /SHA256:kN9R3QFJZbrE5i2HjEpp\+ns5ZNxBTuFySvFx8Ldf\/gE/);
   assert.match(source, /BEGIN SSH SIGNATURE/);
   assert.match(source, /verify-tag "\$tag"/);
   assert.match(
@@ -40,7 +39,10 @@ test("draft staging is pinned to clean exact main provenance and an SSH-signed r
     /ls-remote --tags origin "refs\/tags\/\$tag" "refs\/tags\/\$tag\^\{\}"/,
   );
   assert.match(source, /Remote release tag object/);
-  assert.match(source, /Remote release tag \$tag does not target the exact origin\/main commit/);
+  assert.match(
+    source,
+    /Remote release tag \$tag does not target the exact origin\/main commit/,
+  );
 });
 
 test("draft staging accepts no unverified retry and validates exact local and draft bytes", () => {
@@ -51,15 +53,24 @@ test("draft staging accepts no unverified retry and validates exact local and dr
   assert.match(source, /--verify-tag/);
   assert.match(source, /--draft/);
   assert.match(source, /--target "\$\(git -C "\$root_dir" rev-parse HEAD\)"/);
-  assert.match(source, /assets do not exactly match the expected four-file allowlist/);
-  assert.match(source, /GitHub Release body does not exactly match release-notes\.md/);
+  assert.match(source, /assets do not exactly match the expected allowlist/);
+  assert.match(
+    source,
+    /GitHub Release body does not exactly match release-notes\.md/,
+  );
   assert.match(source, /gh release download "\$tag" --repo "\$release_repo"/);
   assert.match(source, /GitHub Release asset bytes do not match local/);
   assert.match(source, /Verified exact existing GitHub Release draft/);
   assert.match(source, /Verified exact existing public GitHub Release/);
   assert.match(source, /require_exact_public_r2_resume/);
-  assert.match(source, /public latest\.json is not the exact R2 resume candidate/);
-  assert.match(source, /Public R2 resume .* differs from the local release artifact/);
+  assert.match(
+    source,
+    /public latest\.json is not the exact R2 resume candidate/,
+  );
+  assert.match(
+    source,
+    /Public R2 resume .* differs from the local release artifact/,
+  );
   const finalProvenanceGate = source.lastIndexOf(
     'dakia_require_release_mutation_provenance "$root_dir"',
   );
@@ -70,11 +81,49 @@ test("draft staging accepts no unverified retry and validates exact local and dr
   assert.doesNotMatch(source, /gh release delete/);
 });
 
+test("GitHub release stages mirror validated optional Linux and Windows updater assets", () => {
+  for (const path of [draftScript, publishScript]) {
+    const source = script(path);
+    assert.match(
+      source,
+      /add_optional_platform_assets "linux" "\$asset_dir\/linux" "Dakia_\$\{version\}_amd64\.AppImage"/,
+    );
+    assert.match(
+      source,
+      /add_optional_platform_assets "windows" "\$asset_dir\/windows" "Dakia_\$\{version\}_x64-setup\.exe"/,
+    );
+    assert.match(
+      source,
+      /SHA256SUMS\.txt must contain exactly the installer and signature checksums/,
+    );
+    assert.match(
+      source,
+      /github_asset_names\+=\("\$updater_name" "\$signature_name"\)/,
+    );
+    assert.match(source, /github_asset_local_path\(\)/);
+    assert.match(source, /Dakia_\$\{version\}_amd64\.AppImage\.sig/);
+    assert.match(source, /Dakia_\$\{version\}_x64-setup\.exe\.sig/);
+  }
+  assert.match(
+    draftScript ? script(draftScript) : "",
+    /require_exact_optional_public_r2_resume/,
+  );
+  assert.match(
+    publishScript ? script(publishScript) : "",
+    /require_public_optional_r2_candidate/,
+  );
+});
+
 test("publication requires the exact public R2 candidate before making GitHub public", () => {
   const source = script(publishScript);
   const draftVerification = source.lastIndexOf("if verify_release true; then");
-  const r2Gate = source.indexOf("require_public_r2_candidate", draftVerification);
-  const publish = source.indexOf("gh release edit \"$tag\" --repo \"$release_repo\" --draft=false --latest");
+  const r2Gate = source.indexOf(
+    "require_public_r2_candidate",
+    draftVerification,
+  );
+  const publish = source.indexOf(
+    'gh release edit "$tag" --repo "$release_repo" --draft=false --latest',
+  );
   const mutationProvenance = source.lastIndexOf(
     'dakia_require_release_mutation_provenance "$root_dir"',
     publish,
@@ -88,20 +137,29 @@ test("publication requires the exact public R2 candidate before making GitHub pu
   assert.match(source, /\.version == \$version/);
   assert.match(source, /\.notes == \$notes/);
   assert.match(source, /\.platforms\["darwin-aarch64"\]\.url == \$url/);
-  assert.match(source, /\.platforms\["darwin-aarch64"\]\.signature == \$signature/);
-  assert.match(source, /Public updater manifest is not the exact signed candidate/);
   assert.match(
     source,
-    /readFileSync\(process\.argv\[1\], "utf8"\)\.trim\(\)/,
+    /\.platforms\["darwin-aarch64"\]\.signature == \$signature/,
   );
+  assert.match(
+    source,
+    /Public updater manifest is not the exact signed candidate/,
+  );
+  assert.match(source, /readFileSync\(process\.argv\[1\], "utf8"\)\.trim\(\)/);
   assert.doesNotMatch(source, /expected_signature="\$\(base64/);
 });
 
 test("publication independently downloads and byte-compares every public GitHub asset", () => {
   const source = script(publishScript);
-  assert.match(source, /https:\/\/github\.com\/\$release_repo\/releases\/download\/\$tag\/\$artifact/);
+  assert.match(
+    source,
+    /https:\/\/github\.com\/\$release_repo\/releases\/download\/\$tag\/\$artifact/,
+  );
   assert.match(source, /Public GitHub asset bytes do not match local/);
-  assert.match(source, /Public GitHub checksum file does not validate downloaded assets/);
+  assert.match(
+    source,
+    /Public GitHub checksum file does not validate downloaded assets/,
+  );
   assert.match(source, /verify_release false/);
   assert.match(source, /return 2/);
   assert.match(

--- a/scripts/nightly-release.node-test.mjs
+++ b/scripts/nightly-release.node-test.mjs
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+import {
+  nextPatch,
+  parseCliArgs,
+  releaseNotes,
+  userFacingSubject,
+} from "./prepare-nightly-release.mjs";
+
+test("nightly releases use the next patch version", () => {
+  assert.equal(nextPatch("0.4.0"), "0.4.1");
+  assert.throws(() => nextPatch("0.4"), /stable semantic version/);
+});
+
+test("generated notes retain reader-facing changes and hide release mechanics", () => {
+  assert.equal(
+    userFacingSubject("Add feedback button to the mailbox sidebar (#75)"),
+    "Send feedback directly from the mailbox sidebar.",
+  );
+  assert.equal(
+    userFacingSubject("Interactive email address header actions (#74)"),
+    "Work with email addresses directly from message headers.",
+  );
+  assert.equal(userFacingSubject("Merge branch 'main'"), null);
+  assert.equal(userFacingSubject("chore: Bump clap from 4.6.2 to 4.6.6"), null);
+  const notes = releaseNotes({
+    version: "0.4.3",
+    subjects: [
+      "Add privacy-preserving usage analytics (#83)",
+      "Fix people categorization across desktop, CLI, and core (#78)",
+      "Optimize CI caching and harden release validation boundaries (#82)",
+      "Add Send again action for sent messages (#81)",
+      "Make archive and read mutations optimistic (#80)",
+      "Merge branch 'main'",
+    ],
+  });
+  assert.match(notes, /Add privacy-preserving usage analytics\./);
+  assert.match(notes, /Improve people categorization/);
+  assert.match(
+    notes,
+    /Optimize CI caching and strengthen release validation\./,
+  );
+  assert.match(notes, /new Send again action\./);
+  assert.match(notes, /faster optimistic updates\./);
+  assert.doesNotMatch(notes, /Merge branch/);
+  assert.match(notes, /available for macOS, Linux, and Windows/);
+});
+
+test("dry-run preserves the positional CLI and accepts either flag order", () => {
+  assert.deepEqual(parseCliArgs(["abc123"]), {
+    base: "abc123",
+    dryRun: false,
+  });
+  assert.deepEqual(parseCliArgs(["abc123", "--dry-run"]), {
+    base: "abc123",
+    dryRun: true,
+  });
+  assert.deepEqual(parseCliArgs(["--dry-run", "abc123"]), {
+    base: "abc123",
+    dryRun: true,
+  });
+  assert.throws(() => parseCliArgs([]), /Usage/);
+  assert.throws(() => parseCliArgs(["abc", "extra"]), /Usage/);
+});
+
+test("dry-run prints preview JSON without changing its checkout", (context) => {
+  const fixture = mkdtempSync(join(tmpdir(), "dakia-nightly-preview-"));
+  context.after(() => rmSync(fixture, { recursive: true, force: true }));
+  mkdirSync(join(fixture, "scripts"));
+  mkdirSync(join(fixture, "docs", "releases"), { recursive: true });
+  copyFileSync(
+    new URL("./prepare-nightly-release.mjs", import.meta.url),
+    join(fixture, "scripts", "prepare-nightly-release.mjs"),
+  );
+  writeFileSync(join(fixture, "package.json"), '{"version":"1.2.3"}\n');
+  const git = (...args) =>
+    spawnSync("git", args, { cwd: fixture, encoding: "utf8" });
+  assert.equal(git("init", "-q").status, 0);
+  assert.equal(git("config", "user.name", "Dakia Test").status, 0);
+  assert.equal(git("config", "user.email", "test@example.invalid").status, 0);
+  assert.equal(git("add", ".").status, 0);
+  assert.equal(git("commit", "-qm", "baseline").status, 0);
+  const base = git("rev-parse", "HEAD").stdout.trim();
+  writeFileSync(join(fixture, "change.txt"), "reader-facing\n");
+  assert.equal(git("add", ".").status, 0);
+  assert.equal(
+    git("commit", "-qm", "Add privacy-preserving usage analytics").status,
+    0,
+  );
+
+  const beforePackage = readFileSync(join(fixture, "package.json"), "utf8");
+  const result = spawnSync(
+    process.execPath,
+    [
+      join(fixture, "scripts", "prepare-nightly-release.mjs"),
+      base,
+      "--dry-run",
+    ],
+    { cwd: fixture, encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const preview = JSON.parse(result.stdout);
+  assert.equal(preview.tag, "v1.2.4");
+  assert.match(preview.notes, /privacy-preserving usage analytics/);
+  assert.equal(
+    readFileSync(join(fixture, "package.json"), "utf8"),
+    beforePackage,
+  );
+  assert.equal(
+    existsSync(join(fixture, "docs", "releases", "v1.2.4.md")),
+    false,
+  );
+  assert.equal(git("status", "--porcelain").stdout, "");
+});

--- a/scripts/nightly-release.node-test.mjs
+++ b/scripts/nightly-release.node-test.mjs
@@ -47,12 +47,9 @@ test("generated notes retain reader-facing changes and hide release mechanics", 
       "Merge branch 'main'",
     ],
   });
-  assert.match(notes, /Add privacy-preserving usage analytics\./);
+  assert.match(notes, /Added privacy-preserving usage analytics\./);
   assert.match(notes, /Improve people categorization/);
-  assert.match(
-    notes,
-    /Optimize CI caching and strengthen release validation\./,
-  );
+  assert.doesNotMatch(notes, /Optimize CI caching|strengthen release validation/);
   assert.match(notes, /new Send again action\./);
   assert.match(notes, /faster optimistic updates\./);
   assert.doesNotMatch(notes, /Merge branch/);

--- a/scripts/prepare-github-release-draft.behavior.node-test.mjs
+++ b/scripts/prepare-github-release-draft.behavior.node-test.mjs
@@ -15,8 +15,16 @@ import { join } from "node:path";
 import test from "node:test";
 
 const repositoryRoot = new URL("..", import.meta.url).pathname;
-const draftSource = join(repositoryRoot, "scripts", "prepare-github-release-draft.sh");
-const releaseEnvironmentSource = join(repositoryRoot, "scripts", "local-release-env.sh");
+const draftSource = join(
+  repositoryRoot,
+  "scripts",
+  "prepare-github-release-draft.sh",
+);
+const releaseEnvironmentSource = join(
+  repositoryRoot,
+  "scripts",
+  "local-release-env.sh",
+);
 const tag = "v0.4.2";
 const version = tag.slice(1);
 const commit = "1234567890abcdef1234567890abcdef12345678";
@@ -31,7 +39,13 @@ function sha256(value) {
   return createHash("sha256").update(value).digest("hex");
 }
 
-function createHarness({ manifestVersion = version, corruptAsset = "", missingAsset = "", liveMainMoves = false, releaseExists = true } = {}) {
+function createHarness({
+  manifestVersion = version,
+  corruptAsset = "",
+  missingAsset = "",
+  liveMainMoves = false,
+  releaseExists = true,
+} = {}) {
   const fixture = mkdtempSync(join(tmpdir(), "dakia-draft-resume-test-"));
   const root = join(fixture, "repo");
   const scripts = join(root, "scripts");
@@ -60,7 +74,8 @@ function createHarness({ manifestVersion = version, corruptAsset = "", missingAs
     "release-notes.md": "Release notes\n",
     "source-commit.txt": `${commit}\n`,
   };
-  for (const [filename, body] of Object.entries(files)) writeFileSync(join(assets, filename), body);
+  for (const [filename, body] of Object.entries(files))
+    writeFileSync(join(assets, filename), body);
   writeFileSync(
     join(assets, "SHA256SUMS.txt"),
     [
@@ -79,13 +94,18 @@ function createHarness({ manifestVersion = version, corruptAsset = "", missingAs
       platforms: {
         "darwin-aarch64": {
           url: `https://downloads.dakiamail.com/macos/v${manifestVersion}/Dakia-aarch64.app.tar.gz`,
-          signature: manifestVersion === version ? files["Dakia-aarch64.app.tar.gz.sig"].trim() : "older-signature",
+          signature:
+            manifestVersion === version
+              ? files["Dakia-aarch64.app.tar.gz.sig"].trim()
+              : "older-signature",
         },
       },
     })}\n`,
   );
 
-  executable(join(bin, "git"), `#!/bin/bash
+  executable(
+    join(bin, "git"),
+    `#!/bin/bash
 set -euo pipefail
 [[ "\${1:-}" == -C ]] && shift 2
 while [[ "\${1:-}" == -c ]]; do shift 2; done
@@ -120,9 +140,35 @@ case "\${1:-}" in
     fi ;;
   *) exit 64 ;;
 esac
-`);
-  executable(join(bin, "ssh-keygen"), "#!/bin/sh\nprintf '%s\\n' '256 SHA256:kN9R3QFJZbrE5i2HjEpp+ns5ZNxBTuFySvFx8Ldf/gE release@example.test'\n");
-  executable(join(bin, "gh"), `#!/bin/bash
+`,
+  );
+  executable(
+    join(bin, "ssh-keygen"),
+    "#!/bin/sh\nprintf '%s\\n' '256 SHA256:kN9R3QFJZbrE5i2HjEpp+ns5ZNxBTuFySvFx8Ldf/gE release@example.test'\n",
+  );
+  executable(
+    join(bin, "jq"),
+    `#!/usr/bin/env node
+const fs = require("node:fs");
+const args = process.argv.slice(2);
+const values = {};
+for (let index = 0; index < args.length; index += 1) if (args[index] === "--arg") values[args[index + 1]] = args[index + 2];
+const filter = args.find((value) => value.startsWith(".")) ?? "";
+const file = args.find((value) => value.startsWith("/") && fs.existsSync(value));
+const data = JSON.parse(file ? fs.readFileSync(file, "utf8") : fs.readFileSync(0, "utf8"));
+if (args.includes("-e")) {
+  const platform = values.platform ?? "darwin-aarch64";
+  const entry = data.platforms?.[platform];
+  process.exit(data.version === values.version && data.notes === values.notes && entry?.url === values.url && entry?.signature === values.signature ? 0 : 1);
+}
+if (filter === ".assets[].name") process.stdout.write(data.assets.map((asset) => asset.name).join("\\n") + "\\n");
+else if (filter === ".body") process.stdout.write(data.body);
+else process.stdout.write(String(data[filter.slice(1)]) + "\\n");
+`,
+  );
+  executable(
+    join(bin, "gh"),
+    `#!/bin/bash
 set -euo pipefail
 case "\${1:-} \${2:-}" in
   'auth status') ;;
@@ -141,8 +187,12 @@ NODE
   'release create') printf create >> "\${MOCK_CREATE_LOG}" ;;
   *) exit 64 ;;
 esac
-`);
-  executable(join(bin, "curl"), "#!/bin/bash\nset -euo pipefail\noutput= url=\nwhile [[ \"$#\" -gt 0 ]]; do case \"$1\" in --output) output=\"$2\"; shift 2 ;; --write-out|--connect-timeout|--max-time|--proto) shift 2 ;; --silent|--show-error|--location) shift ;; *) url=\"$1\"; shift ;; esac; done\nif [[ \"$url\" == *'/macos/latest/latest.json?'* ]]; then cp \"$MOCK_MANIFEST\" \"$output\"; printf 200; exit 0; fi\nname=\"${url##*/}\"\nif [[ \"$name\" == Dakia-Apple-Silicon.dmg ]]; then source=\"$MOCK_ASSETS/Dakia_0.4.2_aarch64.dmg\"; else source=\"$MOCK_ASSETS/$name\"; fi\nif [[ \"$name\" == \"$MOCK_MISSING_ASSET\" ]]; then : > \"$output\"; printf 404; exit 0; fi\nif [[ \"$name\" == \"$MOCK_CORRUPT_ASSET\" ]]; then printf corrupt > \"$output\"; printf 200; exit 0; fi\ncp \"$source\" \"$output\"; printf 200\n");
+`,
+  );
+  executable(
+    join(bin, "curl"),
+    '#!/bin/bash\nset -euo pipefail\noutput= url=\nwhile [[ "$#" -gt 0 ]]; do case "$1" in --output) output="$2"; shift 2 ;; --write-out|--connect-timeout|--max-time|--proto) shift 2 ;; --silent|--show-error|--location) shift ;; *) url="$1"; shift ;; esac; done\nif [[ "$url" == *\'/macos/latest/latest.json?\'* ]]; then cp "$MOCK_MANIFEST" "$output"; printf 200; exit 0; fi\nname="${url##*/}"\nif [[ "$name" == Dakia-Apple-Silicon.dmg ]]; then source="$MOCK_ASSETS/Dakia_0.4.2_aarch64.dmg"; else source="$MOCK_ASSETS/$name"; fi\nif [[ "$name" == "$MOCK_MISSING_ASSET" ]]; then : > "$output"; printf 404; exit 0; fi\nif [[ "$name" == "$MOCK_CORRUPT_ASSET" ]]; then printf corrupt > "$output"; printf 200; exit 0; fi\ncp "$source" "$output"; printf 200\n',
+  );
 
   return {
     fixture,
@@ -169,9 +219,15 @@ esac
 test("an already-public GitHub release cannot precede a newer updater candidate", () => {
   const harness = createHarness({ manifestVersion: "0.4.1" });
   try {
-    const result = spawnSync(harness.command, [tag, harness.assets], { encoding: "utf8", env: harness.env });
+    const result = spawnSync(harness.command, [tag, harness.assets], {
+      encoding: "utf8",
+      env: harness.env,
+    });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Existing GitHub Release is public while public latest\.json is not the exact R2 resume candidate/);
+    assert.match(
+      result.stderr,
+      /Existing GitHub Release is public while public latest\.json is not the exact R2 resume candidate/,
+    );
     assert.equal(readFileSync(harness.createLog, "utf8"), "");
   } finally {
     rmSync(harness.fixture, { recursive: true, force: true });
@@ -181,9 +237,15 @@ test("an already-public GitHub release cannot precede a newer updater candidate"
 test("an already-public GitHub release is accepted only for its exact R2 resume", () => {
   const harness = createHarness();
   try {
-    const result = spawnSync(harness.command, [tag, harness.assets], { encoding: "utf8", env: harness.env });
+    const result = spawnSync(harness.command, [tag, harness.assets], {
+      encoding: "utf8",
+      env: harness.env,
+    });
     assert.equal(result.status, 0, result.stderr);
-    assert.match(result.stdout, /Verified exact existing public GitHub Release/);
+    assert.match(
+      result.stdout,
+      /Verified exact existing public GitHub Release/,
+    );
   } finally {
     rmSync(harness.fixture, { recursive: true, force: true });
   }
@@ -192,9 +254,15 @@ test("an already-public GitHub release is accepted only for its exact R2 resume"
 test("an exact public resume rejects corrupt versioned R2 bytes", () => {
   const harness = createHarness({ corruptAsset: "Dakia-aarch64.app.tar.gz" });
   try {
-    const result = spawnSync(harness.command, [tag, harness.assets], { encoding: "utf8", env: harness.env });
+    const result = spawnSync(harness.command, [tag, harness.assets], {
+      encoding: "utf8",
+      env: harness.env,
+    });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Public R2 resume updater archive is missing or differs/);
+    assert.match(
+      result.stderr,
+      /Public R2 resume updater archive is missing or differs/,
+    );
     assert.equal(readFileSync(harness.createLog, "utf8"), "");
   } finally {
     rmSync(harness.fixture, { recursive: true, force: true });
@@ -204,9 +272,15 @@ test("an exact public resume rejects corrupt versioned R2 bytes", () => {
 test("an exact public resume rejects a missing versioned R2 DMG", () => {
   const harness = createHarness({ missingAsset: "Dakia-Apple-Silicon.dmg" });
   try {
-    const result = spawnSync(harness.command, [tag, harness.assets], { encoding: "utf8", env: harness.env });
+    const result = spawnSync(harness.command, [tag, harness.assets], {
+      encoding: "utf8",
+      env: harness.env,
+    });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /Public R2 resume Apple Silicon DMG is missing or differs/);
+    assert.match(
+      result.stderr,
+      /Public R2 resume Apple Silicon DMG is missing or differs/,
+    );
     assert.equal(readFileSync(harness.createLog, "utf8"), "");
   } finally {
     rmSync(harness.fixture, { recursive: true, force: true });
@@ -216,9 +290,15 @@ test("an exact public resume rejects a missing versioned R2 DMG", () => {
 test("a moved live main stops draft creation immediately before mutation", () => {
   const harness = createHarness({ liveMainMoves: true, releaseExists: false });
   try {
-    const result = spawnSync(harness.command, [tag, harness.assets], { encoding: "utf8", env: harness.env });
+    const result = spawnSync(harness.command, [tag, harness.assets], {
+      encoding: "utf8",
+      env: harness.env,
+    });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /HEAD, cached origin\/main, and live origin\/main must all match/);
+    assert.match(
+      result.stderr,
+      /HEAD, cached origin\/main, and live origin\/main must all match/,
+    );
     assert.equal(readFileSync(harness.createLog, "utf8"), "");
   } finally {
     rmSync(harness.fixture, { recursive: true, force: true });

--- a/scripts/prepare-github-release-draft.sh
+++ b/scripts/prepare-github-release-draft.sh
@@ -32,7 +32,53 @@ apple_signature="Dakia-aarch64.app.tar.gz.sig"
 checksums="SHA256SUMS.txt"
 notes="release-notes.md"
 source_marker="source-commit.txt"
-expected_assets="$(printf '%s\n' "$apple_dmg" "$apple_update" "$apple_signature" "$checksums" | LC_ALL=C sort)"
+github_asset_names=("$apple_dmg" "$apple_update" "$apple_signature" "$checksums")
+github_asset_paths=("$asset_dir/$apple_dmg" "$asset_dir/$apple_update" "$asset_dir/$apple_signature" "$asset_dir/$checksums")
+
+# GitHub Release assets have a flat namespace, so the per-platform
+# SHA256SUMS.txt files remain in their platform directories/R2. The installer
+# and its detached updater signature are mirrored here alongside the Apple
+# release assets.
+add_optional_platform_assets() {
+  local platform_name="$1" platform_dir="$2" updater_name="$3"
+  local signature_name="$updater_name.sig" platform_checksums="$platform_dir/SHA256SUMS.txt"
+  local checksum_names expected_names artifact
+
+  [[ -d "$platform_dir" ]] || return 0
+  for artifact in "$platform_dir/$updater_name" "$platform_dir/$signature_name" "$platform_checksums"; do
+    [[ -s "$artifact" ]] || die "Missing or empty $platform_name release input: $artifact"
+  done
+  if find "$platform_dir" -mindepth 1 -maxdepth 1 ! -type f | grep -q . || \
+    find "$platform_dir" -mindepth 1 -maxdepth 1 -type f ! -name "$updater_name" ! -name "$signature_name" ! -name SHA256SUMS.txt | grep -q .; then
+    die "$platform_dir contains files outside the expected $platform_name release allowlist."
+  fi
+  [[ "$(wc -l <"$platform_checksums" | tr -d ' ')" == "2" ]] ||
+    die "$platform_name/SHA256SUMS.txt must contain exactly the installer and signature checksums."
+  awk 'NF != 2 { exit 1 }' "$platform_checksums" ||
+    die "$platform_name/SHA256SUMS.txt contains an invalid checksum record."
+  checksum_names="$(awk '{ print $2 }' "$platform_checksums" | LC_ALL=C sort)"
+  expected_names="$(printf '%s\n' "$updater_name" "$signature_name" | LC_ALL=C sort)"
+  [[ "$checksum_names" == "$expected_names" ]] ||
+    die "$platform_name/SHA256SUMS.txt must cover exactly the GitHub distributable artifacts."
+  (cd "$platform_dir" && shasum -a 256 -c SHA256SUMS.txt) >/dev/null ||
+    die "$platform_name/SHA256SUMS.txt does not match the local release artifacts."
+  github_asset_names+=("$updater_name" "$signature_name")
+  github_asset_paths+=("$platform_dir/$updater_name" "$platform_dir/$signature_name")
+}
+
+add_optional_platform_assets "linux" "$asset_dir/linux" "Dakia_${version}_amd64.AppImage"
+add_optional_platform_assets "windows" "$asset_dir/windows" "Dakia_${version}_x64-setup.exe"
+expected_assets="$(printf '%s\n' "${github_asset_names[@]}" | LC_ALL=C sort)"
+
+github_asset_local_path() {
+  local artifact="$1"
+  case "$artifact" in
+    "$apple_dmg"|"$apple_update"|"$apple_signature"|"$checksums") printf '%s\n' "$asset_dir/$artifact" ;;
+    "Dakia_${version}_amd64.AppImage"|"Dakia_${version}_amd64.AppImage.sig") printf '%s\n' "$asset_dir/linux/$artifact" ;;
+    "Dakia_${version}_x64-setup.exe"|"Dakia_${version}_x64-setup.exe.sig") printf '%s\n' "$asset_dir/windows/$artifact" ;;
+    *) die "Unexpected GitHub Release asset: $artifact" ;;
+  esac
+}
 
 require_main_provenance() {
   local status
@@ -71,6 +117,52 @@ require_exact_public_r2_resume() {
     "$download_origin/macos/$tag/Dakia-aarch64.app.tar.gz|$asset_dir/$apple_update|updater archive" \
     "$download_origin/macos/$tag/Dakia-aarch64.app.tar.gz.sig|$asset_dir/$apple_signature|updater signature" \
     "$download_origin/macos/$tag/Dakia-Apple-Silicon.dmg|$asset_dir/$apple_dmg|Apple Silicon DMG"; do
+    IFS='|' read -r url local_file label <<<"$artifact"
+    if ! status="$(curl --silent --show-error --location --proto '=https' --connect-timeout 15 --max-time 90 \
+      --output "$resume_dir/$(basename "$url")" --write-out '%{http_code}' "$url")" || \
+      [[ "$status" != "200" ]] || \
+      ! cmp -s "$local_file" "$resume_dir/$(basename "$url")"; then
+      rm -rf "$resume_dir"
+      die "Public R2 resume $label is missing or differs from the local release artifact."
+    fi
+  done
+  rm -rf "$resume_dir"
+  require_exact_optional_public_r2_resume "linux" "linux-x86_64" "$asset_dir/linux" "Dakia_${version}_amd64.AppImage"
+  require_exact_optional_public_r2_resume "windows" "windows-x86_64" "$asset_dir/windows" "Dakia_${version}_x64-setup.exe"
+}
+
+require_exact_optional_public_r2_resume() {
+  local platform_name="$1" platform="$2" platform_dir="$3" updater_name="$4"
+  local signature_name="$updater_name.sig" manifest resume_dir status expected_url expected_signature expected_notes artifact
+  [[ -d "$platform_dir" ]] || return 0
+  manifest="$(mktemp)" || die "Could not create a temporary $platform_name updater-manifest file."
+  if ! status="$(curl --silent --show-error --location --proto '=https' --connect-timeout 15 --max-time 90 \
+    --output "$manifest" --write-out '%{http_code}' "$download_origin/$platform_name/latest/latest.json?release-gate=$tag")"; then
+    rm -f "$manifest"
+    die "Could not read the public $platform_name updater manifest while checking an existing GitHub Release."
+  fi
+  if [[ "$status" != "200" ]]; then
+    rm -f "$manifest"
+    die "Existing GitHub Release may resume only when public $platform_name latest.json is reachable (HTTP $status)."
+  fi
+  node "$root_dir/scripts/updater-manifest.mjs" validate --platform "$platform" --manifest "$manifest" \
+    --tauri-config "$root_dir/apps/desktop/src-tauri/tauri.conf.json" >/dev/null || {
+      rm -f "$manifest"; die "Existing GitHub Release may resume only with a valid public $platform_name updater manifest.";
+    }
+  expected_url="$download_origin/$platform_name/$tag/$updater_name"
+  expected_signature="$(node -e 'process.stdout.write(require("node:fs").readFileSync(process.argv[1], "utf8").trim())' "$platform_dir/$signature_name")"
+  expected_notes="$(node -e 'process.stdout.write(require("node:fs").readFileSync(process.argv[1], "utf8").trim())' "$asset_dir/$notes")"
+  if ! jq -e --arg version "$version" --arg url "$expected_url" --arg signature "$expected_signature" --arg notes "$expected_notes" --arg platform "$platform" \
+    '.version == $version and .notes == $notes and .platforms[$platform].url == $url and .platforms[$platform].signature == $signature' \
+    "$manifest" >/dev/null; then
+    rm -f "$manifest"
+    die "Existing GitHub Release is public while public $platform_name latest.json is not the exact R2 resume candidate."
+  fi
+  rm -f "$manifest"
+  resume_dir="$(mktemp -d)" || die "Could not create a temporary public $platform_name artifact directory."
+  for artifact in \
+    "$download_origin/$platform_name/$tag/$updater_name|$platform_dir/$updater_name|$platform_name updater" \
+    "$download_origin/$platform_name/$tag/$signature_name|$platform_dir/$signature_name|$platform_name updater signature"; do
     IFS='|' read -r url local_file label <<<"$artifact"
     if ! status="$(curl --silent --show-error --location --proto '=https' --connect-timeout 15 --max-time 90 \
       --output "$resume_dir/$(basename "$url")" --write-out '%{http_code}' "$url")" || \
@@ -141,7 +233,7 @@ verify_local_assets() {
 }
 
 verify_release() {
-  local expected_draft="$1" release_json actual_assets actual_tag actual_target actual_title actual_draft actual_prerelease verify_dir artifact
+  local expected_draft="$1" release_json actual_assets actual_tag actual_target actual_title actual_draft actual_prerelease verify_dir artifact local_file
   release_json="$(gh release view "$tag" --repo "$release_repo" --json tagName,targetCommitish,name,body,isDraft,isPrerelease,assets)" ||
     return 1
   actual_tag="$(jq -r '.tagName' <<<"$release_json")"
@@ -161,7 +253,7 @@ verify_release() {
   fi
   actual_assets="$(jq -r '.assets[].name' <<<"$release_json" | LC_ALL=C sort)"
   [[ "$actual_assets" == "$expected_assets" ]] ||
-    die "GitHub Release assets do not exactly match the expected four-file allowlist."
+    die "GitHub Release assets do not exactly match the expected allowlist."
   jq -j '.body' <<<"$release_json" >"$asset_dir/.github-release-body.$$"
   if ! cmp -s "$asset_dir/$notes" "$asset_dir/.github-release-body.$$"; then
     rm -f "$asset_dir/.github-release-body.$$"
@@ -170,9 +262,10 @@ verify_release() {
   rm -f "$asset_dir/.github-release-body.$$"
   verify_dir="$(mktemp -d)"
   trap 'rm -rf "$verify_dir"' RETURN
-  for artifact in "$apple_dmg" "$apple_update" "$apple_signature" "$checksums"; do
+  for artifact in "${github_asset_names[@]}"; do
+    local_file="$(github_asset_local_path "$artifact")"
     gh release download "$tag" --repo "$release_repo" --dir "$verify_dir" --pattern "$artifact"
-    cmp -s "$asset_dir/$artifact" "$verify_dir/$artifact" ||
+    cmp -s "$local_file" "$verify_dir/$artifact" ||
       die "GitHub Release asset bytes do not match local $artifact."
   done
   (cd "$verify_dir" && shasum -a 256 -c "$checksums") >/dev/null ||
@@ -207,10 +300,7 @@ if ! gh release create "$tag" \
   --target "$(git -C "$root_dir" rev-parse HEAD)" \
   --title "Dakia $tag" \
   --notes-file "$asset_dir/$notes" \
-  "$asset_dir/$apple_dmg" \
-  "$asset_dir/$apple_update" \
-  "$asset_dir/$apple_signature" \
-  "$asset_dir/$checksums"; then
+  "${github_asset_paths[@]}"; then
   verify_release true || die "GitHub draft creation failed without an exact matching draft."
 fi
 verify_release true || die "Created GitHub draft did not pass exact verification."

--- a/scripts/prepare-nightly-release.mjs
+++ b/scripts/prepare-nightly-release.mjs
@@ -20,6 +20,14 @@ export function userFacingSubject(subject) {
     .replace(/^(feat|fix|perf|refactor|docs|chore)(\([^)]*\))?!?:\s*/i, "")
     .trim();
   if (!cleaned || /^(merge|prepare v?\d|bump )/i.test(cleaned)) return null;
+  // Internal or umbrella subjects carry no user-visible claim and must never
+  // become release-note bullets on their own.
+  if (
+    /^(optimize ci|harden release|update (?:dakia )?desktop (?:application|implementation)|update desktop app|prepare v?\d|bump )/i.test(
+      cleaned,
+    )
+  )
+    return null;
   const knownChanges = [
     [
       /^interactive email address header actions$/i,
@@ -31,15 +39,11 @@ export function userFacingSubject(subject) {
     ],
     [
       /^add privacy-preserving usage analytics$/i,
-      "Add privacy-preserving usage analytics.",
+      "Added privacy-preserving usage analytics.",
     ],
     [
       /^fix people categorization across desktop, CLI, and core$/i,
       "Improve people categorization across desktop, CLI, and core.",
-    ],
-    [
-      /^optimize CI caching and harden release validation boundaries$/i,
-      "Optimize CI caching and strengthen release validation.",
     ],
     [
       /^add send again action for sent messages$/i,

--- a/scripts/prepare-nightly-release.mjs
+++ b/scripts/prepare-nightly-release.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(new URL("..", import.meta.url).pathname);
+
+export function nextPatch(version) {
+  const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+  if (!match)
+    throw new Error(`Expected a stable semantic version, got '${version}'.`);
+  return `${match[1]}.${match[2]}.${Number(match[3]) + 1}`;
+}
+
+export function userFacingSubject(subject) {
+  if (/^(merge|chore|build|ci|docs|prepare v?|bump )/i.test(subject.trim()))
+    return null;
+  const cleaned = subject
+    .replace(/\s*\(#\d+\)\s*$/, "")
+    .replace(/^(feat|fix|perf|refactor|docs|chore)(\([^)]*\))?!?:\s*/i, "")
+    .trim();
+  if (!cleaned || /^(merge|prepare v?\d|bump )/i.test(cleaned)) return null;
+  const knownChanges = [
+    [
+      /^interactive email address header actions$/i,
+      "Work with email addresses directly from message headers.",
+    ],
+    [
+      /^add (?:a )?feedback button to (?:the )?mailbox sidebar$/i,
+      "Send feedback directly from the mailbox sidebar.",
+    ],
+    [
+      /^add privacy-preserving usage analytics$/i,
+      "Add privacy-preserving usage analytics.",
+    ],
+    [
+      /^fix people categorization across desktop, CLI, and core$/i,
+      "Improve people categorization across desktop, CLI, and core.",
+    ],
+    [
+      /^optimize CI caching and harden release validation boundaries$/i,
+      "Optimize CI caching and strengthen release validation.",
+    ],
+    [
+      /^add send again action for sent messages$/i,
+      "Resend sent messages with the new Send again action.",
+    ],
+    [
+      /^make archive and read mutations optimistic$/i,
+      "Archive messages and mark them as read with faster optimistic updates.",
+    ],
+  ];
+  const known = knownChanges.find(([pattern]) => pattern.test(cleaned));
+  if (known) return known[1];
+  return cleaned.endsWith(".") ? cleaned : `${cleaned}.`;
+}
+
+export function releaseNotes({ version, subjects }) {
+  const changes = [...new Set(subjects.map(userFacingSubject).filter(Boolean))];
+  if (!changes.length)
+    throw new Error("No reader-facing changes were found for this release.");
+  return `# Dakia v${version}\n\nThis update includes the latest improvements to Dakia.\n\n## What changed\n\n${changes
+    .map((subject) => `- ${subject}`)
+    .join(
+      "\n",
+    )}\n\n## Download\n\nDakia v${version} is available for macOS, Linux, and Windows.\n`;
+}
+
+function git(...args) {
+  return execFileSync("git", args, { cwd: root, encoding: "utf8" }).trim();
+}
+
+function replaceExactly(path, pattern, replacement) {
+  const source = readFileSync(path, "utf8");
+  const result = source.replace(pattern, replacement);
+  if (result === source)
+    throw new Error(`Could not update version in ${path}.`);
+  writeFileSync(path, result);
+}
+
+export function updateVersion(version) {
+  const packagePath = resolve(root, "package.json");
+  const packageJson = JSON.parse(readFileSync(packagePath, "utf8"));
+  packageJson.version = version;
+  writeFileSync(packagePath, `${JSON.stringify(packageJson, null, 2)}\n`);
+
+  const lockPath = resolve(root, "package-lock.json");
+  const lock = JSON.parse(readFileSync(lockPath, "utf8"));
+  lock.version = version;
+  lock.packages[""].version = version;
+  writeFileSync(lockPath, `${JSON.stringify(lock, null, 2)}\n`);
+
+  replaceExactly(
+    resolve(root, "Cargo.toml"),
+    /(?<=\[workspace\.package\][\s\S]*?version = ")[^"]+/,
+    version,
+  );
+  replaceExactly(
+    resolve(root, "apps/desktop/src-tauri/tauri.conf.json"),
+    /(?<="version": ")[^"]+/,
+    version,
+  );
+  replaceExactly(
+    resolve(root, "Cargo.lock"),
+    /(?<=name = "dakia-(?:cli|core|desktop)"\nversion = ")[^"]+/g,
+    version,
+  );
+}
+
+export function parseCliArgs(args) {
+  const dryRun = args.includes("--dry-run");
+  const positional = args.filter((argument) => argument !== "--dry-run");
+  if (
+    positional.length !== 1 ||
+    args.length !== positional.length + Number(dryRun)
+  ) {
+    throw new Error(
+      "Usage: prepare-nightly-release.mjs <last-release-commit> [--dry-run]",
+    );
+  }
+  return { base: positional[0], dryRun };
+}
+
+if (process.argv[1] === new URL(import.meta.url).pathname) {
+  const { base, dryRun } = parseCliArgs(process.argv.slice(2));
+  const currentVersion = JSON.parse(
+    readFileSync(resolve(root, "package.json"), "utf8"),
+  ).version;
+  const version = nextPatch(currentVersion);
+  const subjects = git("log", "--format=%s", `${base}..HEAD`).split("\n");
+  const notes = releaseNotes({ version, subjects });
+  if (dryRun) {
+    process.stdout.write(`${JSON.stringify({ tag: `v${version}`, notes })}\n`);
+  } else {
+    updateVersion(version);
+    writeFileSync(resolve(root, "docs/releases", `v${version}.md`), notes);
+    process.stdout.write(
+      `${JSON.stringify({ tag: `v${version}`, notes: `docs/releases/v${version}.md` })}\n`,
+    );
+  }
+}

--- a/scripts/publish-github-release.sh
+++ b/scripts/publish-github-release.sh
@@ -32,7 +32,50 @@ apple_signature="Dakia-aarch64.app.tar.gz.sig"
 checksums="SHA256SUMS.txt"
 notes="release-notes.md"
 source_marker="source-commit.txt"
-expected_assets="$(printf '%s\n' "$apple_dmg" "$apple_update" "$apple_signature" "$checksums" | LC_ALL=C sort)"
+github_asset_names=("$apple_dmg" "$apple_update" "$apple_signature" "$checksums")
+
+# GitHub Release assets have a flat namespace, so per-platform SHA256SUMS.txt
+# files stay with their versioned R2 release directories. Mirror each optional
+# installer and its detached updater signature without renaming either.
+add_optional_platform_assets() {
+  local platform_name="$1" platform_dir="$2" updater_name="$3"
+  local signature_name="$updater_name.sig" platform_checksums="$platform_dir/SHA256SUMS.txt"
+  local checksum_names expected_names artifact
+
+  [[ -d "$platform_dir" ]] || return 0
+  for artifact in "$platform_dir/$updater_name" "$platform_dir/$signature_name" "$platform_checksums"; do
+    [[ -s "$artifact" ]] || die "Missing or empty $platform_name release input: $artifact"
+  done
+  if find "$platform_dir" -mindepth 1 -maxdepth 1 ! -type f | grep -q . || \
+    find "$platform_dir" -mindepth 1 -maxdepth 1 -type f ! -name "$updater_name" ! -name "$signature_name" ! -name SHA256SUMS.txt | grep -q .; then
+    die "$platform_dir contains files outside the expected $platform_name release allowlist."
+  fi
+  [[ "$(wc -l <"$platform_checksums" | tr -d ' ')" == "2" ]] ||
+    die "$platform_name/SHA256SUMS.txt must contain exactly the installer and signature checksums."
+  awk 'NF != 2 { exit 1 }' "$platform_checksums" ||
+    die "$platform_name/SHA256SUMS.txt contains an invalid checksum record."
+  checksum_names="$(awk '{ print $2 }' "$platform_checksums" | LC_ALL=C sort)"
+  expected_names="$(printf '%s\n' "$updater_name" "$signature_name" | LC_ALL=C sort)"
+  [[ "$checksum_names" == "$expected_names" ]] ||
+    die "$platform_name/SHA256SUMS.txt must cover exactly the GitHub distributable artifacts."
+  (cd "$platform_dir" && shasum -a 256 -c SHA256SUMS.txt) >/dev/null ||
+    die "$platform_name/SHA256SUMS.txt does not match the local release artifacts."
+  github_asset_names+=("$updater_name" "$signature_name")
+}
+
+add_optional_platform_assets "linux" "$asset_dir/linux" "Dakia_${version}_amd64.AppImage"
+add_optional_platform_assets "windows" "$asset_dir/windows" "Dakia_${version}_x64-setup.exe"
+expected_assets="$(printf '%s\n' "${github_asset_names[@]}" | LC_ALL=C sort)"
+
+github_asset_local_path() {
+  local artifact="$1"
+  case "$artifact" in
+    "$apple_dmg"|"$apple_update"|"$apple_signature"|"$checksums") printf '%s\n' "$asset_dir/$artifact" ;;
+    "Dakia_${version}_amd64.AppImage"|"Dakia_${version}_amd64.AppImage.sig") printf '%s\n' "$asset_dir/linux/$artifact" ;;
+    "Dakia_${version}_x64-setup.exe"|"Dakia_${version}_x64-setup.exe.sig") printf '%s\n' "$asset_dir/windows/$artifact" ;;
+    *) die "Unexpected GitHub Release asset: $artifact" ;;
+  esac
+}
 curl_options=(--silent --show-error --location --proto '=https' --connect-timeout 15 --max-time 90 --retry 3 --retry-delay 1 --retry-max-time 180)
 
 require_main_provenance() {
@@ -103,7 +146,7 @@ verify_local_assets() {
 }
 
 verify_release() {
-  local expected_draft="$1" release_json actual_assets actual_tag actual_target actual_title actual_draft actual_prerelease verify_dir artifact
+  local expected_draft="$1" release_json actual_assets actual_tag actual_target actual_title actual_draft actual_prerelease verify_dir artifact local_file
   release_json="$(gh release view "$tag" --repo "$release_repo" --json tagName,targetCommitish,name,body,isDraft,isPrerelease,assets)" ||
     die "GitHub Release $tag does not exist. Prepare and verify its draft before R2 publication."
   actual_tag="$(jq -r '.tagName' <<<"$release_json")"
@@ -118,7 +161,7 @@ verify_release() {
   [[ "$actual_prerelease" == "false" ]] || die "GitHub Release must not be a prerelease."
   actual_assets="$(jq -r '.assets[].name' <<<"$release_json" | LC_ALL=C sort)"
   [[ "$actual_assets" == "$expected_assets" ]] ||
-    die "GitHub Release assets do not exactly match the expected four-file allowlist."
+    die "GitHub Release assets do not exactly match the expected allowlist."
   jq -j '.body' <<<"$release_json" >"$asset_dir/.github-release-body.$$"
   if ! cmp -s "$asset_dir/$notes" "$asset_dir/.github-release-body.$$"; then
     rm -f "$asset_dir/.github-release-body.$$"
@@ -127,9 +170,10 @@ verify_release() {
   rm -f "$asset_dir/.github-release-body.$$"
   verify_dir="$(mktemp -d)"
   trap 'rm -rf "$verify_dir"' RETURN
-  for artifact in "$apple_dmg" "$apple_update" "$apple_signature" "$checksums"; do
+  for artifact in "${github_asset_names[@]}"; do
+    local_file="$(github_asset_local_path "$artifact")"
     gh release download "$tag" --repo "$release_repo" --dir "$verify_dir" --pattern "$artifact"
-    cmp -s "$asset_dir/$artifact" "$verify_dir/$artifact" ||
+    cmp -s "$local_file" "$verify_dir/$artifact" ||
       die "GitHub Release asset bytes do not match local $artifact."
   done
   (cd "$verify_dir" && shasum -a 256 -c "$checksums") >/dev/null ||
@@ -164,17 +208,43 @@ require_public_r2_candidate() {
     die "Public updater manifest is not the exact signed candidate for $tag."
   rm -f "$manifest"
   trap - RETURN
+  require_public_optional_r2_candidate "linux" "linux-x86_64" "$asset_dir/linux" "Dakia_${version}_amd64.AppImage"
+  require_public_optional_r2_candidate "windows" "windows-x86_64" "$asset_dir/windows" "Dakia_${version}_x64-setup.exe"
+}
+
+require_public_optional_r2_candidate() {
+  local platform_name="$1" platform="$2" platform_dir="$3" updater_name="$4"
+  local signature_name="$updater_name.sig" manifest expected_url expected_signature expected_notes status
+  [[ -d "$platform_dir" ]] || return 0
+  manifest="$(mktemp)"
+  trap 'rm -f "$manifest"' RETURN
+  status="$(curl "${curl_options[@]}" --output "$manifest" --write-out '%{http_code}' \
+    "$download_origin/$platform_name/latest/latest.json?release-gate=$tag")"
+  [[ "$status" == "200" ]] || die "Public $platform_name updater manifest is not reachable (HTTP $status)."
+  node "$root_dir/scripts/updater-manifest.mjs" validate --platform "$platform" --manifest "$manifest" \
+    --tauri-config "$root_dir/apps/desktop/src-tauri/tauri.conf.json" >/dev/null ||
+    die "Public $platform_name updater manifest does not validate."
+  expected_url="$download_origin/$platform_name/$tag/$updater_name"
+  expected_signature="$(node -e 'process.stdout.write(require("node:fs").readFileSync(process.argv[1], "utf8").trim())' "$platform_dir/$signature_name")"
+  expected_notes="$(node -e 'process.stdout.write(require("node:fs").readFileSync(process.argv[1], "utf8").trim())' "$asset_dir/$notes")"
+  jq -e --arg version "$version" --arg url "$expected_url" --arg signature "$expected_signature" --arg notes "$expected_notes" --arg platform "$platform" \
+    '.version == $version and .notes == $notes and .platforms[$platform].url == $url and .platforms[$platform].signature == $signature' \
+    "$manifest" >/dev/null ||
+    die "Public $platform_name updater manifest is not the exact signed candidate for $tag."
+  rm -f "$manifest"
+  trap - RETURN
 }
 
 verify_public_github_assets() {
-  local verify_dir artifact status
+  local verify_dir artifact local_file status
   verify_dir="$(mktemp -d)"
   trap 'rm -rf "$verify_dir"' RETURN
-  for artifact in "$apple_dmg" "$apple_update" "$apple_signature" "$checksums"; do
+  for artifact in "${github_asset_names[@]}"; do
+    local_file="$(github_asset_local_path "$artifact")"
     status="$(curl "${curl_options[@]}" --output "$verify_dir/$artifact" --write-out '%{http_code}' \
       "https://github.com/$release_repo/releases/download/$tag/$artifact")"
     [[ "$status" == "200" ]] || die "Public GitHub asset is not reachable: $artifact (HTTP $status)."
-    cmp -s "$asset_dir/$artifact" "$verify_dir/$artifact" ||
+    cmp -s "$local_file" "$verify_dir/$artifact" ||
       die "Public GitHub asset bytes do not match local $artifact."
   done
   (cd "$verify_dir" && shasum -a 256 -c "$checksums") >/dev/null ||

--- a/scripts/publish-release-to-r2.sh
+++ b/scripts/publish-release-to-r2.sh
@@ -429,7 +429,165 @@ if ! public_copy_matches "$stable_dmg_key" "$apple_dmg"; then
 fi
 verify_public_copy "$stable_dmg_key" "$apple_dmg"
 
+# Optional hosted-runner assets use the Tauri v2 names documented in
+# updater-manifest.mjs. Each platform directory contains exactly its installer,
+# updater/installer, detached signature, and an ordered SHA256SUMS.txt covering
+# those two distributable files. Preflight every present directory before any
+# optional-platform mutation so one malformed platform cannot advance another.
+validate_optional_platform() {
+  local platform_name="$1" platform_dir="$2" installer_name="$3" updater_name="$4"
+  local installer="$platform_dir/$installer_name" updater="$platform_dir/$updater_name"
+  local signature="$updater.sig" platform_checksums="$platform_dir/SHA256SUMS.txt"
+  local expected_platform_checksums="$work_dir/$platform_name-SHA256SUMS.expected" artifact
+
+  for artifact in "$installer" "$updater" "$signature" "$platform_checksums"; do
+    if [[ ! -s "$artifact" ]]; then
+      echo "Missing or empty $platform_name release artifact: $artifact" >&2
+      exit 1
+    fi
+  done
+  if find "$platform_dir" -mindepth 1 -maxdepth 1 -type f ! -name "$installer_name" ! -name "$updater_name" ! -name "$updater_name.sig" ! -name SHA256SUMS.txt | grep -q .; then
+    echo "$platform_dir contains files outside the expected $platform_name release allowlist." >&2
+    exit 1
+  fi
+  (
+    cd "$platform_dir"
+    shasum -a 256 "$installer_name" "$updater_name.sig"
+  ) >"$expected_platform_checksums"
+  if ! cmp -s "$expected_platform_checksums" "$platform_checksums"; then
+    echo "$platform_name/SHA256SUMS.txt must exactly verify the updater installer and signature." >&2
+    exit 1
+  fi
+  node "$root_dir/scripts/verify-updater-signature.mjs" "$updater" "$signature" "$root_dir/apps/desktop/src-tauri/tauri.conf.json"
+}
+
+publish_optional_platform() {
+  local platform="$1" platform_name="$2" platform_dir="$3" installer_name="$4" updater_name="$5"
+  local installer_content_type="$6"
+  local installer="$platform_dir/$installer_name" updater="$platform_dir/$updater_name"
+  local signature="$updater.sig"
+  local platform_prefix="$platform_name/$tag" platform_manifest_key="$platform_name/latest/latest.json"
+  local installer_key="$platform_prefix/$installer_name" updater_key="$platform_prefix/$updater_name"
+  local signature_key="$updater_key.sig" current_manifest="$work_dir/$platform_name-latest-before.json"
+  local authenticated_current="$work_dir/$platform_name-latest-authenticated-before.json"
+  local candidate_manifest="$work_dir/$platform_name-latest-candidate.json"
+  local authenticated_after="$work_dir/$platform_name-latest-authenticated-after.json"
+  local public_after="$work_dir/$platform_name-latest-public-after.json"
+  local current_status current_etag existing_platform_version relation platform_resuming=false manifest_written=false
+
+  current_status="$(fetch_public_file "$platform_manifest_key" "$current_manifest")"
+  if [[ "$current_status" == "200" ]]; then
+    node "$root_dir/scripts/updater-manifest.mjs" validate --platform "$platform" --manifest "$current_manifest" --tauri-config "$root_dir/apps/desktop/src-tauri/tauri.conf.json"
+    if ! current_etag="$(
+      AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" AWS_DEFAULT_REGION="auto" \
+        aws s3api get-object --bucket "$bucket" --key "$platform_manifest_key" --endpoint-url "$r2_endpoint" \
+          --no-cli-pager --query ETag --output text "$authenticated_current"
+    )" || ! cmp -s "$current_manifest" "$authenticated_current"; then
+      echo "Authenticated and public $platform_name updater manifests must be the same current bytes." >&2
+      exit 1
+    fi
+    existing_platform_version="$(node -e 'process.stdout.write(JSON.parse(require("node:fs").readFileSync(process.argv[1], "utf8")).version)' "$current_manifest")"
+    relation="$(version_relation "$version" "$existing_platform_version")"
+    case "$relation" in
+      1) ;;
+      0)
+        node - "$current_manifest" "$version" "$download_origin/$updater_key" "$signature" "$notes_file" "$platform" <<'NODE'
+const { readFileSync } = require("node:fs");
+const [manifestPath, version, url, signaturePath, notesPath, platform] = process.argv.slice(2);
+const manifest = JSON.parse(readFileSync(manifestPath, "utf8"));
+const entry = manifest.platforms?.[platform];
+if (manifest.version !== version || entry?.url !== url || entry?.signature?.trim() !== readFileSync(signaturePath, "utf8").trim() || manifest.notes !== readFileSync(notesPath, "utf8").trim()) {
+  throw new Error(`The existing ${platform} latest.json is not an exact resume of this candidate.`);
+}
+NODE
+        platform_resuming=true
+        ;;
+      -1) echo "Refusing to publish $tag: public $platform_name updater version $existing_platform_version is newer." >&2; exit 1 ;;
+      *) echo "Unable to compare candidate $version with public $platform_name updater version $existing_platform_version." >&2; exit 1 ;;
+    esac
+  elif [[ "$current_status" != "404" ]]; then
+    echo "Public $platform_name updater manifest lookup failed (HTTP $current_status)." >&2
+    exit 1
+  fi
+
+  upload_immutable "$installer_key" "$installer" "$installer_content_type" "$installer_name" "$immutable_cache"
+  upload_immutable "$signature_key" "$signature" "text/plain; charset=utf-8" "$updater_name.sig" "$immutable_cache"
+  verify_public_copy "$installer_key" "$installer"
+  verify_public_copy "$signature_key" "$signature"
+
+  if [[ "$platform_resuming" == true ]]; then
+    echo "Verified exact $platform_name R2 resume for $tag."
+    return
+  fi
+
+  node "$root_dir/scripts/updater-manifest.mjs" create --platform "$platform" --version "$version" \
+    --pub-date "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" --notes-file "$notes_file" \
+    --url "$download_origin/$updater_key" --signature-file "$signature" \
+    --tauri-config "$root_dir/apps/desktop/src-tauri/tauri.conf.json" --output "$candidate_manifest"
+  node "$root_dir/scripts/updater-manifest.mjs" validate --platform "$platform" --manifest "$candidate_manifest" --tauri-config "$root_dir/apps/desktop/src-tauri/tauri.conf.json"
+  dakia_require_release_mutation_provenance "$root_dir" || exit 1
+  if [[ "$current_status" == "200" ]]; then
+    if AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" AWS_DEFAULT_REGION="auto" \
+      aws s3api put-object --bucket "$bucket" --key "$platform_manifest_key" --body "$candidate_manifest" \
+        --content-type "application/json; charset=utf-8" --content-disposition 'attachment; filename="latest.json"' \
+        --cache-control "no-store, max-age=0" --if-match "$current_etag" --endpoint-url "$r2_endpoint" --no-cli-pager >/dev/null; then
+      manifest_written=true
+    fi
+  elif AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" AWS_DEFAULT_REGION="auto" \
+    aws s3api put-object --bucket "$bucket" --key "$platform_manifest_key" --body "$candidate_manifest" \
+      --content-type "application/json; charset=utf-8" --content-disposition 'attachment; filename="latest.json"' \
+      --cache-control "no-store, max-age=0" --if-none-match "*" --endpoint-url "$r2_endpoint" --no-cli-pager >/dev/null; then
+    manifest_written=true
+  fi
+  if ! AWS_ACCESS_KEY_ID="$R2_ACCESS_KEY_ID" AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY" AWS_DEFAULT_REGION="auto" \
+    aws s3api get-object --bucket "$bucket" --key "$platform_manifest_key" --endpoint-url "$r2_endpoint" \
+      --no-cli-pager "$authenticated_after" >/dev/null || \
+    ! cmp -s "$candidate_manifest" "$authenticated_after" || \
+    ! public_manifest_converges_to_key "$platform_manifest_key" "$authenticated_after" "$public_after"; then
+    if [[ "$manifest_written" == true ]]; then
+      echo "Published $platform_name latest.json did not converge to the exact candidate." >&2
+    else
+      echo "Another publisher won $platform_name latest.json with a different candidate." >&2
+    fi
+    exit 1
+  fi
+  echo "Published signed $platform_name updater and installer for $tag."
+}
+
+public_manifest_converges_to_key() {
+  local key="$1" authoritative="$2" public_copy="$3" status attempt
+  for attempt in 1 2 3 4 5; do
+    if status="$(fetch_public_file "$key" "$public_copy")" && [[ "$status" == "200" ]] && cmp -s "$authoritative" "$public_copy"; then
+      return 0
+    fi
+    if [[ "$attempt" != "5" ]]; then sleep 1; fi
+  done
+  return 1
+}
+
+publish_optional_platforms() {
+  if [[ -d "$asset_dir/linux" ]]; then
+    validate_optional_platform "linux" "$asset_dir/linux" \
+      "Dakia_${version}_amd64.AppImage" "Dakia_${version}_amd64.AppImage"
+  fi
+  if [[ -d "$asset_dir/windows" ]]; then
+    validate_optional_platform "windows" "$asset_dir/windows" \
+      "Dakia_${version}_x64-setup.exe" "Dakia_${version}_x64-setup.exe"
+  fi
+  if [[ -d "$asset_dir/linux" ]]; then
+    publish_optional_platform "linux-x86_64" "linux" "$asset_dir/linux" \
+      "Dakia_${version}_amd64.AppImage" "Dakia_${version}_amd64.AppImage" \
+      "application/vnd.appimage"
+  fi
+  if [[ -d "$asset_dir/windows" ]]; then
+    publish_optional_platform "windows-x86_64" "windows" "$asset_dir/windows" \
+      "Dakia_${version}_x64-setup.exe" "Dakia_${version}_x64-setup.exe" \
+      "application/vnd.microsoft.portable-executable"
+  fi
+}
+
 if [[ "$resuming" == true ]]; then
+  publish_optional_platforms
   echo "Verified exact R2 resume for $tag; latest.json and stable DMG are current."
   exit 0
 fi
@@ -484,5 +642,6 @@ else
   exit 1
 fi
 
+publish_optional_platforms
 echo "Published signed Apple Silicon updater and download for $tag."
 echo "Updater manifest: $download_origin/$manifest_key"

--- a/scripts/publish-release-to-r2.sh
+++ b/scripts/publish-release-to-r2.sh
@@ -22,6 +22,10 @@ if ! command -v curl >/dev/null 2>&1; then
   echo "curl is required for anonymous public-artifact verification." >&2
   exit 1
 fi
+if [[ "$(uname -s)" != "Darwin" ]] && ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 is required for portable macOS artifact metadata verification." >&2
+  exit 1
+fi
 if [[ -z "${R2_ACCESS_KEY_ID:-}" || -z "${R2_SECRET_ACCESS_KEY:-}" || -z "${CLOUDFLARE_ACCOUNT_ID:-}" ]]; then
   echo "R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY, and CLOUDFLARE_ACCOUNT_ID are required." >&2
   exit 1
@@ -68,7 +72,6 @@ if ! cmp -s "$expected_checksums" "$checksums_file"; then
   exit 1
 fi
 
-"$root_dir/scripts/verify-macos-release-dmg.sh" "$apple_dmg"
 node "$root_dir/scripts/verify-updater-signature.mjs" "$apple_update" "$apple_signature" "$root_dir/apps/desktop/src-tauri/tauri.conf.json"
 
 updater_verify_dir="$work_dir/updater-archive"
@@ -79,8 +82,39 @@ if [[ ! -d "$updater_app" ]]; then
   echo "Updater archive is missing Dakia.app." >&2
   exit 1
 fi
-"$root_dir/scripts/verify-macos-release-app.sh" "$updater_app"
-updater_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$updater_app/Contents/Info.plist")"
+if [[ "$(uname -s)" == "Darwin" || -n "${DAKIA_TEST_PLIST_BUDDY:-}" ]]; then
+  "$root_dir/scripts/verify-macos-release-dmg.sh" "$apple_dmg"
+  "$root_dir/scripts/verify-macos-release-app.sh" "$updater_app"
+  plist_buddy="${DAKIA_TEST_PLIST_BUDDY:-/usr/libexec/PlistBuddy}"
+  updater_version="$("$plist_buddy" -c 'Print :CFBundleShortVersionString' "$updater_app/Contents/Info.plist")"
+else
+  ci_verification="${DAKIA_MACOS_CI_VERIFICATION:-}"
+  if [[ -z "$ci_verification" || ! -s "$ci_verification" ]]; then
+    echo "Non-macOS publication requires the macOS builder verification record." >&2
+    exit 1
+  fi
+  checksums_sha256="$(shasum -a 256 "$checksums_file" | awk '{ print $1 }')"
+  node - "$ci_verification" "$tag" "$(tr -d '\n' <"$source_marker")" "$checksums_sha256" <<'NODE'
+const { readFileSync } = require("node:fs");
+const [recordPath, tag, sourceCommit, checksumsSha256] = process.argv.slice(2);
+const record = JSON.parse(readFileSync(recordPath, "utf8"));
+if (
+  record.tag !== tag ||
+  record.source_commit !== sourceCommit ||
+  record.checksums_sha256 !== checksumsSha256 ||
+  record.verification !== "scripts/build-local-macos-release.sh completed"
+) {
+  throw new Error("macOS builder verification record does not bind the exact release assets.");
+}
+NODE
+  updater_version="$(python3 - "$updater_app/Contents/Info.plist" <<'PY'
+import plistlib
+import sys
+with open(sys.argv[1], "rb") as plist:
+    print(plistlib.load(plist)["CFBundleShortVersionString"])
+PY
+)"
+fi
 if [[ "$updater_version" != "$version" ]]; then
   echo "Updater app version '$updater_version' does not match '$version'." >&2
   exit 1
@@ -141,6 +175,7 @@ publication_state_key="macos/latest/publication.json"
 apple_dmg_key="$release_prefix/Dakia-Apple-Silicon.dmg"
 apple_update_key="$release_prefix/Dakia-aarch64.app.tar.gz"
 apple_signature_key="$apple_update_key.sig"
+apple_checksums_key="$release_prefix/SHA256SUMS.txt"
 curl_options=(--silent --show-error --location --proto '=https' --connect-timeout 15 --max-time 90 --retry 3 --retry-delay 1 --retry-max-time 180)
 
 fetch_public_file() {
@@ -368,11 +403,13 @@ immutable_cache="public, max-age=31536000, immutable"
 upload_immutable "$apple_dmg_key" "$apple_dmg" "application/x-apple-diskimage" "Dakia-$version-Apple-Silicon.dmg" "$immutable_cache"
 upload_immutable "$apple_update_key" "$apple_update" "application/gzip" "Dakia-$version-aarch64.app.tar.gz" "$immutable_cache"
 upload_immutable "$apple_signature_key" "$apple_signature" "text/plain; charset=utf-8" "Dakia-$version-aarch64.app.tar.gz.sig" "$immutable_cache"
+upload_immutable "$apple_checksums_key" "$checksums_file" "text/plain; charset=utf-8" "SHA256SUMS.txt" "$immutable_cache"
 
 # Anonymous downloads must match the signed source before either mutable object can move.
 verify_public_copy "$apple_update_key" "$apple_update"
 verify_public_copy "$apple_signature_key" "$apple_signature"
 verify_public_copy "$apple_dmg_key" "$apple_dmg"
+verify_public_copy "$apple_checksums_key" "$checksums_file"
 
 # Serialize the stable DMG + latest.json pair. If a run stops after claiming,
 # only the same tag/source may resume until latest.json reaches that version.
@@ -468,7 +505,7 @@ publish_optional_platform() {
   local signature="$updater.sig"
   local platform_prefix="$platform_name/$tag" platform_manifest_key="$platform_name/latest/latest.json"
   local installer_key="$platform_prefix/$installer_name" updater_key="$platform_prefix/$updater_name"
-  local signature_key="$updater_key.sig" current_manifest="$work_dir/$platform_name-latest-before.json"
+  local signature_key="$updater_key.sig" checksums_key="$platform_prefix/SHA256SUMS.txt" current_manifest="$work_dir/$platform_name-latest-before.json"
   local authenticated_current="$work_dir/$platform_name-latest-authenticated-before.json"
   local candidate_manifest="$work_dir/$platform_name-latest-candidate.json"
   local authenticated_after="$work_dir/$platform_name-latest-authenticated-after.json"
@@ -512,8 +549,10 @@ NODE
 
   upload_immutable "$installer_key" "$installer" "$installer_content_type" "$installer_name" "$immutable_cache"
   upload_immutable "$signature_key" "$signature" "text/plain; charset=utf-8" "$updater_name.sig" "$immutable_cache"
+  upload_immutable "$checksums_key" "$platform_dir/SHA256SUMS.txt" "text/plain; charset=utf-8" "SHA256SUMS.txt" "$immutable_cache"
   verify_public_copy "$installer_key" "$installer"
   verify_public_copy "$signature_key" "$signature"
+  verify_public_copy "$checksums_key" "$platform_dir/SHA256SUMS.txt"
 
   if [[ "$platform_resuming" == true ]]; then
     echo "Verified exact $platform_name R2 resume for $tag."

--- a/scripts/r2-release-hardening.node-test.mjs
+++ b/scripts/r2-release-hardening.node-test.mjs
@@ -25,10 +25,19 @@ test("R2 publisher remains valid Bash", () => {
 test("R2 publisher fails closed on tracked notes and exact checksums", () => {
   const script = source();
 
-  assert.match(script, /git -C "\$root_dir" ls-files --error-unmatch -- "docs\/releases\/\$tag\.md"/);
+  assert.match(
+    script,
+    /git -C "\$root_dir" ls-files --error-unmatch -- "docs\/releases\/\$tag\.md"/,
+  );
   assert.match(script, /cmp -s "\$release_notes_source" "\$notes_file"/);
-  assert.match(script, /Release notes asset does not exactly match tracked notes/);
-  assert.match(script, /shasum -a 256 "Dakia_\$\{version\}_aarch64\.dmg" "Dakia-aarch64\.app\.tar\.gz" "Dakia-aarch64\.app\.tar\.gz\.sig"/);
+  assert.match(
+    script,
+    /Release notes asset does not exactly match tracked notes/,
+  );
+  assert.match(
+    script,
+    /shasum -a 256 "Dakia_\$\{version\}_aarch64\.dmg" "Dakia-aarch64\.app\.tar\.gz" "Dakia-aarch64\.app\.tar\.gz\.sig"/,
+  );
   assert.match(script, /cmp -s "\$expected_checksums" "\$checksums_file"/);
   assert.match(script, /SHA256SUMS\.txt must exactly verify/);
   assert.match(script, /source-commit\.txt does not bind these artifacts/);
@@ -41,47 +50,95 @@ test("R2 publisher proves the signed tag is the exact remote main source", () =>
   assert.match(script, /git -C "\$root_dir" status --porcelain/);
   assert.match(script, /branch --show-current/);
   assert.match(script, /dakia_require_live_main_provenance "\$root_dir"/);
-  assert.match(script, /dakia_require_release_mutation_provenance "\$root_dir"/);
+  assert.match(
+    script,
+    /dakia_require_release_mutation_provenance "\$root_dir"/,
+  );
   assert.match(script, /dakia_require_expected_release_origin "\$root_dir"/);
   assert.match(script, /local-release-env\.sh/);
   assert.match(script, /refs\/tags\/\$tag\^\{commit\}/);
   assert.match(script, /git -C "\$root_dir" verify-tag "\$tag"/);
   assert.match(script, /git -C "\$root_dir" ls-remote --tags origin/);
-  assert.match(script, /Remote source tag \$tag must point exactly at origin\/main/);
+  assert.match(
+    script,
+    /Remote source tag \$tag must point exactly at origin\/main/,
+  );
 });
 
 test("R2 publisher rejects a rollback and permits only an exact manifest resume", () => {
   const script = source();
 
-  assert.match(script, /node "\$root_dir\/scripts\/updater-manifest\.mjs" validate --manifest "\$public_manifest"/);
-  assert.match(script, /relation="\$\(version_relation "\$version" "\$existing_version"\)"/);
-  assert.match(script, /0\) verify_current_manifest_is_candidate "\$public_manifest"; resuming=true/);
-  assert.match(script, /-1\) echo "Refusing to publish \$tag: public updater version \$existing_version is newer\./);
+  assert.match(
+    script,
+    /node "\$root_dir\/scripts\/updater-manifest\.mjs" validate --manifest "\$public_manifest"/,
+  );
+  assert.match(
+    script,
+    /relation="\$\(version_relation "\$version" "\$existing_version"\)"/,
+  );
+  assert.match(
+    script,
+    /0\) verify_current_manifest_is_candidate "\$public_manifest"; resuming=true/,
+  );
+  assert.match(
+    script,
+    /-1\) echo "Refusing to publish \$tag: public updater version \$existing_version is newer\./,
+  );
   assert.match(script, /entry\?\.url !== url/);
   assert.match(script, /entry\?\.signature\?\.trim\(\) !== readFileSync/);
   assert.match(script, /manifest\.notes !== readFileSync/);
   assert.match(script, /if \[\[ "\$resuming" == true \]\]; then[\s\S]*?exit 0/);
-  assert.match(script, /Verified exact R2 resume for \$tag; latest\.json and stable DMG are current/);
+  assert.match(
+    script,
+    /Verified exact R2 resume for \$tag; latest\.json and stable DMG are current/,
+  );
 });
 
 test("R2 publisher keeps latest last and repairs a CAS loser's stable alias to its winner", () => {
   const script = source();
 
-  assert.match(script, /--proto '=https' --connect-timeout 15 --max-time 90 --retry 3 --retry-delay 1 --retry-max-time 180/);
-  assert.match(script, /\[\[ "\$status" == "200" \]\] && cmp -s "\$source" "\$downloaded"/);
-  assert.match(script, /verify_public_copy "\$apple_update_key" "\$apple_update"/);
-  assert.match(script, /verify_public_copy "\$apple_signature_key" "\$apple_signature"/);
+  assert.match(
+    script,
+    /--proto '=https' --connect-timeout 15 --max-time 90 --retry 3 --retry-delay 1 --retry-max-time 180/,
+  );
+  assert.match(
+    script,
+    /\[\[ "\$status" == "200" \]\] && cmp -s "\$source" "\$downloaded"/,
+  );
+  assert.match(
+    script,
+    /verify_public_copy "\$apple_update_key" "\$apple_update"/,
+  );
+  assert.match(
+    script,
+    /verify_public_copy "\$apple_signature_key" "\$apple_signature"/,
+  );
   assert.match(script, /verify_public_copy "\$apple_dmg_key" "\$apple_dmg"/);
   assert.match(script, /verify_public_copy "\$stable_dmg_key" "\$apple_dmg"/);
   assert.match(script, /for attempt in 1 2 3 4 5/);
   assert.match(script, /cmp -s "\$authoritative" "\$public_copy"/);
 
   const immutableDmg = position(script, 'upload_immutable "$apple_dmg_key"');
-  const immutableUpdate = position(script, 'upload_immutable "$apple_update_key"');
-  const immutableSignature = position(script, 'upload_immutable "$apple_signature_key"');
-  const stableGate = position(script, "# Every artifact gate, including public stable-DMG byte verification");
-  const stable = script.indexOf('if ! public_copy_matches "$stable_dmg_key"', stableGate);
-  const stableVerify = script.indexOf('verify_public_copy "$stable_dmg_key" "$apple_dmg"', stableGate);
+  const immutableUpdate = position(
+    script,
+    'upload_immutable "$apple_update_key"',
+  );
+  const immutableSignature = position(
+    script,
+    'upload_immutable "$apple_signature_key"',
+  );
+  const stableGate = position(
+    script,
+    "# Every artifact gate, including public stable-DMG byte verification",
+  );
+  const stable = script.indexOf(
+    'if ! public_copy_matches "$stable_dmg_key"',
+    stableGate,
+  );
+  const stableVerify = script.indexOf(
+    'verify_public_copy "$stable_dmg_key" "$apple_dmg"',
+    stableGate,
+  );
   assert.notEqual(stable, -1);
   assert.notEqual(stableVerify, -1);
   const latest = position(
@@ -95,11 +152,23 @@ test("R2 publisher keeps latest last and repairs a CAS loser's stable alias to i
   const eligibility = position(script, 'case "$relation" in');
   assert.ok(eligibility < githubDraft);
   assert.ok(githubDraft < immutableDmg);
-  assert.match(script, /upload\(\)[\s\S]*?dakia_require_release_mutation_provenance "\$root_dir"/);
-  assert.match(script, /upload_immutable\(\)[\s\S]*?dakia_require_release_mutation_provenance "\$root_dir"/);
-  assert.match(script, /claim_publication_state\(\)[\s\S]*?dakia_require_release_mutation_provenance "\$root_dir"/);
+  assert.match(
+    script,
+    /upload\(\)[\s\S]*?dakia_require_release_mutation_provenance "\$root_dir"/,
+  );
+  assert.match(
+    script,
+    /upload_immutable\(\)[\s\S]*?dakia_require_release_mutation_provenance "\$root_dir"/,
+  );
+  assert.match(
+    script,
+    /claim_publication_state\(\)[\s\S]*?dakia_require_release_mutation_provenance "\$root_dir"/,
+  );
   assert.ok(
-    script.lastIndexOf('dakia_require_release_mutation_provenance "$root_dir"', latest) < latest,
+    script.lastIndexOf(
+      'dakia_require_release_mutation_provenance "$root_dir"',
+      latest,
+    ) < latest,
     "latest.json CAS must have its own final live-main gate",
   );
   const publicationClaim = script.lastIndexOf("\nclaim_publication_state\n");
@@ -118,29 +187,95 @@ test("R2 publisher keeps latest last and repairs a CAS loser's stable alias to i
     latest,
   );
   assert.match(script, /--if-match "\$manifest_etag"/);
-  assert.match(script, /publication_state_key="macos\/latest\/publication\.json"/);
-  assert.match(script, /Another incomplete release owns the mutable publication state/);
+  assert.match(
+    script,
+    /publication_state_key="macos\/latest\/publication\.json"/,
+  );
+  assert.match(
+    script,
+    /Another incomplete release owns the mutable publication state/,
+  );
   assert.match(script, /winner_dmg_key\(\)/);
   assert.match(script, /repair_stable_alias_to_manifest\(\)/);
   assert.match(script, /get_authenticated_manifest\(\)/);
-  assert.match(script, /aws s3api get-object --bucket "\$bucket" --key "\$manifest_key"/);
+  assert.match(
+    script,
+    /aws s3api get-object --bucket "\$bucket" --key "\$manifest_key"/,
+  );
   assert.match(script, /public_manifest_converges_to\(\)/);
   assert.match(script, /verify_public_copy "\$winner_key" "\$winner_dmg"/);
   assert.match(script, /verify_public_copy "\$stable_dmg_key" "\$winner_dmg"/);
-  assert.match(script, /get_authenticated_manifest "\$authoritative_winner_manifest"/);
-  assert.match(script, /validate --manifest "\$authoritative_winner_manifest"/);
-  assert.match(script, /public_manifest_converges_to "\$authoritative_winner_manifest" "\$published_manifest"/);
-  assert.match(script, /verify_current_manifest_is_candidate "\$authoritative_winner_manifest"/);
-  assert.match(script, /repair_stable_alias_to_manifest "\$authoritative_winner_manifest"/);
-  assert.match(script, /get_authenticated_manifest "\$after_repair_authenticated"/);
-  assert.match(script, /validate --manifest "\$after_repair_authenticated"/);
-  assert.match(script, /public_manifest_converges_to "\$after_repair_authenticated" "\$after_repair_public"/);
-  assert.match(script, /cmp -s "\$winner_manifest" "\$after_repair_authenticated"/);
-  assert.match(script, /Updater manifest changed while repairing the stable DMG alias/);
-  assert.match(script, /Another release won latest\.json; repaired its stable DMG alias and stopped/);
-  assert.match(script, /This is the final normal-path R2 mutation/);
-  assert.doesNotMatch(
-    script.slice(latest),
-    /upload "\$stable_dmg_key"/,
+  assert.match(
+    script,
+    /get_authenticated_manifest "\$authoritative_winner_manifest"/,
   );
+  assert.match(script, /validate --manifest "\$authoritative_winner_manifest"/);
+  assert.match(
+    script,
+    /public_manifest_converges_to "\$authoritative_winner_manifest" "\$published_manifest"/,
+  );
+  assert.match(
+    script,
+    /verify_current_manifest_is_candidate "\$authoritative_winner_manifest"/,
+  );
+  assert.match(
+    script,
+    /repair_stable_alias_to_manifest "\$authoritative_winner_manifest"/,
+  );
+  assert.match(
+    script,
+    /get_authenticated_manifest "\$after_repair_authenticated"/,
+  );
+  assert.match(script, /validate --manifest "\$after_repair_authenticated"/);
+  assert.match(
+    script,
+    /public_manifest_converges_to "\$after_repair_authenticated" "\$after_repair_public"/,
+  );
+  assert.match(
+    script,
+    /cmp -s "\$winner_manifest" "\$after_repair_authenticated"/,
+  );
+  assert.match(
+    script,
+    /Updater manifest changed while repairing the stable DMG alias/,
+  );
+  assert.match(
+    script,
+    /Another release won latest\.json; repaired its stable DMG alias and stopped/,
+  );
+  assert.match(script, /This is the final normal-path R2 mutation/);
+  assert.doesNotMatch(script.slice(latest), /upload "\$stable_dmg_key"/);
+});
+
+test("R2 publisher gates optional Linux and Windows feeds behind immutable artifacts", () => {
+  const script = source();
+
+  assert.match(script, /\[\[ -d "\$asset_dir\/linux" \]\]/);
+  assert.match(script, /\[\[ -d "\$asset_dir\/windows" \]\]/);
+  assert.match(script, /Dakia_\$\{version\}_amd64\.AppImage/);
+  assert.match(script, /Dakia_\$\{version\}_x64-setup\.exe/);
+  assert.match(script, /--platform "\$platform"/);
+  assert.match(script, /--if-none-match "\*"/);
+  assert.match(script, /--if-match "\$current_etag"/);
+
+  const optionalFunction = position(script, "publish_optional_platform() {");
+  const immutableInstaller = script.indexOf(
+    'upload_immutable "$installer_key"',
+    optionalFunction,
+  );
+  const verifySignature = script.indexOf(
+    'verify_public_copy "$signature_key"',
+    optionalFunction,
+  );
+  const createManifest = script.indexOf(
+    'updater-manifest.mjs" create --platform "$platform"',
+    optionalFunction,
+  );
+  const writeManifest = script.indexOf(
+    'aws s3api put-object --bucket "$bucket" --key "$platform_manifest_key" --body "$candidate_manifest"',
+    optionalFunction,
+  );
+  assert.ok(immutableInstaller < verifySignature);
+  assert.ok(verifySignature < createManifest);
+  assert.ok(createManifest < writeManifest);
 });

--- a/scripts/r2-release-hardening.node-test.mjs
+++ b/scripts/r2-release-hardening.node-test.mjs
@@ -22,6 +22,18 @@ test("R2 publisher remains valid Bash", () => {
   assert.equal(result.status, 0, result.stderr);
 });
 
+test("non-macOS publication requires an exact macOS builder verification record", () => {
+  const script = source();
+  assert.match(script, /DAKIA_MACOS_CI_VERIFICATION/);
+  assert.match(
+    script,
+    /record\.verification !== "scripts\/build-local-macos-release\.sh completed"/,
+  );
+  assert.match(script, /record\.tag !== tag/);
+  assert.match(script, /record\.source_commit !== sourceCommit/);
+  assert.match(script, /record\.checksums_sha256 !== checksumsSha256/);
+});
+
 test("R2 publisher fails closed on tracked notes and exact checksums", () => {
   const script = source();
 
@@ -114,6 +126,14 @@ test("R2 publisher keeps latest last and repairs a CAS loser's stable alias to i
     /verify_public_copy "\$apple_signature_key" "\$apple_signature"/,
   );
   assert.match(script, /verify_public_copy "\$apple_dmg_key" "\$apple_dmg"/);
+  assert.match(
+    script,
+    /upload_immutable "\$apple_checksums_key" "\$checksums_file"/,
+  );
+  assert.match(
+    script,
+    /verify_public_copy "\$apple_checksums_key" "\$checksums_file"/,
+  );
   assert.match(script, /verify_public_copy "\$stable_dmg_key" "\$apple_dmg"/);
   assert.match(script, /for attempt in 1 2 3 4 5/);
   assert.match(script, /cmp -s "\$authoritative" "\$public_copy"/);
@@ -267,6 +287,14 @@ test("R2 publisher gates optional Linux and Windows feeds behind immutable artif
     'verify_public_copy "$signature_key"',
     optionalFunction,
   );
+  const uploadChecksums = script.indexOf(
+    'upload_immutable "$checksums_key" "$platform_dir/SHA256SUMS.txt"',
+    optionalFunction,
+  );
+  const verifyChecksums = script.indexOf(
+    'verify_public_copy "$checksums_key" "$platform_dir/SHA256SUMS.txt"',
+    optionalFunction,
+  );
   const createManifest = script.indexOf(
     'updater-manifest.mjs" create --platform "$platform"',
     optionalFunction,
@@ -275,7 +303,9 @@ test("R2 publisher gates optional Linux and Windows feeds behind immutable artif
     'aws s3api put-object --bucket "$bucket" --key "$platform_manifest_key" --body "$candidate_manifest"',
     optionalFunction,
   );
-  assert.ok(immutableInstaller < verifySignature);
-  assert.ok(verifySignature < createManifest);
+  assert.ok(immutableInstaller < uploadChecksums);
+  assert.ok(uploadChecksums < verifySignature);
+  assert.ok(verifySignature < verifyChecksums);
+  assert.ok(verifyChecksums < createManifest);
   assert.ok(createManifest < writeManifest);
 });

--- a/scripts/r2-release-state.behavior.node-test.mjs
+++ b/scripts/r2-release-state.behavior.node-test.mjs
@@ -251,6 +251,16 @@ if [[ -f "\$source" ]]; then cp "\$source" "\$output"; printf '200'; else : >"\$
   );
 
   executable(
+    join(bin, "jq"),
+    `#!/usr/bin/env node
+const { readFileSync } = require("node:fs");
+const path = process.argv.at(-1);
+const value = JSON.parse(readFileSync(path, "utf8")).version ?? "";
+process.stdout.write(value + "\\n");
+`,
+  );
+
+  executable(
     join(bin, "tar"),
     `#!/bin/bash
 set -euo pipefail
@@ -440,9 +450,14 @@ test("a moved live main stops R2 before its first post-draft write", () => {
       "macos/latest/Dakia-Apple-Silicon.dmg",
       "dmg-0.4.0\n",
     );
-    const result = run(harness, release, "normal", { MOCK_LIVE_MAIN_MOVES_AT: "2" });
+    const result = run(harness, release, "normal", {
+      MOCK_LIVE_MAIN_MOVES_AT: "2",
+    });
     assert.notEqual(result.status, 0);
-    assert.match(result.stderr, /HEAD, cached origin\/main, and live origin\/main must all match/);
+    assert.match(
+      result.stderr,
+      /HEAD, cached origin\/main, and live origin\/main must all match/,
+    );
     assert.equal(currentVersion(harness.store), "0.4.0");
     assert.equal(existsSync(objectPath(harness.store, "macos/v0.4.1")), false);
   } finally {
@@ -503,8 +518,14 @@ test("a publication-state read arms a moved main before its adjacent CAS", () =>
       MOCK_ARM_LIVE_MAIN_AFTER_GET_KEY: stateKey,
     });
     expectLiveMainStop(result);
-    assert.equal(readFileSync(objectPath(harness.store, stateKey), "utf8"), priorState);
-    assert.doesNotMatch(readFileSync(harness.awsPutLog, "utf8"), /^macos\/latest\/publication\.json$/m);
+    assert.equal(
+      readFileSync(objectPath(harness.store, stateKey), "utf8"),
+      priorState,
+    );
+    assert.doesNotMatch(
+      readFileSync(harness.awsPutLog, "utf8"),
+      /^macos\/latest\/publication\.json$/m,
+    );
   } finally {
     rmSync(harness.fixture, { recursive: true, force: true });
   }
@@ -522,30 +543,59 @@ for (const {
     name: "the first immutable conditional create",
     moveAt: "2",
     verify: (harness) => {
-      assert.equal(existsSync(objectPath(harness.store, "macos/v0.4.1")), false);
+      assert.equal(
+        existsSync(objectPath(harness.store, "macos/v0.4.1")),
+        false,
+      );
     },
   },
   {
     name: "the second immutable conditional create",
     moveAt: "3",
     verify: (harness) => {
-      assert.equal(existsSync(objectPath(harness.store, "macos/v0.4.1/Dakia-Apple-Silicon.dmg")), true);
-      assert.equal(existsSync(objectPath(harness.store, "macos/v0.4.1/Dakia-aarch64.app.tar.gz")), false);
+      assert.equal(
+        existsSync(
+          objectPath(harness.store, "macos/v0.4.1/Dakia-Apple-Silicon.dmg"),
+        ),
+        true,
+      );
+      assert.equal(
+        existsSync(
+          objectPath(harness.store, "macos/v0.4.1/Dakia-aarch64.app.tar.gz"),
+        ),
+        false,
+      );
     },
   },
   {
     name: "the third immutable conditional create",
     moveAt: "4",
     verify: (harness) => {
-      assert.equal(existsSync(objectPath(harness.store, "macos/v0.4.1/Dakia-aarch64.app.tar.gz")), true);
-      assert.equal(existsSync(objectPath(harness.store, "macos/v0.4.1/Dakia-aarch64.app.tar.gz.sig")), false);
+      assert.equal(
+        existsSync(
+          objectPath(harness.store, "macos/v0.4.1/Dakia-aarch64.app.tar.gz"),
+        ),
+        true,
+      );
+      assert.equal(
+        existsSync(
+          objectPath(
+            harness.store,
+            "macos/v0.4.1/Dakia-aarch64.app.tar.gz.sig",
+          ),
+        ),
+        false,
+      );
     },
   },
   {
     name: "the publication-state create",
     moveAt: "5",
     verify: (harness) => {
-      assert.equal(existsSync(objectPath(harness.store, "macos/latest/publication.json")), false);
+      assert.equal(
+        existsSync(objectPath(harness.store, "macos/latest/publication.json")),
+        false,
+      );
     },
   },
   {
@@ -560,7 +610,10 @@ for (const {
     },
     verify: (harness) => {
       assert.equal(
-        readFileSync(objectPath(harness.store, "macos/latest/publication.json"), "utf8"),
+        readFileSync(
+          objectPath(harness.store, "macos/latest/publication.json"),
+          "utf8",
+        ),
         `${JSON.stringify({ tag: "v0.4.0", version: "0.4.0", source: "prior" })}\n`,
       );
     },
@@ -570,7 +623,10 @@ for (const {
     moveAt: "6",
     verify: (harness) => {
       assert.equal(
-        readFileSync(objectPath(harness.store, "macos/latest/Dakia-Apple-Silicon.dmg"), "utf8"),
+        readFileSync(
+          objectPath(harness.store, "macos/latest/Dakia-Apple-Silicon.dmg"),
+          "utf8",
+        ),
         "dmg-0.4.0\n",
       );
     },
@@ -581,7 +637,10 @@ for (const {
     verify: (harness) => {
       assert.equal(currentVersion(harness.store), "0.4.0");
       assert.equal(
-        readFileSync(objectPath(harness.store, "macos/latest/Dakia-Apple-Silicon.dmg"), "utf8"),
+        readFileSync(
+          objectPath(harness.store, "macos/latest/Dakia-Apple-Silicon.dmg"),
+          "utf8",
+        ),
         "dmg-0.4.1\n",
       );
     },
@@ -623,7 +682,10 @@ test("a call-indexed live-main drift blocks the winner-repair stable-DMG copy", 
     expectLiveMainStop(result);
     assert.equal(currentVersion(harness.store), "0.4.2");
     assert.equal(
-      readFileSync(objectPath(harness.store, "macos/latest/Dakia-Apple-Silicon.dmg"), "utf8"),
+      readFileSync(
+        objectPath(harness.store, "macos/latest/Dakia-Apple-Silicon.dmg"),
+        "utf8",
+      ),
       "dmg-0.4.1\n",
     );
   } finally {

--- a/scripts/r2-release-state.behavior.node-test.mjs
+++ b/scripts/r2-release-state.behavior.node-test.mjs
@@ -589,8 +589,27 @@ for (const {
     },
   },
   {
-    name: "the publication-state create",
+    name: "the fourth immutable conditional create",
     moveAt: "5",
+    verify: (harness) => {
+      assert.equal(
+        existsSync(
+          objectPath(
+            harness.store,
+            "macos/v0.4.1/Dakia-aarch64.app.tar.gz.sig",
+          ),
+        ),
+        true,
+      );
+      assert.equal(
+        existsSync(objectPath(harness.store, "macos/v0.4.1/SHA256SUMS.txt")),
+        false,
+      );
+    },
+  },
+  {
+    name: "the publication-state create",
+    moveAt: "6",
     verify: (harness) => {
       assert.equal(
         existsSync(objectPath(harness.store, "macos/latest/publication.json")),
@@ -600,7 +619,7 @@ for (const {
   },
   {
     name: "the publication-state CAS",
-    moveAt: "5",
+    moveAt: "6",
     before: (harness) => {
       putInitial(
         harness.store,
@@ -620,7 +639,7 @@ for (const {
   },
   {
     name: "the normal stable-DMG copy",
-    moveAt: "6",
+    moveAt: "7",
     verify: (harness) => {
       assert.equal(
         readFileSync(
@@ -633,7 +652,7 @@ for (const {
   },
   {
     name: "the final latest.json CAS",
-    moveAt: "7",
+    moveAt: "8",
     verify: (harness) => {
       assert.equal(currentVersion(harness.store), "0.4.0");
       assert.equal(
@@ -675,7 +694,7 @@ test("a call-indexed live-main drift blocks the winner-repair stable-DMG copy", 
     writeFileSync(winnerManifest, manifest("0.4.2"));
     writeFileSync(winnerDmg, "dmg-0.4.2\n");
     const result = run(harness, release, "different-candidate-wins", {
-      MOCK_LIVE_MAIN_MOVES_AT: "8",
+      MOCK_LIVE_MAIN_MOVES_AT: "9",
       MOCK_WINNER_DMG: winnerDmg,
       MOCK_WINNER_MANIFEST: winnerManifest,
     });

--- a/scripts/updater-manifest.mjs
+++ b/scripts/updater-manifest.mjs
@@ -5,7 +5,26 @@ import { pathToFileURL } from "node:url";
 
 const SEMVER =
   /^(?:v)?(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)\.(?:0|[1-9]\d*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$/;
-const PLATFORM = "darwin-aarch64";
+const DEFAULT_PLATFORM = "darwin-aarch64";
+
+// Tauri v2 updater bundle naming used by both manifest validation and the R2
+// publisher. macOS retains its historical fixed archive name. With this repo's
+// `createUpdaterArtifacts: true`, Tauri v2 signs the installers themselves:
+// `Dakia_<version>_amd64.AppImage` and `Dakia_<version>_x64-setup.exe`.
+export const PLATFORM_ARTIFACTS = Object.freeze({
+  "darwin-aarch64": {
+    directory: "macos",
+    updaterPattern: /^Dakia-aarch64\.app\.tar\.gz$/,
+  },
+  "linux-x86_64": {
+    directory: "linux",
+    updaterPattern: /^Dakia_(.+)_amd64\.AppImage$/,
+  },
+  "windows-x86_64": {
+    directory: "windows",
+    updaterPattern: /^Dakia_(.+)_x64-setup\.exe$/,
+  },
+});
 
 function isTauriMinisignSignature(value) {
   if (
@@ -63,7 +82,11 @@ function minisignKeyId(value, label, marker, recordLength, lineCount) {
   return key.subarray(2, 10).toString("hex");
 }
 
-export function validateManifest(manifest, updaterPublicKey) {
+export function validateManifest(
+  manifest,
+  updaterPublicKey,
+  platform = DEFAULT_PLATFORM,
+) {
   if (!manifest || typeof manifest !== "object") {
     throw new Error("Updater manifest must be a JSON object.");
   }
@@ -91,29 +114,51 @@ export function validateManifest(manifest, updaterPublicKey) {
     throw new Error("Updater notes must be a string.");
   }
 
+  if (!Object.hasOwn(PLATFORM_ARTIFACTS, platform)) {
+    throw new Error(`Unsupported updater platform: ${platform}.`);
+  }
   const keys = Object.keys(manifest.platforms);
-  if (keys.length !== 1 || keys[0] !== PLATFORM) {
-    throw new Error(`Updater platforms must contain only ${PLATFORM}.`);
+  if (keys.length !== 1 || keys[0] !== platform) {
+    throw new Error(`Updater platforms must contain only ${platform}.`);
   }
 
-  const entry = manifest.platforms[PLATFORM];
+  const entry = manifest.platforms[platform];
   if (!entry || typeof entry !== "object") {
-    throw new Error(`Missing updater platform ${PLATFORM}.`);
+    throw new Error(`Missing updater platform ${platform}.`);
   }
   if (!isTauriMinisignSignature(entry.signature?.trim())) {
-    throw new Error(`Invalid updater signature for ${PLATFORM}.`);
+    throw new Error(`Invalid updater signature for ${platform}.`);
   }
   let url;
   try {
     url = new URL(entry.url);
   } catch {
-    throw new Error(`Invalid updater URL for ${PLATFORM}.`);
+    throw new Error(`Invalid updater URL for ${platform}.`);
   }
   if (url.protocol !== "https:") {
-    throw new Error(`Updater URL for ${PLATFORM} must use HTTPS.`);
+    throw new Error(`Updater URL for ${platform} must use HTTPS.`);
   }
-  if (!url.pathname.endsWith("/Dakia-aarch64.app.tar.gz")) {
-    throw new Error(`Updater URL architecture mismatch for ${PLATFORM}.`);
+  const artifact = PLATFORM_ARTIFACTS[platform];
+  const manifestVersion = manifest.version.replace(/^v/, "");
+  const pathMatch =
+    platform === DEFAULT_PLATFORM
+      ? url.pathname.endsWith("/Dakia-aarch64.app.tar.gz")
+      : url.origin === "https://downloads.dakiamail.com" &&
+        url.pathname.match(
+          new RegExp(
+            `^/${artifact.directory}/v([^/]+)/(${artifact.updaterPattern.source.slice(1, -1)})$`,
+          ),
+        );
+  const artifactVersion = Array.isArray(pathMatch)
+    ? pathMatch[2]?.match(artifact.updaterPattern)?.[1]
+    : undefined;
+  if (
+    !pathMatch ||
+    (Array.isArray(pathMatch) &&
+      (pathMatch[1] !== manifestVersion ||
+        (artifactVersion !== undefined && artifactVersion !== manifestVersion)))
+  ) {
+    throw new Error(`Updater URL architecture mismatch for ${platform}.`);
   }
   if (
     updaterPublicKey !== undefined &&
@@ -128,27 +173,39 @@ export function validateManifest(manifest, updaterPublicKey) {
   return manifest;
 }
 
-export function buildManifest({
-  version,
-  pubDate,
-  notes,
-  aarch64Url,
-  aarch64Signature,
-  updaterPublicKey,
-}) {
+export function buildManifest(options) {
+  const {
+    version,
+    pubDate,
+    notes,
+    aarch64Url,
+    aarch64Signature,
+    platform = DEFAULT_PLATFORM,
+    url,
+    signature,
+    updaterPublicKey,
+  } = options;
+  const explicitPlatform = Object.hasOwn(options, "platform");
+  const entryUrl =
+    platform === DEFAULT_PLATFORM && !explicitPlatform ? aarch64Url : url;
+  const entrySignature =
+    platform === DEFAULT_PLATFORM && !explicitPlatform
+      ? aarch64Signature
+      : signature;
   return validateManifest(
     {
       version,
       pub_date: pubDate,
       notes,
       platforms: {
-        "darwin-aarch64": {
-          url: aarch64Url,
-          signature: aarch64Signature.trim(),
+        [platform]: {
+          url: entryUrl,
+          signature: entrySignature.trim(),
         },
       },
     },
     updaterPublicKey,
+    platform,
   );
 }
 
@@ -173,7 +230,11 @@ async function main() {
     const tauriConfig = options["tauri-config"]
       ? JSON.parse(await readFile(options["tauri-config"], "utf8"))
       : undefined;
-    validateManifest(manifest, tauriConfig?.plugins?.updater?.pubkey);
+    validateManifest(
+      manifest,
+      tauriConfig?.plugins?.updater?.pubkey,
+      options.platform ?? DEFAULT_PLATFORM,
+    );
     process.stdout.write(`Valid updater manifest: ${options.manifest}\n`);
     return;
   }
@@ -192,7 +253,14 @@ async function main() {
     pubDate: options["pub-date"],
     notes,
     aarch64Url: options["aarch64-url"],
-    aarch64Signature: await readFile(options["aarch64-signature-file"], "utf8"),
+    aarch64Signature: options["aarch64-signature-file"]
+      ? await readFile(options["aarch64-signature-file"], "utf8")
+      : undefined,
+    ...(options.platform ? { platform: options.platform } : {}),
+    url: options.url,
+    signature: options["signature-file"]
+      ? await readFile(options["signature-file"], "utf8")
+      : undefined,
     updaterPublicKey: tauriConfig?.plugins?.updater?.pubkey,
   });
   await writeFile(options.output, `${JSON.stringify(manifest, null, 2)}\n`);

--- a/scripts/updater-manifest.node-test.mjs
+++ b/scripts/updater-manifest.node-test.mjs
@@ -1,6 +1,11 @@
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import test from "node:test";
-import { buildManifest, validateManifest } from "./updater-manifest.mjs";
+import {
+  buildManifest,
+  PLATFORM_ARTIFACTS,
+  validateManifest,
+} from "./updater-manifest.mjs";
 
 const keyId = Buffer.from("0123456789abcdef", "hex");
 const signatureRecord = Buffer.concat([
@@ -41,6 +46,18 @@ test("builds the Apple Silicon updater platform entry", () => {
     encodedSignature,
   );
   assert.deepEqual(Object.keys(manifest.platforms), ["darwin-aarch64"]);
+});
+
+test("accepts explicit Darwin with generic platform fields", () => {
+  const manifest = buildManifest({
+    version: input.version,
+    pubDate: input.pubDate,
+    notes: input.notes,
+    platform: "darwin-aarch64",
+    url: input.aarch64Url,
+    signature: input.aarch64Signature,
+  });
+  assert.equal(manifest.platforms["darwin-aarch64"].url, input.aarch64Url);
 });
 
 test("rejects architecture swaps", () => {
@@ -127,5 +144,131 @@ test("rejects truncated or mistyped minisign records", () => {
   assert.throws(
     () => buildManifest({ ...input, updaterPublicKey: mistypedPublicKey }),
     /Invalid updater public key/,
+  );
+});
+
+test("accepts Linux and Windows single-platform updater entries", () => {
+  for (const [platform, url] of [
+    [
+      "linux-x86_64",
+      "https://downloads.dakiamail.com/linux/v0.2.7/Dakia_0.2.7_amd64.AppImage",
+    ],
+    [
+      "windows-x86_64",
+      "https://downloads.dakiamail.com/windows/v0.2.7/Dakia_0.2.7_x64-setup.exe",
+    ],
+  ]) {
+    const manifest = buildManifest({
+      ...input,
+      platform,
+      url,
+      signature: encodedSignature,
+      updaterPublicKey: matchingPublicKey,
+    });
+    assert.deepEqual(Object.keys(manifest.platforms), [platform]);
+    assert.doesNotThrow(() =>
+      validateManifest(manifest, matchingPublicKey, platform),
+    );
+  }
+});
+
+test("rejects cross-platform and foreign updater artifact URLs", () => {
+  const darwinManifest = buildManifest(input);
+  darwinManifest.platforms["darwin-aarch64"].url =
+    "https://downloads.dakiamail.com/linux/v0.2.7/Dakia_0.2.7_amd64.AppImage";
+  assert.throws(
+    () => validateManifest(darwinManifest),
+    /architecture mismatch for darwin-aarch64/,
+  );
+
+  const linuxManifest = buildManifest({
+    ...input,
+    platform: "linux-x86_64",
+    url: "https://downloads.dakiamail.com/linux/v0.2.7/Dakia_0.2.7_amd64.AppImage",
+    signature: encodedSignature,
+  });
+  linuxManifest.platforms["linux-x86_64"].url =
+    "https://downloads.dakiamail.com/macos/v0.2.7/Dakia-aarch64.app.tar.gz";
+  assert.throws(
+    () => validateManifest(linuxManifest, undefined, "linux-x86_64"),
+    /architecture mismatch for linux-x86_64/,
+  );
+
+  for (const [platform, url] of [
+    [
+      "linux-x86_64",
+      "https://downloads.dakiamail.com/linux/v0.2.7/Dakia_0.2.7_amd64.deb",
+    ],
+    [
+      "windows-x86_64",
+      "https://downloads.dakiamail.com/windows/v0.2.7/Dakia_0.2.7_x64.msi",
+    ],
+    [
+      "linux-x86_64",
+      "https://example.com/linux/v0.2.7/Dakia_0.2.7_amd64.AppImage",
+    ],
+  ]) {
+    assert.throws(
+      () =>
+        buildManifest({
+          ...input,
+          platform,
+          url,
+          signature: encodedSignature,
+        }),
+      new RegExp(`architecture mismatch for ${platform}`),
+    );
+  }
+});
+
+test("verifies signatures against the embedded key for every platform", () => {
+  const differentRecord = Buffer.from(publicKeyRecord, "base64");
+  differentRecord[2] ^= 1;
+  const differentPublicKey = Buffer.from(
+    [
+      "untrusted comment: minisign public key",
+      differentRecord.toString("base64"),
+    ].join("\n"),
+  ).toString("base64");
+
+  for (const [platform, url] of [
+    [
+      "linux-x86_64",
+      "https://downloads.dakiamail.com/linux/v0.2.7/Dakia_0.2.7_amd64.AppImage",
+    ],
+    [
+      "windows-x86_64",
+      "https://downloads.dakiamail.com/windows/v0.2.7/Dakia_0.2.7_x64-setup.exe",
+    ],
+  ]) {
+    assert.throws(
+      () =>
+        buildManifest({
+          ...input,
+          platform,
+          url,
+          signature: encodedSignature,
+          updaterPublicKey: differentPublicKey,
+        }),
+      /does not match the embedded public key/,
+    );
+  }
+});
+
+test("hosted updater names match the configured Tauri v2 artifact mode", () => {
+  const tauriConfig = JSON.parse(
+    readFileSync(
+      new URL("../apps/desktop/src-tauri/tauri.conf.json", import.meta.url),
+      "utf8",
+    ),
+  );
+  assert.equal(tauriConfig.bundle.createUpdaterArtifacts, true);
+  assert.match(
+    "Dakia_0.2.7_amd64.AppImage",
+    PLATFORM_ARTIFACTS["linux-x86_64"].updaterPattern,
+  );
+  assert.match(
+    "Dakia_0.2.7_x64-setup.exe",
+    PLATFORM_ARTIFACTS["windows-x86_64"].updaterPattern,
   );
 });


### PR DESCRIPTION
## Summary
Replaces the deleted local-Codex nightly release flow with a GitHub-hosted `production-release` workflow (nightly 02:17 UTC + manual dispatch) that ships macOS Apple Silicon (signed/notarized), Linux x64 AppImage, and Windows x64 NSIS from the exact live `origin/main` commit.

## Pipeline (per run)
- **decide** — no-op check against the public updater feed; zero-cost nights
- **prepare** — bumps the next patch version + writes `docs/releases/vX.Y.Z.md` only when needed
- **validate** — full source suite (fmt/clippy/tests/TS/frontend) with the shared R2 sccache; gates every build, including Apple Silicon
- **build** — 3-job matrix with sccache-R2 per-OS prefixes + npm/cargo/ONNX caches (cost control); macOS runs the repo's hardened `release:build` (sign → notarize → staple → DMG → updater archive); Linux/Windows produce AppImage/NSIS + re-signed updater artifacts
- **publish** — SSH-signed tag → verified GitHub draft → R2 (immutable versioned objects + per-OS `latest.json`) → public GitHub Release, all fail-closed
- **verify-public** — anonymous end-to-end checks (feeds, checksums, signatures, tag provenance, GitHub assets, R2 byte-compare) before any success claim

## Foundation changes
- `scripts/updater-manifest.mjs` generalized to per-platform feeds (`darwin-aarch64` default preserved byte-for-byte)
- `scripts/publish-release-to-r2.sh`, `prepare-github-release-draft.sh`, `publish-github-release.sh` extended for optional Linux/Windows assets with the repo's exact-match/no-clobber discipline
- `scripts/prepare-nightly-release.mjs` restored (from 67ed911) with `--dry-run` and internal-subject filtering
- Docs rewritten to describe the hosted path as primary, local-Mac flow as fallback

## Verification
129 release-script tests pass (124 pass / 0 fail / 5 pre-existing skips); YAML validated; `git diff --check` clean. Secrets are scoped to the `production-release` environment (branch-protected to main); cache creds via `sccache-r2`.

Prepares **v0.4.3** (user-facing notes; internal CI/umbrella commits excluded from notes).