### PR TITLE
Decode encoded attachment filenames

### DIFF
--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -91,6 +91,7 @@ const MAX_IMAP_RESPONSE_LITERALS: usize = 64;
 const MAX_IMAP_RESPONSE_LITERAL_BYTES: usize = 100 * 1024 * 1024;
 const MAX_ATTACHMENT_COUNT: usize = 50;
 const MIME_CONTENT_UNDECODABLE: &str = "mime_content_undecodable";
+const INVALID_FILENAME_PARAMETER_MARKER: &str = "x-dakia-invalid-filename";
 const MAX_OUTBOUND_ATTACHMENT_BYTES: usize = 25 * 1024 * 1024;
 const MAX_OUTBOUND_ATTACHMENT_TOTAL_BYTES: usize = 50 * 1024 * 1024;
 /// Existing databases are enriched gradually during ordinary catalogue syncs.
@@ -2801,7 +2802,14 @@ impl MimePart {
     fn is_attachment_candidate(&self) -> bool {
         self.is_explicit_attachment()
             || self.filename().is_some()
+            || self.has_invalid_filename_parameter()
             || (self.is_leaf() && !self.is_text_body())
+    }
+    fn has_invalid_filename_parameter(&self) -> bool {
+        self.params.contains_key(INVALID_FILENAME_PARAMETER_MARKER)
+            || self
+                .disposition_params
+                .contains_key(INVALID_FILENAME_PARAMETER_MARKER)
     }
     fn is_attached_container(&self) -> bool {
         !self.is_leaf() && self.is_attachment_candidate()
@@ -3016,7 +3024,7 @@ fn bodystructure_params(value: Option<&[ImapBodyValue]>) -> BTreeMap<String, Str
         }
     }
     // BODYSTRUCTURE exposes RFC 2231 extended parameters verbatim on many
-    // providers.  Normalize the common single-value form so targeted
+    // providers. Normalize the common single-value form so targeted
     // attachment metadata agrees with the complete MIME parser.
     for (extended, plain) in [("filename*", "filename"), ("name*", "name")] {
         let Some(value) = params.get(extended) else {
@@ -3034,7 +3042,131 @@ fn bodystructure_params(value: Option<&[ImapBodyValue]>) -> BTreeMap<String, Str
             }
         }
     }
+    // RFC 2047 encoded words are nonstandard in MIME parameters, but common
+    // in IMAP BODYSTRUCTURE responses. Decode validated encoded-word values,
+    // including safe literal suffixes, before the filename is selected and
+    // sanitized.
+    for parameter in ["filename", "name"] {
+        normalize_bodystructure_rfc2047_parameter(&mut params, parameter);
+    }
     params
+}
+
+fn normalize_bodystructure_rfc2047_parameter(
+    params: &mut BTreeMap<String, String>,
+    parameter: &str,
+) {
+    let Some(value) = params.get(parameter).cloned() else {
+        return;
+    };
+    if !value.contains("=?") {
+        return;
+    }
+    if let Some(decoded) = decode_rfc2047_filename(&value) {
+        params.insert(parameter.to_owned(), decoded);
+    } else {
+        // Do not expose malformed transport syntax as a plausible filename.
+        // Keep separate evidence that a filename was supplied so a named
+        // text/plain leaf cannot become a message body. MimePart::filename
+        // will use the next valid parameter or the safe attachment fallback.
+        params.remove(parameter);
+        params.insert(INVALID_FILENAME_PARAMETER_MARKER.into(), "1".into());
+    }
+}
+
+fn decode_rfc2047_filename(value: &str) -> Option<String> {
+    if !is_safe_rfc2047_filename(value) {
+        return None;
+    }
+    // Use the same pinned parser and MIME-parameter path as complete message
+    // parsing, so mixed encoded-word/literal values keep identical spacing.
+    let escaped = value.replace('\\', "\\\\").replace('"', "\\\"");
+    let header = format!("Content-Disposition: attachment; filename=\"{escaped}\"\r\n\r\n");
+    let parsed = configured_message_parser().parse_headers(header.as_bytes())?;
+    let part = parsed.part(0)?;
+    let decoded = part
+        .content_disposition()
+        .and_then(|disposition| mime_attribute(disposition, "filename"))?
+        .to_owned();
+    (decoded != value
+        && !decoded.trim().is_empty()
+        && !decoded.contains("=?")
+        && !decoded.contains("?=")
+        && !decoded.chars().any(char::is_control))
+    .then_some(decoded)
+}
+
+fn is_safe_rfc2047_filename(value: &str) -> bool {
+    if value.len() > MAX_MIME_HEADER_BYTES || value.chars().any(char::is_control) {
+        return false;
+    }
+    let mut remaining = value;
+    let mut found_encoded_word = false;
+    while let Some(offset) = remaining.find("=?") {
+        let literal = &remaining[..offset];
+        if literal.contains("?=") {
+            return false;
+        }
+        let word = &remaining[offset + 2..];
+        let Some((word, rest)) = word.split_once("?=") else {
+            return false;
+        };
+        let mut fields = word.split('?');
+        let (Some(charset), Some(encoding), Some(encoded), None) =
+            (fields.next(), fields.next(), fields.next(), fields.next())
+        else {
+            return false;
+        };
+        if charset.is_empty()
+            || encoded.is_empty()
+            || !matches!(encoding, "Q" | "q" | "B" | "b")
+            || !charset.bytes().all(|byte| {
+                byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'*')
+            })
+            || !rfc2047_charset_is_supported(charset)
+            || !encoded
+                .bytes()
+                .all(|byte| (33..=126).contains(&byte) && byte != b'?')
+            || !rfc2047_encoded_text_is_valid(encoding, encoded)
+        {
+            return false;
+        }
+        found_encoded_word = true;
+        remaining = rest;
+    }
+    found_encoded_word && !remaining.contains("?=")
+}
+
+fn rfc2047_charset_is_supported(charset: &str) -> bool {
+    let charset = charset
+        .split_once('*')
+        .map_or(charset, |(charset, _)| charset);
+    !charset.is_empty()
+        && (charset.eq_ignore_ascii_case("utf-8") || charset_decoder(charset.as_bytes()).is_some())
+}
+
+fn rfc2047_encoded_text_is_valid(encoding: &str, encoded: &str) -> bool {
+    match encoding {
+        "B" | "b" => STANDARD.decode(encoded).is_ok(),
+        "Q" | "q" => {
+            let bytes = encoded.as_bytes();
+            let mut index = 0;
+            while index < bytes.len() {
+                if bytes[index] == b'=' {
+                    if !bytes.get(index + 1).is_some_and(u8::is_ascii_hexdigit)
+                        || !bytes.get(index + 2).is_some_and(u8::is_ascii_hexdigit)
+                    {
+                        return false;
+                    }
+                    index += 3;
+                } else {
+                    index += 1;
+                }
+            }
+            true
+        }
+        _ => false,
+    }
 }
 
 fn bodystructure_disposition(values: &[ImapBodyValue]) -> Option<&[ImapBodyValue]> {
@@ -7302,6 +7434,23 @@ mod tests {
         })
     }
 
+    fn filename_parameters_bodystructure() -> &'static str {
+        // This is deliberately a raw IMAP BODYSTRUCTURE representation, not a
+        // value generated from mail-parser's decoded attributes. Gmail-like
+        // servers can return the RFC 2047 encoded word verbatim here.
+        concat!(
+            "((\"TEXT\" \"PLAIN\" (\"CHARSET\" \"utf-8\") NIL NIL \"7BIT\" 29 1 NIL NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"fallback.pdf\") NIL NIL \"BASE64\" 10 0 (\"ATTACHMENT\" (\"FILENAME*\" \"utf-8''quarterly%20report%20final.pdf\")) NIL NIL) ",
+            "(\"APPLICATION\" \"OCTET-STREAM\" (\"NAME\" \"=?UTF-8?B?cmVwb3J0LXRlc3QudHh0?=\") NIL NIL \"BASE64\" 12 0 (\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?B?cmVwb3J0LXRlc3QudHh0?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"OCTET-STREAM\" (\"NAME\" \"=?UTF-8?Q?Pr=C3=BCgimaja_plaan_vaated_31.08.pdf?=\") NIL NIL \"BASE64\" 12 0 (\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?Pr=C3=BCgimaja_plaan_vaated_31.08.pdf?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"OCTET-STREAM\" (\"NAME\" \"=?UTF-8?Q?Pr=C3=BCgimaja?=_31.08.pdf\") NIL NIL \"BASE64\" 12 0 (\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?Pr=C3=BCgimaja?=_31.08.pdf\")) NIL NIL) ",
+            "(\"APPLICATION\" \"OCTET-STREAM\" NIL NIL NIL \"BASE64\" 12 0 (\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8*et?Q?Pr=C3=BCgimaja.pdf?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"OCTET-STREAM\" (\"NAME\" \"safe-name.txt\") NIL NIL \"BASE64\" 12 0 (\"ATTACHMENT\" (\"FILENAME\" \"../../invoice;final.pdf\")) NIL NIL) ",
+            "(\"APPLICATION\" \"OCTET-STREAM\" NIL NIL NIL \"BASE64\" 12 0 (\"ATTACHMENT\" (\"FILENAME\" \"invoice\u{202e}gpj.exe\")) NIL NIL) ",
+            "(\"APPLICATION\" \"OCTET-STREAM\" NIL NIL NIL \"BASE64\" 12 0 (\"ATTACHMENT\" (\"FILENAME\" \"broken%ZZname.pdf\")) NIL NIL) \"MIXED\")"
+        )
+    }
+
     fn fixture_bodystructure_part(
         message: &ParsedMessage<'_>,
         part_id: u32,
@@ -7623,6 +7772,9 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(filenames.contains(&"quarterly report final.pdf"));
         assert!(filenames.contains(&"report-test.txt"));
+        assert!(filenames.contains(&"Prügimaja plaan vaated 31.08.pdf"));
+        assert!(filenames.contains(&"Prügimaja_31.08.pdf"));
+        assert!(filenames.contains(&"Prügimaja.pdf"));
         assert!(filenames.contains(&"invoice;final.pdf"));
         assert!(filenames
             .iter()
@@ -7796,6 +7948,7 @@ mod tests {
         // sections generated from its actual raw RFC822 representation.
         let cases = [
             "attached-message-rfc822",
+            "filename-parameters-and-encodings",
             "format-flowed-delsp",
             "linkedin-inline-content-id",
             "multipart-attachment-container",
@@ -7837,7 +7990,7 @@ mod tests {
             "* 1 FETCH (UID 1 FLAGS (\\Seen \\Flagged) INTERNALDATE \"21-Jul-2026 10:00:00 +0000\")"
                 .to_owned(),
         ];
-        let mut complete_messages = Vec::new();
+        let mut selective_messages = Vec::new();
 
         for (index, name) in cases.iter().enumerate() {
             let raw = if *name == "provider-signature-inline" {
@@ -7851,9 +8004,13 @@ mod tests {
                 .unwrap_or_else(|error| panic!("{name} complete parse failed: {error}"));
             let fixture = fixture_imap_message(raw)
                 .unwrap_or_else(|error| panic!("{name} fixture IMAP derivation failed: {error}"));
+            let bodystructure = if *name == "filename-parameters-and-encodings" {
+                filename_parameters_bodystructure().to_owned()
+            } else {
+                fixture.bodystructure.clone()
+            };
             let structure = parse_bodystructure(&[format!(
-                "* 1 FETCH (UID {uid} BODYSTRUCTURE {})",
-                fixture.bodystructure
+                "* 1 FETCH (UID {uid} BODYSTRUCTURE {bodystructure})"
             )])
             .unwrap_or_else(|error| {
                 panic!("{name} generated BODYSTRUCTURE failed to parse: {error}")
@@ -7897,36 +8054,58 @@ mod tests {
                 selective_user_visible_semantics(&complete),
                 "{name} complete and selective user-visible content diverged"
             );
-            complete_messages.push(complete);
+            if *name == "filename-parameters-and-encodings" {
+                assert!(selective.attachments.iter().any(|attachment| {
+                    attachment.attachment.filename == "Prügimaja plaan vaated 31.08.pdf"
+                }));
+                for expected in ["Prügimaja_31.08.pdf", "Prügimaja.pdf"] {
+                    assert!(complete
+                        .attachments
+                        .iter()
+                        .any(|attachment| attachment.attachment.filename == expected));
+                    assert!(selective
+                        .attachments
+                        .iter()
+                        .any(|attachment| attachment.attachment.filename == expected));
+                }
+            }
+            selective_messages.push(selective);
         }
 
         let directory = tempfile::tempdir().unwrap();
         let database = directory.path().join("selective-fixtures.sqlite");
         let store = Store::open(&database).await.unwrap();
         store.save_account(&account).await.unwrap();
-        store.upsert_messages(&complete_messages).await.unwrap();
+        store.upsert_messages(&selective_messages).await.unwrap();
         drop(store);
 
         let reopened = Store::open(&database).await.unwrap();
-        for complete in &complete_messages {
-            let stored = reopened.message(&complete.id).await.unwrap().unwrap();
-            assert_eq!(stored.body_text, complete.body_text, "{}", complete.id);
-            assert_eq!(stored.body_html, complete.body_html, "{}", complete.id);
-            assert_eq!(stored.snippet, complete.snippet, "{}", complete.id);
+        for selective in &selective_messages {
+            let stored = reopened.message(&selective.id).await.unwrap().unwrap();
+            assert_eq!(stored.body_text, selective.body_text, "{}", selective.id);
+            assert_eq!(stored.body_html, selective.body_html, "{}", selective.id);
+            assert_eq!(stored.snippet, selective.snippet, "{}", selective.id);
             let metadata = reopened
-                .starred_attachment_metadata(&complete.id)
+                .starred_attachment_metadata(&selective.id)
                 .await
                 .unwrap();
             assert_eq!(
                 metadata.len(),
-                complete
+                selective
                     .attachments
                     .iter()
                     .filter(|attachment| attachment.attachment.presentation.is_downloadable())
                     .count(),
                 "{}",
-                complete.id
+                selective.id
             );
+            if selective.attachments.iter().any(|attachment| {
+                attachment.attachment.filename == "Prügimaja plaan vaated 31.08.pdf"
+            }) {
+                assert!(metadata.iter().any(|attachment| {
+                    attachment.filename == "Prügimaja plaan vaated 31.08.pdf"
+                }));
+            }
         }
     }
 
@@ -8827,6 +9006,33 @@ mod tests {
     }
 
     #[test]
+    fn targeted_fetch_attachment_keeps_bodystructure_and_mime_header_filenames_in_sync() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (\"APPLICATION\" \"PDF\" NIL NIL NIL \"BASE64\" 4 NIL ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?Pr=C3=BCgimaja_plaan.pdf?=\"))))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        let display =
+            attachment_data_from_part(&plan.attachments[0], "message-42", &[], None, false)
+                .unwrap();
+        let downloaded = attachment_data_from_part(
+            &plan.attachments[0],
+            "message-42",
+            b"Content-Type: application/pdf\r\nContent-Transfer-Encoding: base64\r\nContent-Disposition: attachment; filename=\"=?UTF-8?Q?Pr=C3=BCgimaja_plaan.pdf?=\"\r\n",
+            Some(b"cGRm".to_vec()),
+            false,
+        )
+        .unwrap();
+
+        assert_eq!(display.attachment.id, downloaded.attachment.id);
+        assert_eq!(display.attachment.filename, "Prügimaja plaan.pdf");
+        assert_eq!(downloaded.attachment.filename, display.attachment.filename);
+        assert_eq!(downloaded.bytes, b"pdf");
+    }
+
+    #[test]
     fn selective_image_only_messages_do_not_require_a_text_part() {
         let structure = parse_bodystructure(&[concat!(
             "* 1 FETCH (BODYSTRUCTURE (\"IMAGE\" \"PNG\" (\"NAME\" \"logo.png\") \"<logo@example>\" NIL \"BASE64\" 8 NIL ",
@@ -9167,6 +9373,99 @@ mod tests {
         .into()])
         .unwrap();
         assert_eq!(structure.filename(), Some("café.pdf"));
+    }
+
+    #[test]
+    fn selective_bodystructure_decodes_rfc2047_filenames_and_keeps_valid_fallbacks() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"APPLICATION\" \"PDF\" NIL NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?Pr=C3=BCgimaja_plaan.pdf?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" NIL NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?B?cmVwb3J0LXRlc3QudHh0?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"fallback.pdf\") NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?broken=ZZ?=\")) NIL NIL) \"MIXED\"))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+        let filenames = plan
+            .attachments
+            .iter()
+            .map(|attachment| attachment.part.filename())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            filenames,
+            vec![
+                Some("Prügimaja plaan.pdf"),
+                Some("report-test.txt"),
+                Some("fallback.pdf"),
+            ]
+        );
+    }
+
+    #[test]
+    fn selective_filename_decoding_covers_encoded_word_and_safety_boundaries() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE ((\"APPLICATION\" \"PDF\" NIL NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?Pr=C3=BC?= =?UTF-8?Q?gimaja.pdf?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"base64-fallback.pdf\") NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?B?%%%?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"terminator-fallback.pdf\") NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?broken\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"name-fallback.pdf\") NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME*\" \"utf-8''preferred%20name.pdf\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" NIL NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?../../Pr=C3=BCgimaja.pdf?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" NIL NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8?Q?invoice=E2=80=AEgpj.exe?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" (\"NAME\" \"charset-fallback.pdf\") NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?x-unknown?Q?ignored.pdf?=\")) NIL NIL) ",
+            "(\"APPLICATION\" \"PDF\" NIL NIL NIL \"BASE64\" 4 0 ",
+            "(\"ATTACHMENT\" (\"FILENAME\" \"=?UTF-8*et?Q?Pr=C3=BCgimaja.pdf?=\")) NIL NIL) \"MIXED\"))"
+        )
+        .into()])
+        .unwrap();
+        let filenames = selective_plan(&structure)
+            .unwrap()
+            .attachments
+            .iter()
+            .map(|attachment| {
+                attachment_data_from_part(attachment, "message-1", &[], None, false)
+                    .unwrap()
+                    .attachment
+                    .filename
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            filenames,
+            vec![
+                "Prü gimaja.pdf",
+                "base64-fallback.pdf",
+                "terminator-fallback.pdf",
+                "preferred name.pdf",
+                "Prügimaja.pdf",
+                "invoicegpj.exe",
+                "charset-fallback.pdf",
+                "Prügimaja.pdf",
+            ]
+        );
+    }
+
+    #[test]
+    fn selective_malformed_text_filename_remains_an_attachment_not_a_body() {
+        let structure = parse_bodystructure(&[concat!(
+            "* 1 FETCH (BODYSTRUCTURE (\"TEXT\" \"PLAIN\" (\"NAME\" ",
+            "\"=?UTF-8?Q?broken=ZZ?=\") NIL NIL \"7BIT\" 4 1 NIL NIL NIL))"
+        )
+        .into()])
+        .unwrap();
+        let plan = selective_plan(&structure).unwrap();
+
+        assert!(plan.text_parts.is_empty());
+        assert_eq!(plan.attachments.len(), 1);
+        let attachment =
+            attachment_data_from_part(&plan.attachments[0], "message-1", &[], None, false).unwrap();
+        assert_eq!(attachment.attachment.filename, "attachment");
     }
 
     #[test]

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -34,11 +34,13 @@ const VAULT_NONCE_LEN: usize = 12;
 const MESSAGE_CONTENT_CACHE_MAX_BYTES: i64 = 512 * 1024 * 1024;
 const MESSAGE_CONTENT_CACHE_RECENT_WINDOW_DAYS: i64 = 30;
 /// Attachment presentation and opaque IDs change when the selected HTML/MIME
-/// branch changes. Version 2 invalidates IDs written by the full-message
+/// branch changes. Version 3 invalidates IDs written by the full-message
 /// parser, whose downloadable-only numbering can otherwise select a different
-/// part when interpreted by the sectioned MIME planner.
-const ATTACHMENT_PRESENTATION_CACHE_VERSION: &str = "2";
-const ATTACHMENT_PRESENTATION_VERSION: i64 = 2;
+/// part when interpreted by the sectioned MIME planner, and cached attachment
+/// names written before selective BODYSTRUCTURE decoding handled RFC 2047
+/// parameters.
+const ATTACHMENT_PRESENTATION_CACHE_VERSION: &str = "3";
+const ATTACHMENT_PRESENTATION_VERSION: i64 = 3;
 /// Classification policy is versioned independently from the bundled model.
 /// A policy change must re-run model-owned classifications while preserving
 /// categories the user chose explicitly.
@@ -5213,6 +5215,122 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(attachment_bytes, 0);
+    }
+
+    #[tokio::test]
+    async fn attachment_filename_cache_migration_discards_stale_foreground_metadata() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("filename-cache-migration.sqlite");
+        let store = Store::open(&database).await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut cached_message = message("Filename migration", "preview");
+        cached_message.account_id = account_id.to_string();
+        let id = cached_message.id.clone();
+        store.upsert_messages(&[cached_message]).await.unwrap();
+        store
+            .cache_message_content(
+                &id,
+                false,
+                CachedMessageContent {
+                    body_text: "cached body".into(),
+                    body_html: None,
+                    unsubscribe_kind: None,
+                    attachments: vec![Attachment {
+                        id: "stale-filename".into(),
+                        message_id: id.clone(),
+                        filename: "=UTF-8QPr=C3=BCgimaja_plaan.pdf=".into(),
+                        mime_type: "application/pdf".into(),
+                        size_bytes: 42,
+                        is_inline: false,
+                        presentation: AttachmentPresentation::Downloadable,
+                        is_potentially_unsafe: false,
+                    }],
+                },
+            )
+            .await
+            .unwrap();
+        assert!(store.cached_message_content(&id).await.unwrap().is_some());
+
+        let mut starred = message("Starred filename migration", "preview");
+        starred.account_id = account_id.to_string();
+        starred.uid = 2;
+        starred.is_flagged = true;
+        starred.has_attachments = true;
+        let starred_id = starred.id.clone();
+        store.upsert_messages(&[starred]).await.unwrap();
+        assert!(store
+            .cache_starred_message_content(
+                &starred_id,
+                CachedMessageContent {
+                    body_text: "starred cached body".into(),
+                    body_html: None,
+                    unsubscribe_kind: None,
+                    attachments: vec![Attachment {
+                        id: "stale-starred-filename".into(),
+                        message_id: starred_id.clone(),
+                        filename: "=UTF-8QPr=C3=BCgimaja_plaan.pdf=".into(),
+                        mime_type: "application/pdf".into(),
+                        size_bytes: 42,
+                        is_inline: false,
+                        presentation: AttachmentPresentation::Downloadable,
+                        is_potentially_unsafe: false,
+                    }],
+                },
+            )
+            .await
+            .unwrap());
+        assert_eq!(
+            store
+                .starred_attachment_metadata(&starred_id)
+                .await
+                .unwrap()
+                .len(),
+            1
+        );
+
+        // Version 2 predates selective RFC 2047 filename decoding. Reopening
+        // takes the production migration path and forces the authoritative
+        // provider fetch instead of showing a cached transport artifact.
+        sqlx::query(
+            "UPDATE app_meta SET value = '2' WHERE key = 'attachment_presentation_cache_version'",
+        )
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE starred_message_bodies SET attachment_presentation_version = 2 WHERE message_id = ?",
+        )
+        .bind(&starred_id)
+        .execute(&store.pool)
+        .await
+        .unwrap();
+        store.pool.close().await;
+
+        let store = Store::open(&database).await.unwrap();
+        assert!(store.cached_message_content(&id).await.unwrap().is_none());
+        let cached_rows: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM message_content_cache WHERE message_id = ?")
+                .bind(&id)
+                .fetch_one(&store.pool)
+                .await
+                .unwrap();
+        assert_eq!(cached_rows, 0);
+        assert!(!store.message(&id).await.unwrap().unwrap().has_attachments);
+        assert!(store.starred_body(&starred_id).await.unwrap().is_none());
+        assert!(store
+            .starred_attachment_metadata(&starred_id)
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(
+            !store
+                .message(&starred_id)
+                .await
+                .unwrap()
+                .unwrap()
+                .has_attachments
+        );
     }
 
     #[tokio::test]

--- a/crates/dakia-core/testdata/mime/filename-parameters-and-encodings.eml
+++ b/crates/dakia-core/testdata/mime/filename-parameters-and-encodings.eml
@@ -23,6 +23,24 @@ Content-Transfer-Encoding: base64
 
 cmVkYWN0ZWQ=
 --files
+Content-Type: application/octet-stream; name="=?UTF-8?Q?Pr=C3=BCgimaja_plaan_vaated_31.08.pdf?="
+Content-Disposition: attachment; filename="=?UTF-8?Q?Pr=C3=BCgimaja_plaan_vaated_31.08.pdf?="
+Content-Transfer-Encoding: base64
+
+cmVkYWN0ZWQ=
+--files
+Content-Type: application/octet-stream; name="=?UTF-8?Q?Pr=C3=BCgimaja?=_31.08.pdf"
+Content-Disposition: attachment; filename="=?UTF-8?Q?Pr=C3=BCgimaja?=_31.08.pdf"
+Content-Transfer-Encoding: base64
+
+cmVkYWN0ZWQ=
+--files
+Content-Type: application/octet-stream
+Content-Disposition: attachment; filename="=?UTF-8*et?Q?Pr=C3=BCgimaja.pdf?="
+Content-Transfer-Encoding: base64
+
+cmVkYWN0ZWQ=
+--files
 Content-Type: application/octet-stream; name="safe-name.txt"
 Content-Disposition: attachment; filename="../../invoice;final.pdf"
 Content-Transfer-Encoding: base64

--- a/testdata/realistic-fixtures.manifest.json
+++ b/testdata/realistic-fixtures.manifest.json
@@ -195,7 +195,7 @@
     {
       "id": "mime.filename-parameters-and-encodings",
       "path": "crates/dakia-core/testdata/mime/filename-parameters-and-encodings.eml",
-      "sha256": "e0e71d12dbeec09ec8c833d7b98f363366963edf5d00641b893249fba97b7a0e",
+      "sha256": "77095fc2d7516b0ab1c62782778579112749ea2dc802fea5e4e7fb591dae5b5e",
       "provenance": {
         "kind": "synthetic",
         "detail": "Synthetic RFC 2231, RFC 2047, malformed, and hostile filename parameters."
@@ -213,7 +213,13 @@
         "error": "Malformed filename parameters must not cause a message parse failure.",
         "resourceLimit": "No resource-limit error is expected for this bounded fixture."
       },
-      "applicablePaths": ["complete-rfc822", "catalogue", "header"],
+      "applicablePaths": [
+        "complete-rfc822",
+        "catalogue",
+        "header",
+        "selective-bodystructure",
+        "storage-round-trip"
+      ],
       "redaction": {
         "reviewer": "Dakia maintainers",
         "reviewedOn": "2026-07-30",
@@ -224,6 +230,11 @@
           "domain": "rust.mail.parse-paths",
           "source": "crates/dakia-core/src/mail.rs",
           "id": "every_mime_corpus_fixture_uses_all_publication_parse_paths"
+        },
+        {
+          "domain": "rust.mail.selective-bodystructure",
+          "source": "crates/dakia-core/src/mail.rs",
+          "id": "realistic_selective_bodystructure_fixtures_match_complete_parser_and_starred_storage"
         }
       ]
     },


### PR DESCRIPTION
## Summary

- decode RFC 2047 Q and B encoded attachment filename parameters in the selective IMAP BODYSTRUCTURE path
- preserve attachment classification and safe fallbacks for malformed or unsupported filename encodings
- invalidate stale attachment metadata caches so affected messages are fetched again
- add a redacted realistic fixture based on the reported filename and cover complete parsing, selective parsing, targeted downloads, and cache migration

## User-visible result

A filename such as `=UTF-8QPr=C3=BCgimaja_plaan_vaated_31.08.pdf=` is now shown as `Prügimaja_plaan_vaated_31.08.pdf` instead of leaking MIME encoding syntax.

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy -p dakia-core --all-targets -- -D warnings`
- `cargo test -p dakia-core`: 290 tests passed
- `node scripts/validate-realistic-fixtures.mjs`: 17 fixtures valid
- `node --test scripts/validate-realistic-fixtures.node-test.mjs`: 8 tests passed