### PR TITLE
Make IMAP synchronization restart-safe

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -2,7 +2,7 @@ name: Production release
 
 on:
   schedule:
-    - cron: '17 2 * * *'
+    - cron: "17 2 * * *"
   workflow_dispatch:
     inputs:
       reason:
@@ -286,7 +286,10 @@ jobs:
   build:
     name: Build ${{ matrix.name }}
     needs: [decide, validate]
-    if: needs.decide.outputs.should_release == 'true'
+    if: >-
+      always() && needs.decide.result == 'success' &&
+      needs.validate.result == 'success' &&
+      needs.decide.outputs.should_release == 'true'
     strategy:
       fail-fast: false
       matrix:

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -22,7 +22,7 @@ use secrecy::SecretString;
 use serde::Deserialize;
 use serde::Serialize;
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     fs::OpenOptions,
     future::Future,
     io::{ErrorKind, Read, Write},
@@ -47,7 +47,7 @@ use tauri::{
 };
 use tauri_plugin_clipboard_manager::ClipboardExt;
 use tauri_plugin_opener::OpenerExt;
-use tokio::sync::{Mutex as AsyncMutex, Notify, OwnedMutexGuard, Semaphore};
+use tokio::sync::{watch, Mutex as AsyncMutex, Notify, OwnedMutexGuard, Semaphore};
 use url::Url;
 use uuid::Uuid;
 
@@ -74,6 +74,8 @@ struct AppState {
     realtime: RealtimeSyncManager,
     remote_operation_slots: Arc<Semaphore>,
     mail_rebuilds: Mutex<HashMap<Uuid, MailRebuildProgress>>,
+    mail_rebuild_running: Mutex<HashSet<Uuid>>,
+    mail_rebuild_cancellations: MailRebuildCancellations,
     account_operations: AccountOperationLocks,
     translation_downloads: Mutex<HashMap<String, Arc<AtomicBool>>>,
 }
@@ -124,6 +126,125 @@ impl AccountOperationLocks {
     }
 }
 
+/// Coordinates a rebuild cancellation across the brief interval before a
+/// queued rebuild obtains the per-account operation lock.
+#[derive(Default)]
+struct MailRebuildCancellations {
+    active: Mutex<HashMap<Uuid, MailRebuildCancellation>>,
+}
+
+struct MailRebuildCancellation {
+    sender: watch::Sender<MailRebuildCancellationDisposition>,
+    registrations: usize,
+    reserved: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum MailRebuildCancellationDisposition {
+    None,
+    Retain,
+    Replace,
+    Remove,
+}
+
+impl MailRebuildCancellations {
+    fn reserve(&self, account_id: Uuid) {
+        let mut active = self
+            .active
+            .lock()
+            .expect("mail rebuild cancellation lock poisoned");
+        let cancellation = active.entry(account_id).or_insert_with(|| {
+            let (sender, _) = watch::channel(MailRebuildCancellationDisposition::None);
+            MailRebuildCancellation {
+                sender,
+                registrations: 0,
+                reserved: false,
+            }
+        });
+        cancellation.reserved = true;
+    }
+
+    fn register(&self, account_id: Uuid) -> watch::Receiver<MailRebuildCancellationDisposition> {
+        let mut active = self
+            .active
+            .lock()
+            .expect("mail rebuild cancellation lock poisoned");
+        let cancellation = active.entry(account_id).or_insert_with(|| {
+            let (sender, _) = watch::channel(MailRebuildCancellationDisposition::None);
+            MailRebuildCancellation {
+                sender,
+                registrations: 0,
+                reserved: false,
+            }
+        });
+        cancellation.registrations += 1;
+        cancellation.sender.subscribe()
+    }
+
+    fn request(&self, account_id: Uuid, disposition: MailRebuildCancellationDisposition) {
+        if let Some(sender) = self
+            .active
+            .lock()
+            .expect("mail rebuild cancellation lock poisoned")
+            .get(&account_id)
+            .map(|cancellation| cancellation.sender.clone())
+        {
+            let current = *sender.borrow();
+            let next = match (current, disposition) {
+                (MailRebuildCancellationDisposition::Remove, _)
+                | (_, MailRebuildCancellationDisposition::Remove) => {
+                    MailRebuildCancellationDisposition::Remove
+                }
+                (MailRebuildCancellationDisposition::Replace, _)
+                | (_, MailRebuildCancellationDisposition::Replace) => {
+                    MailRebuildCancellationDisposition::Replace
+                }
+                (MailRebuildCancellationDisposition::Retain, _)
+                | (_, MailRebuildCancellationDisposition::Retain) => {
+                    MailRebuildCancellationDisposition::Retain
+                }
+                _ => MailRebuildCancellationDisposition::None,
+            };
+            // `send` drops the update when a reservation has no subscribed
+            // task yet. `send_replace` records it for the later register.
+            sender.send_replace(next);
+        }
+    }
+
+    fn disposition(
+        &self,
+        receiver: &watch::Receiver<MailRebuildCancellationDisposition>,
+    ) -> MailRebuildCancellationDisposition {
+        *receiver.borrow()
+    }
+
+    fn clear(&self, account_id: Uuid) {
+        let mut active = self
+            .active
+            .lock()
+            .expect("mail rebuild cancellation lock poisoned");
+        if let Some(cancellation) = active.get_mut(&account_id) {
+            cancellation.registrations -= 1;
+            if cancellation.registrations == 0 && !cancellation.reserved {
+                active.remove(&account_id);
+            }
+        }
+    }
+
+    fn release_reservation(&self, account_id: Uuid) {
+        let mut active = self
+            .active
+            .lock()
+            .expect("mail rebuild cancellation lock poisoned");
+        if let Some(cancellation) = active.get_mut(&account_id) {
+            cancellation.reserved = false;
+            if cancellation.registrations == 0 {
+                active.remove(&account_id);
+            }
+        }
+    }
+}
+
 fn normalized_account_email(email: &str) -> String {
     email.trim().to_ascii_lowercase()
 }
@@ -132,10 +253,63 @@ fn matching_account_email(account: &Account, email: &str) -> bool {
     normalized_account_email(&account.email) == normalized_account_email(email)
 }
 
+fn same_mail_namespace(existing: &Account, candidate: &Account) -> bool {
+    existing.provider_id == candidate.provider_id
+        && match (&existing.auth, &candidate.auth) {
+            (
+                AccountAuth::Password {
+                    username: existing_username,
+                },
+                AccountAuth::Password {
+                    username: candidate_username,
+                },
+            ) => existing_username == candidate_username,
+            (
+                AccountAuth::OAuth2 {
+                    username: existing_username,
+                    provider: existing_provider,
+                    ..
+                },
+                AccountAuth::OAuth2 {
+                    username: candidate_username,
+                    provider: candidate_provider,
+                    ..
+                },
+            ) => existing_username == candidate_username && existing_provider == candidate_provider,
+            _ => false,
+        }
+        && existing
+            .imap_host
+            .trim()
+            .eq_ignore_ascii_case(candidate.imap_host.trim())
+        && existing.imap_port == candidate.imap_port
+        && existing.imap_security == candidate.imap_security
+        && existing.archive_mailbox == candidate.archive_mailbox
+        && existing.spam_mailbox == candidate.spam_mailbox
+}
+
+fn reuse_existing_account_record(existing: &Account, candidate: &mut Account) -> bool {
+    let can_resume_existing_index = same_mail_namespace(existing, candidate);
+    candidate.id = existing.id;
+    candidate.created_at = existing.created_at;
+    candidate.account_name = existing.account_name.clone();
+    can_resume_existing_index
+}
+
 fn credential_secret_name(account: &Account) -> String {
     // Keep this aligned with `dakia_core::mail::CredentialStore::key` so an
     // OAuth save failure can restore a credential it just replaced.
     format!("dev.dakia.mail:{}:{}", account.id, account.auth.username())
+}
+
+fn previous_credential_secret_name(
+    existing: Option<&Account>,
+    candidate: &Account,
+) -> Option<String> {
+    let current = credential_secret_name(candidate);
+    existing
+        .map(credential_secret_name)
+        .filter(|previous| previous != &current)
 }
 
 async fn enabled_account_for_operation(
@@ -195,6 +369,29 @@ fn complete_manual_sync_attempt<T>(
 mod account_operation_lock_tests {
     use super::*;
 
+    fn account() -> Account {
+        Account {
+            id: Uuid::new_v4(),
+            email: "reader@example.com".into(),
+            account_name: "Reader".into(),
+            display_name: "Reader".into(),
+            provider_id: "fastmail".into(),
+            auth: AccountAuth::Password {
+                username: "reader@example.com".into(),
+            },
+            imap_host: "imap.fastmail.com".into(),
+            imap_port: 993,
+            imap_security: dakia_core::provider::Security::Tls,
+            smtp_host: "smtp.fastmail.com".into(),
+            smtp_port: 465,
+            smtp_security: dakia_core::provider::Security::Tls,
+            archive_mailbox: "Archive".into(),
+            spam_mailbox: "Spam".into(),
+            enabled: true,
+            created_at: chrono::Utc::now(),
+        }
+    }
+
     #[tokio::test]
     async fn serializes_the_same_account_without_blocking_the_lock_registry() {
         let locks = Arc::new(AccountOperationLocks::default());
@@ -239,11 +436,169 @@ mod account_operation_lock_tests {
         assert_eq!(error.to_string(), "restart failed");
     }
 
+    #[tokio::test]
+    async fn cancellation_reaches_a_rebuild_registered_while_waiting_for_its_account_lock() {
+        let cancellations = MailRebuildCancellations::default();
+        let account_id = Uuid::new_v4();
+        let locks = AccountOperationLocks::default();
+        let held_lock = locks.acquire(account_id).await;
+
+        let receiver = cancellations.register(account_id);
+        cancellations.request(account_id, MailRebuildCancellationDisposition::Retain);
+
+        assert_eq!(
+            cancellations.disposition(&receiver),
+            MailRebuildCancellationDisposition::Retain
+        );
+        drop(held_lock);
+        cancellations.clear(account_id);
+
+        // An account update with no registered rebuild must not turn into a
+        // stale cancellation for a later, unrelated full sync.
+        cancellations.request(account_id, MailRebuildCancellationDisposition::Retain);
+        let next_attempt = cancellations.register(account_id);
+        assert_eq!(
+            cancellations.disposition(&next_attempt),
+            MailRebuildCancellationDisposition::None
+        );
+    }
+
+    #[test]
+    fn cancellation_reaches_a_reserved_rebuild_before_its_task_registers() {
+        let cancellations = MailRebuildCancellations::default();
+        let account_id = Uuid::new_v4();
+
+        cancellations.reserve(account_id);
+        cancellations.request(account_id, MailRebuildCancellationDisposition::Retain);
+        let receiver = cancellations.register(account_id);
+
+        assert_eq!(
+            cancellations.disposition(&receiver),
+            MailRebuildCancellationDisposition::Retain
+        );
+        cancellations.clear(account_id);
+        cancellations.release_reservation(account_id);
+
+        // A later unrelated reservation gets a fresh channel, rather than a
+        // stale cancellation from a completed update.
+        cancellations.reserve(account_id);
+        let next = cancellations.register(account_id);
+        assert_eq!(
+            cancellations.disposition(&next),
+            MailRebuildCancellationDisposition::None
+        );
+    }
+
+    #[test]
+    fn durable_reset_intent_cannot_be_downgraded_by_a_queued_worker() {
+        assert!(effective_rebuild_reset(false, Some(true)));
+        assert!(effective_rebuild_reset(true, Some(false)));
+        assert!(!effective_rebuild_reset(false, Some(false)));
+    }
+
+    #[test]
+    fn initial_reset_jobs_survive_missing_or_rejected_credentials() {
+        assert!(!should_retain_mail_rebuild_job(
+            &anyhow::anyhow!("mail rebuild cancelled"),
+            MailRebuildCancellationDisposition::Remove,
+            true,
+        ));
+        assert!(!should_retain_mail_rebuild_job(
+            &anyhow::anyhow!("IMAP authentication rejected: invalid credentials"),
+            MailRebuildCancellationDisposition::None,
+            false,
+        ));
+        assert!(should_retain_mail_rebuild_job(
+            &anyhow::anyhow!("IMAP authentication rejected: invalid credentials"),
+            MailRebuildCancellationDisposition::None,
+            true,
+        ));
+        assert!(!should_retain_mail_rebuild_job(
+            &anyhow::anyhow!("credentials are not stored for this account"),
+            MailRebuildCancellationDisposition::None,
+            false,
+        ));
+        assert!(should_retain_mail_rebuild_job(
+            &anyhow::anyhow!("credentials are not stored for this account"),
+            MailRebuildCancellationDisposition::None,
+            true,
+        ));
+        assert!(should_retain_mail_rebuild_job(
+            &anyhow::anyhow!("IMAP connection closed during command"),
+            MailRebuildCancellationDisposition::None,
+            false,
+        ));
+    }
+
+    #[test]
+    fn cancellation_disposition_retains_replacement_but_removes_deleted_account_jobs() {
+        let transient = anyhow::anyhow!("IMAP connection closed during command");
+        let permanent = anyhow::anyhow!("IMAP authentication rejected");
+        assert!(should_retain_mail_rebuild_job(
+            &permanent,
+            MailRebuildCancellationDisposition::Retain,
+            false,
+        ));
+        assert!(should_retain_mail_rebuild_job(
+            &transient,
+            MailRebuildCancellationDisposition::Replace,
+            false,
+        ));
+        assert!(!should_retain_mail_rebuild_job(
+            &transient,
+            MailRebuildCancellationDisposition::Remove,
+            true,
+        ));
+    }
+
     #[test]
     fn normalizes_email_identity_for_account_reuse() {
         assert_eq!(
             normalized_account_email(" Existing@Example.Com "),
             "existing@example.com"
+        );
+    }
+
+    #[test]
+    fn reuses_an_index_only_for_the_same_remote_namespace() {
+        let existing = account();
+        let same_remote = existing.clone();
+        assert!(same_mail_namespace(&existing, &same_remote));
+
+        let mut different_provider = same_remote.clone();
+        different_provider.provider_id = "outlook".into();
+        assert!(!same_mail_namespace(&existing, &different_provider));
+
+        let mut different_host = same_remote.clone();
+        different_host.imap_host = "imap.other.example".into();
+        assert!(!same_mail_namespace(&existing, &different_host));
+
+        let mut different_username = same_remote.clone();
+        different_username.auth = AccountAuth::Password {
+            username: "other@example.com".into(),
+        };
+        assert!(!same_mail_namespace(&existing, &different_username));
+
+        let mut different_mailbox = same_remote;
+        different_mailbox.archive_mailbox = "All Mail".into();
+        assert!(!same_mail_namespace(&existing, &different_mailbox));
+    }
+
+    #[test]
+    fn reconnecting_with_a_new_login_selects_only_the_old_credential_key() {
+        let existing = account();
+        let mut reconnected = existing.clone();
+        reconnected.auth = AccountAuth::Password {
+            username: "new-login@example.com".into(),
+        };
+
+        assert_eq!(
+            previous_credential_secret_name(Some(&existing), &reconnected),
+            Some(credential_secret_name(&existing)),
+        );
+        assert_eq!(
+            previous_credential_secret_name(Some(&reconnected), &reconnected),
+            None,
         );
     }
 }
@@ -680,6 +1035,8 @@ struct MailRebuildProgress {
     phase: String,
     completed: usize,
     total: Option<usize>,
+    #[serde(skip)]
+    reset_before_sync: bool,
 }
 
 impl From<MailRebuildJob> for MailRebuildProgress {
@@ -689,6 +1046,7 @@ impl From<MailRebuildJob> for MailRebuildProgress {
             phase: job.phase,
             completed: job.completed,
             total: job.total,
+            reset_before_sync: job.reset_before_sync,
         }
     }
 }
@@ -1112,6 +1470,13 @@ struct AddAccountInput {
     password: String,
 }
 
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct AccountConnection {
+    account: Account,
+    reused_existing_account: bool,
+}
+
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct UpdateAccountInput {
@@ -1438,6 +1803,8 @@ mod message_content_repair_tests {
             classification_owner: "message-content-test".into(),
             classification: Arc::new(ClassificationScheduler::default()),
             mail_rebuilds: Mutex::new(HashMap::new()),
+            mail_rebuild_running: Mutex::new(HashSet::new()),
+            mail_rebuild_cancellations: MailRebuildCancellations::default(),
             account_operations: AccountOperationLocks::default(),
             remote_operation_slots: Arc::new(Semaphore::new(MESSAGE_HYDRATION_CONCURRENCY)),
             translation_downloads: Mutex::new(HashMap::new()),
@@ -2841,6 +3208,14 @@ async fn update_account(
     if input.imap_host.trim().is_empty() || input.smtp_host.trim().is_empty() {
         return Err("IMAP and SMTP hosts are required".into());
     }
+    // Ask an existing rebuild to stop before waiting for its account lock. A
+    // normal settings or credential update retains the durable job so it can
+    // resume with the new connection details.
+    request_mail_rebuild_cancel(
+        state.inner(),
+        input.id,
+        MailRebuildCancellationDisposition::Retain,
+    );
     let _operation = state.account_operations.acquire(input.id).await;
     let mut account = state
         .store
@@ -2848,6 +3223,7 @@ async fn update_account(
         .await
         .map_err(error)?
         .ok_or_else(|| "Account not found".to_owned())?;
+    let previous_account = account.clone();
     account.account_name = input.account_name.trim().to_owned();
     account.display_name = input.display_name.trim().to_owned();
     account.imap_host = input.imap_host.trim().to_owned();
@@ -2858,18 +3234,78 @@ async fn update_account(
     account.smtp_security = input.smtp_security;
     account.archive_mailbox = input.archive_mailbox.trim().to_owned();
     account.spam_mailbox = input.spam_mailbox.trim().to_owned();
-    if let Some(password) = input.password.filter(|value| !value.is_empty()) {
-        if !matches!(account.auth, AccountAuth::Password { .. }) {
-            return Err("OAuth accounts must be reconnected through their provider".into());
+    let password_was_supplied = input
+        .password
+        .as_deref()
+        .is_some_and(|value| !value.is_empty());
+    if password_was_supplied && !matches!(account.auth, AccountAuth::Password { .. }) {
+        return Err("OAuth accounts must be reconnected through their provider".into());
+    }
+    let namespace_changed = !same_mail_namespace(&previous_account, &account);
+    if namespace_changed {
+        // Stop the old namespace watcher before committing a replacement.
+        state.realtime.stop_account(account.id).await;
+    }
+    let password_secret_name = credential_secret_name(&account);
+    let previous_password_credential = if password_was_supplied {
+        match state.store.secret(&password_secret_name).await {
+            Ok(credential) => credential,
+            Err(secret_error) => {
+                if namespace_changed {
+                    let _ = state.realtime.reconcile(app.clone()).await;
+                }
+                return Err(error(secret_error));
+            }
         }
-        MailService::new(state.store.clone())
+    } else {
+        None
+    };
+    if let Some(password) = input.password.filter(|value| !value.is_empty()) {
+        if let Err(set_error) = MailService::new(state.store.clone())
             .credentials()
             .set_password(&account, &password)
             .await
-            .map_err(error)?;
+        {
+            if namespace_changed {
+                let _ = state.realtime.reconcile(app.clone()).await;
+            }
+            return Err(error(set_error));
+        }
     }
-    state.store.save_account(&account).await.map_err(error)?;
-    state.realtime.reconcile(app).await.map_err(error)?;
+    if let Err(save_error) = save_account_with_rebuild_intent(
+        state.inner(),
+        &account,
+        namespace_changed,
+        None,
+        &password_secret_name,
+    )
+    .await
+    {
+        if password_was_supplied {
+            let rollback_mail = MailService::new(state.store.clone());
+            let credentials = rollback_mail.credentials();
+            let rollback = match previous_password_credential {
+                Some(previous) => {
+                    state
+                        .store
+                        .set_secret(&password_secret_name, &previous)
+                        .await
+                }
+                None => credentials.delete(&account).await,
+            };
+            if let Err(rollback_error) = rollback {
+                tracing::error!(account_id = %account.id, error = %rollback_error, "could not roll back password credentials after saving the account failed");
+            }
+        }
+        if namespace_changed {
+            let _ = state.realtime.reconcile(app.clone()).await;
+        }
+        return Err(error(save_error));
+    }
+    if !namespace_changed {
+        state.realtime.reconcile(app.clone()).await.map_err(error)?;
+    }
+    resume_scheduled_mail_rebuild(app, state.inner().clone(), account.clone()).await;
     Ok(account)
 }
 
@@ -3026,6 +3462,11 @@ async fn remove_account(
     state: State<'_, Arc<AppState>>,
     account_id: Uuid,
 ) -> Result<(), String> {
+    request_mail_rebuild_cancel(
+        state.inner(),
+        account_id,
+        MailRebuildCancellationDisposition::Remove,
+    );
     let _operation = state.account_operations.acquire(account_id).await;
     let account = state
         .store
@@ -3072,7 +3513,7 @@ async fn add_account(
     app: tauri::AppHandle,
     state: State<'_, Arc<AppState>>,
     input: AddAccountInput,
-) -> Result<Account, String> {
+) -> Result<AccountConnection, String> {
     let preset = input
         .draft
         .provider_id
@@ -3097,35 +3538,100 @@ async fn add_account(
     }
     let mut account = input.draft.into_account(preset);
     let stored_accounts = state.store.accounts().await.map_err(error)?;
-    let mut reused_existing_account = false;
+    let mut reuses_existing_account_record = false;
+    let mut can_resume_existing_index = false;
     if let Some(existing) = stored_accounts
         .into_iter()
         .find(|stored| matching_account_email(stored, &account.email))
     {
-        account.id = existing.id;
-        account.created_at = existing.created_at;
-        account.account_name = existing.account_name;
-        reused_existing_account = true;
+        can_resume_existing_index = reuse_existing_account_record(&existing, &mut account);
+        reuses_existing_account_record = true;
     }
+    if reuses_existing_account_record {
+        request_mail_rebuild_cancel(
+            state.inner(),
+            account.id,
+            MailRebuildCancellationDisposition::Retain,
+        );
+    }
+    let requires_reset = !can_resume_existing_index;
     let _operation = state.account_operations.acquire(account.id).await;
-    if reused_existing_account
-        && state
-            .store
-            .account(account.id)
-            .await
-            .map_err(error)?
-            .is_none()
-    {
+    let existing_account = if reuses_existing_account_record {
+        state.store.account(account.id).await.map_err(error)?
+    } else {
+        None
+    };
+    if reuses_existing_account_record && existing_account.is_none() {
         return Err("Account not found".into());
     }
+    if requires_reset {
+        state.realtime.stop_account(account.id).await;
+    }
     let mail = MailService::new(state.store.clone());
-    mail.credentials()
+    let password_secret_name = credential_secret_name(&account);
+    let previous_secret_name = previous_credential_secret_name(existing_account.as_ref(), &account);
+    let replaced_credential = if let Some(existing) = existing_account.as_ref() {
+        let existing_secret_name = credential_secret_name(&existing);
+        if existing_secret_name == password_secret_name {
+            state
+                .store
+                .secret(&existing_secret_name)
+                .await
+                .map_err(error)?
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+    if let Err(set_error) = mail
+        .credentials()
         .set_password(&account, &input.password)
         .await
-        .map_err(error)?;
-    state.store.save_account(&account).await.map_err(error)?;
-    state.realtime.reconcile(app).await.map_err(error)?;
-    Ok(account)
+    {
+        if requires_reset {
+            let _ = state.realtime.reconcile(app.clone()).await;
+        }
+        return Err(error(set_error));
+    }
+    if let Err(save_error) = save_account_with_rebuild_intent(
+        state.inner(),
+        &account,
+        requires_reset,
+        previous_secret_name.as_deref(),
+        &password_secret_name,
+    )
+    .await
+    {
+        let rollback = match replaced_credential {
+            Some(previous) => {
+                state
+                    .store
+                    .set_secret(&password_secret_name, &previous)
+                    .await
+            }
+            None => mail.credentials().delete(&account).await,
+        };
+        if let Err(rollback_error) = rollback {
+            tracing::error!(
+                account_id = %account.id,
+                error = %rollback_error,
+                "could not roll back password credentials after saving the account failed"
+            );
+        }
+        if requires_reset {
+            let _ = state.realtime.reconcile(app.clone()).await;
+        }
+        return Err(error(save_error));
+    }
+    if !requires_reset {
+        state.realtime.reconcile(app.clone()).await.map_err(error)?;
+    }
+    resume_scheduled_mail_rebuild(app, state.inner().clone(), account.clone()).await;
+    Ok(AccountConnection {
+        account,
+        reused_existing_account: can_resume_existing_index,
+    })
 }
 
 #[tauri::command]
@@ -3133,7 +3639,7 @@ async fn add_oauth_account(
     app: tauri::AppHandle,
     state: State<'_, Arc<AppState>>,
     draft: AccountDraft,
-) -> Result<Account, String> {
+) -> Result<AccountConnection, String> {
     let preset = draft
         .provider_id
         .as_deref()
@@ -3166,18 +3672,25 @@ async fn add_oauth_account(
         access_token_expires_at: tokens.expires_at,
     };
     let stored_accounts = state.store.accounts().await.map_err(error)?;
-    let mut reused_existing_account = false;
+    let mut reuses_existing_account_record = false;
+    let mut can_resume_existing_index = false;
     if let Some(existing) = stored_accounts
         .into_iter()
         .find(|stored| matching_account_email(stored, &account.email))
     {
-        account.id = existing.id;
-        account.created_at = existing.created_at;
-        account.account_name = existing.account_name;
-        reused_existing_account = true;
+        can_resume_existing_index = reuse_existing_account_record(&existing, &mut account);
+        reuses_existing_account_record = true;
     }
+    if reuses_existing_account_record {
+        request_mail_rebuild_cancel(
+            state.inner(),
+            account.id,
+            MailRebuildCancellationDisposition::Retain,
+        );
+    }
+    let requires_reset = !can_resume_existing_index;
     let _operation = state.account_operations.acquire(account.id).await;
-    let existing_account = if reused_existing_account {
+    let existing_account = if reuses_existing_account_record {
         Some(
             state
                 .store
@@ -3189,9 +3702,13 @@ async fn add_oauth_account(
     } else {
         None
     };
+    if requires_reset {
+        state.realtime.stop_account(account.id).await;
+    }
     let mail = MailService::new(state.store.clone());
     let oauth_secret_name = credential_secret_name(&account);
-    let replaced_credential = if let Some(existing) = existing_account {
+    let previous_secret_name = previous_credential_secret_name(existing_account.as_ref(), &account);
+    let replaced_credential = if let Some(existing) = existing_account.as_ref() {
         let existing_secret_name = credential_secret_name(&existing);
         if existing_secret_name == oauth_secret_name {
             state
@@ -3205,11 +3722,21 @@ async fn add_oauth_account(
     } else {
         None
     };
-    mail.credentials()
-        .set_oauth_tokens(&account, &tokens)
-        .await
-        .map_err(error)?;
-    if let Err(save_error) = state.store.save_account(&account).await {
+    if let Err(set_error) = mail.credentials().set_oauth_tokens(&account, &tokens).await {
+        if requires_reset {
+            let _ = state.realtime.reconcile(app.clone()).await;
+        }
+        return Err(error(set_error));
+    }
+    if let Err(save_error) = save_account_with_rebuild_intent(
+        state.inner(),
+        &account,
+        requires_reset,
+        previous_secret_name.as_deref(),
+        &oauth_secret_name,
+    )
+    .await
+    {
         let rollback = match replaced_credential {
             Some(previous_credential) => {
                 state
@@ -3226,10 +3753,19 @@ async fn add_oauth_account(
                 "could not roll back OAuth credentials after saving the account failed"
             );
         }
+        if requires_reset {
+            let _ = state.realtime.reconcile(app.clone()).await;
+        }
         return Err(error(save_error));
     }
-    state.realtime.reconcile(app.clone()).await.map_err(error)?;
-    Ok(account)
+    if !requires_reset {
+        state.realtime.reconcile(app.clone()).await.map_err(error)?;
+    }
+    resume_scheduled_mail_rebuild(app, state.inner().clone(), account.clone()).await;
+    Ok(AccountConnection {
+        account,
+        reused_existing_account: can_resume_existing_index,
+    })
 }
 
 const GOOGLE_DESKTOP_CLIENT_ID: &str =
@@ -3739,11 +4275,19 @@ fn publish_mail_rebuild_progress(
     account_id: Uuid,
     progress: SyncProgress,
 ) {
+    let reset_before_sync = state
+        .mail_rebuilds
+        .lock()
+        .expect("mail rebuild lock poisoned")
+        .get(&account_id)
+        .map(|job| job.reset_before_sync)
+        .unwrap_or(false);
     let update = MailRebuildProgress {
         account_id,
         phase: progress.phase.to_owned(),
         completed: progress.completed,
         total: progress.total,
+        reset_before_sync,
     };
     state
         .mail_rebuilds
@@ -3753,19 +4297,245 @@ fn publish_mail_rebuild_progress(
     let _ = app.emit("mail-rebuild-progress", &update);
 }
 
+fn request_mail_rebuild_cancel(
+    state: &Arc<AppState>,
+    account_id: Uuid,
+    disposition: MailRebuildCancellationDisposition,
+) {
+    state
+        .mail_rebuild_cancellations
+        .request(account_id, disposition);
+}
+
+fn reserve_mail_rebuild(state: &Arc<AppState>, account_id: Uuid) -> bool {
+    let reserved = state
+        .mail_rebuild_running
+        .lock()
+        .expect("mail rebuild reservation lock poisoned")
+        .insert(account_id);
+    if reserved {
+        // Register the cancellation channel with the reservation, before the
+        // spawned task can run. A namespace-changing update can now cancel a
+        // queued worker rather than missing the pre-registration window.
+        state.mail_rebuild_cancellations.reserve(account_id);
+    }
+    reserved
+}
+
+fn release_mail_rebuild(state: &Arc<AppState>, account_id: Uuid) {
+    let released = state
+        .mail_rebuild_running
+        .lock()
+        .expect("mail rebuild reservation lock poisoned")
+        .remove(&account_id);
+    if released {
+        state
+            .mail_rebuild_cancellations
+            .release_reservation(account_id);
+    }
+}
+
+async fn schedule_mail_rebuild(
+    state: &Arc<AppState>,
+    account_id: Uuid,
+    reset_before_sync: bool,
+) -> anyhow::Result<()> {
+    let job = MailRebuildJob {
+        account_id,
+        phase: "connecting".to_owned(),
+        completed: 0,
+        total: None,
+        reset_before_sync,
+    };
+    // Persistence comes first. A realtime reconcile must never win the race
+    // with the durable replacement intent.
+    state.store.save_mail_rebuild_job(&job).await?;
+    state
+        .mail_rebuilds
+        .lock()
+        .expect("mail rebuild lock poisoned")
+        .insert(account_id, job.into());
+    Ok(())
+}
+
+fn reset_mail_rebuild_job(account_id: Uuid) -> MailRebuildJob {
+    MailRebuildJob {
+        account_id,
+        phase: "connecting".to_owned(),
+        completed: 0,
+        total: None,
+        reset_before_sync: true,
+    }
+}
+
+async fn save_account_with_rebuild_intent(
+    state: &Arc<AppState>,
+    account: &Account,
+    reset_before_sync: bool,
+    previous_secret_name: Option<&str>,
+    current_secret_name: &str,
+) -> anyhow::Result<()> {
+    if !reset_before_sync {
+        return state.store.save_account(account).await;
+    }
+    let job = reset_mail_rebuild_job(account.id);
+    // The namespace replacement is indivisible: a reconnect can never leave
+    // a changed remote identity saved without its required reset job.
+    if let Some(previous_secret_name) = previous_secret_name {
+        state
+            .store
+            .save_account_with_reset_mail_rebuild_job_and_delete_previous_secret(
+                account,
+                &job,
+                Some(previous_secret_name),
+                current_secret_name,
+            )
+            .await?;
+    } else {
+        state
+            .store
+            .save_account_with_reset_mail_rebuild_job(account, &job)
+            .await?;
+    }
+    state
+        .mail_rebuilds
+        .lock()
+        .expect("mail rebuild lock poisoned")
+        .insert(account.id, job.into());
+    Ok(())
+}
+
+async fn resume_scheduled_mail_rebuild(
+    app: tauri::AppHandle,
+    state: Arc<AppState>,
+    account: Account,
+) {
+    let in_memory = {
+        state
+            .mail_rebuilds
+            .lock()
+            .expect("mail rebuild lock poisoned")
+            .get(&account.id)
+            .map(|job| job.reset_before_sync)
+    };
+    let reset_before_sync = match in_memory {
+        Some(reset_before_sync) => Some(reset_before_sync),
+        None => match state.store.mail_rebuild_jobs().await {
+            Ok(jobs) => jobs
+                .into_iter()
+                .find(|job| job.account_id == account.id)
+                .map(|job| job.reset_before_sync),
+            Err(error) => {
+                tracing::warn!(account_id = %account.id, error = %error, "could not load retained mail rebuild job");
+                None
+            }
+        },
+    };
+    let Some(reset_before_sync) = reset_before_sync else {
+        return;
+    };
+    if !reserve_mail_rebuild(&state, account.id) {
+        return;
+    }
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run_mail_rebuild(app, state, account, reset_before_sync).await {
+            tracing::warn!(error = %error, "could not resume retained mail rebuild");
+        }
+    });
+}
+
+fn should_retain_mail_rebuild_job(
+    error: &anyhow::Error,
+    disposition: MailRebuildCancellationDisposition,
+    reset_before_sync: bool,
+) -> bool {
+    if matches!(
+        disposition,
+        MailRebuildCancellationDisposition::Retain | MailRebuildCancellationDisposition::Replace
+    ) {
+        return true;
+    }
+    if matches!(disposition, MailRebuildCancellationDisposition::Remove)
+        || error.to_string() == "mail rebuild cancelled"
+    {
+        return false;
+    }
+    // A first or replacement index has no trusted catalogue yet. Keep its
+    // reset intent even for a credential error so reconnecting the same
+    // namespace can finish the original replacement instead of silently
+    // downgrading to a normal incremental sync.
+    if reset_before_sync {
+        return true;
+    }
+    !error.chain().any(|cause| {
+        let message = cause.to_string().to_ascii_lowercase();
+        message.contains("imap authentication rejected")
+            || message.contains("credentials are not stored")
+            || message.contains("stored oauth credentials are invalid")
+    })
+}
+
+fn effective_rebuild_reset(requested_reset: bool, durable_reset: Option<bool>) -> bool {
+    requested_reset || durable_reset.unwrap_or(false)
+}
+
 async fn run_mail_rebuild(
     app: tauri::AppHandle,
     state: Arc<AppState>,
     account: Account,
     reset_before_sync: bool,
 ) -> anyhow::Result<SyncResult> {
+    // Register before waiting on the account lock. Update/remove can request
+    // cancellation while this rebuild is queued behind another operation.
+    let cancel_receiver = state.mail_rebuild_cancellations.register(account.id);
     let _operation = state.account_operations.acquire(account.id).await;
-    let account = state
-        .store
-        .account(account.id)
-        .await?
-        .ok_or_else(|| anyhow::anyhow!("Account not found"))?;
-    run_mail_rebuild_locked(app, state, account, reset_before_sync).await
+    let current_account = match state.store.account(account.id).await {
+        Err(error) => {
+            state.mail_rebuild_cancellations.clear(account.id);
+            release_mail_rebuild(&state, account.id);
+            return Err(error.into());
+        }
+        Ok(Some(account)) => account,
+        Ok(None) => {
+            state
+                .mail_rebuilds
+                .lock()
+                .expect("mail rebuild lock poisoned")
+                .remove(&account.id);
+            state.mail_rebuild_cancellations.clear(account.id);
+            release_mail_rebuild(&state, account.id);
+            return Err(anyhow::anyhow!("Account not found"));
+        }
+    };
+    // The durable job is the source of truth while holding the account lock.
+    // A queued worker may have captured an older `false` before an update
+    // atomically replaced its job with `true`; never downgrade that reset.
+    let durable_reset = match state.store.mail_rebuild_jobs().await {
+        Ok(jobs) => jobs
+            .into_iter()
+            .find(|job| job.account_id == account.id)
+            .map(|job| job.reset_before_sync),
+        Err(error) => {
+            state.mail_rebuild_cancellations.clear(account.id);
+            release_mail_rebuild(&state, account.id);
+            return Err(error);
+        }
+    };
+    let reset_before_sync = effective_rebuild_reset(reset_before_sync, durable_reset);
+    let result = run_mail_rebuild_locked(
+        app,
+        state.clone(),
+        current_account,
+        reset_before_sync,
+        cancel_receiver,
+    )
+    .await;
+    // This is deliberately outside the worker body: database failures before
+    // the first checkpoint must not leave a queued cancellation or a stale
+    // duplicate-run reservation behind.
+    state.mail_rebuild_cancellations.clear(account.id);
+    release_mail_rebuild(&state, account.id);
+    result
 }
 
 async fn run_mail_rebuild_locked(
@@ -3773,58 +4543,134 @@ async fn run_mail_rebuild_locked(
     state: Arc<AppState>,
     account: Account,
     reset_before_sync: bool,
+    mut cancel_receiver: watch::Receiver<MailRebuildCancellationDisposition>,
 ) -> anyhow::Result<SyncResult> {
-    state.realtime.stop_account(account.id).await;
     let initial = MailRebuildJob {
         account_id: account.id,
         phase: "connecting".to_owned(),
         completed: 0,
         total: None,
+        reset_before_sync,
     };
-    state.store.save_mail_rebuild_job(&initial).await?;
-    state
-        .mail_rebuilds
-        .lock()
-        .expect("mail rebuild lock poisoned")
-        .insert(account.id, initial.into());
+    let mut stopped_realtime = false;
+    let result = async {
+        if state
+            .mail_rebuild_cancellations
+            .disposition(&cancel_receiver)
+            != MailRebuildCancellationDisposition::None
+        {
+            return Err(anyhow::anyhow!("mail rebuild cancelled"));
+        }
+        state.realtime.stop_account(account.id).await;
+        stopped_realtime = true;
+        state.store.save_mail_rebuild_job(&initial).await?;
+        state
+            .mail_rebuilds
+            .lock()
+            .expect("mail rebuild lock poisoned")
+            .insert(account.id, initial.clone().into());
 
-    let service = MailService::new(state.store.clone());
-    let progress_app = app.clone();
-    let progress_state = state.clone();
-    let account_id = account.id;
-    let result = if reset_before_sync {
-        service
-            .rebuild_all_with_progress(&account, 250, move |progress| {
-                publish_mail_rebuild_progress(&progress_app, &progress_state, account_id, progress);
-            })
-            .await
-    } else {
-        service
-            .resume_rebuild_all_with_progress(&account, 250, move |progress| {
-                publish_mail_rebuild_progress(&progress_app, &progress_state, account_id, progress);
-            })
-            .await
-    };
+        let service = MailService::new(state.store.clone());
+        let progress_app = app.clone();
+        let progress_state = state.clone();
+        let account_id = account.id;
+        let rebuild = async {
+            if reset_before_sync {
+                service
+                    .rebuild_all_with_progress(&account, 250, move |progress| {
+                        publish_mail_rebuild_progress(
+                            &progress_app,
+                            &progress_state,
+                            account_id,
+                            progress,
+                        );
+                    })
+                    .await
+            } else {
+                service
+                    .resume_rebuild_all_with_progress(&account, 250, move |progress| {
+                        publish_mail_rebuild_progress(
+                            &progress_app,
+                            &progress_state,
+                            account_id,
+                            progress,
+                        );
+                    })
+                    .await
+            }
+        };
+        tokio::pin!(rebuild);
+        tokio::select! {
+            result = &mut rebuild => result,
+            changed = cancel_receiver.changed() => {
+                match changed {
+                    Ok(()) if state.mail_rebuild_cancellations.disposition(&cancel_receiver)
+                        != MailRebuildCancellationDisposition::None =>
+                    {
+                        Err(anyhow::anyhow!("mail rebuild cancelled"))
+                    }
+                    _ => rebuild.await,
+                }
+            }
+        }
+    }
+    .await;
+    let disposition = state
+        .mail_rebuild_cancellations
+        .disposition(&cancel_receiver);
 
+    let mut result = result;
+    let retains_durable_job = result.as_ref().err().is_some_and(|failure| {
+        should_retain_mail_rebuild_job(failure, disposition, reset_before_sync)
+    });
     if result.is_ok() {
-        state.store.delete_mail_rebuild_job(account.id).await?;
+        if let Err(error) = state.store.delete_mail_rebuild_job(account.id).await {
+            result = Err(error.into());
+        }
         state
             .mail_rebuilds
             .lock()
             .expect("mail rebuild lock poisoned")
             .remove(&account.id);
-        let _ = app.emit(
-            "mail-index-rebuilt",
-            serde_json::json!({ "accountId": account.id }),
-        );
-        kick_classification(state.clone());
+        if result.is_ok() {
+            let _ = app.emit(
+                "mail-index-rebuilt",
+                serde_json::json!({ "accountId": account.id }),
+            );
+            kick_classification(state.clone());
+        }
+    } else if retains_durable_job {
+        // Leave the persisted job intact so application startup can resume
+        // this interrupted rebuild. Save the last published checkpoint before
+        // clearing the in-memory entry, so a restart resumes with truthful
+        // progress instead of the initial connecting state.
+        let latest = state
+            .mail_rebuilds
+            .lock()
+            .expect("mail rebuild lock poisoned")
+            .remove(&account.id);
+        if let Some(latest) = latest {
+            if let Err(error) = state
+                .store
+                .save_mail_rebuild_job(&MailRebuildJob {
+                    account_id: latest.account_id,
+                    phase: latest.phase,
+                    completed: latest.completed,
+                    total: latest.total,
+                    reset_before_sync: latest.reset_before_sync,
+                })
+                .await
+            {
+                tracing::warn!(
+                    account_id = %account.id,
+                    error = %error,
+                    "could not persist failed mail rebuild checkpoint"
+                );
+            }
+        }
     } else {
         if let Err(error) = state.store.delete_mail_rebuild_job(account.id).await {
-            tracing::warn!(
-                account_id = %account.id,
-                error = %error,
-                "could not clear failed mail rebuild job"
-            );
+            tracing::warn!(account_id = %account.id, error = %error, "could not delete abandoned mail rebuild job");
         }
         state
             .mail_rebuilds
@@ -3832,7 +4678,27 @@ async fn run_mail_rebuild_locked(
             .expect("mail rebuild lock poisoned")
             .remove(&account.id);
     }
-    restart_realtime_if_current(app, &state, account.id).await?;
+    let outcome = if result.is_ok() {
+        "completed"
+    } else if disposition != MailRebuildCancellationDisposition::None {
+        "cancelled"
+    } else {
+        "failed"
+    };
+    let _ = app.emit(
+        "mail-rebuild-finished",
+        serde_json::json!({ "accountId": account.id, "outcome": outcome }),
+    );
+    // Do not restart realtime into an old catalogue while a replacement reset
+    // remains reserved. The resumed rebuild owns restarting it on success.
+    if stopped_realtime && !(retains_durable_job && reset_before_sync) {
+        if let Err(error) = restart_realtime_if_current(app, &state, account.id).await {
+            if result.is_ok() {
+                return Err(error);
+            }
+            tracing::warn!(account_id = %account.id, error = %error, "could not restart realtime after mail rebuild");
+        }
+    }
     result
 }
 
@@ -3859,22 +4725,42 @@ async fn sync_account(
     on_progress: Channel<SyncProgress>,
 ) -> Result<SyncResult, String> {
     let result = if full.unwrap_or(false) {
-        let account = state
-            .store
-            .account(account_id)
-            .await
-            .map_err(error)?
-            .ok_or_else(|| "Account not found".to_owned())?;
-        if state
-            .mail_rebuilds
-            .lock()
-            .map_err(error)?
-            .contains_key(&account_id)
-        {
+        if !reserve_mail_rebuild(state.inner(), account_id) {
             return Err("A mail re-index is already running for this account".to_owned());
         }
-        let result =
-            run_mail_rebuild(app.clone(), state.inner().clone(), account.clone(), true).await;
+        let account = state.store.account(account_id).await.map_err(error);
+        let account = match account
+            .and_then(|account| account.ok_or_else(|| "Account not found".to_owned()))
+        {
+            Ok(account) => account,
+            Err(error) => {
+                release_mail_rebuild(state.inner(), account_id);
+                return Err(error);
+            }
+        };
+        let reset_before_sync = match state.mail_rebuilds.lock().map_err(error) {
+            Ok(rebuilds) => rebuilds
+                .get(&account_id)
+                .map(|job| job.reset_before_sync)
+                .unwrap_or(true),
+            Err(lock_error) => {
+                release_mail_rebuild(state.inner(), account_id);
+                return Err(lock_error);
+            }
+        };
+        if let Err(schedule_error) =
+            schedule_mail_rebuild(state.inner(), account_id, reset_before_sync).await
+        {
+            release_mail_rebuild(state.inner(), account_id);
+            return Err(error(schedule_error));
+        }
+        let result = run_mail_rebuild(
+            app.clone(),
+            state.inner().clone(),
+            account.clone(),
+            reset_before_sync,
+        )
+        .await;
         if result.is_ok() {
             let _ = on_progress.send(SyncProgress {
                 phase: "complete",
@@ -4465,6 +5351,8 @@ pub fn run() {
                     classification_owner: Uuid::new_v4().to_string(),
                     classification: Arc::new(ClassificationScheduler::default()),
                     mail_rebuilds: Mutex::new(mail_rebuilds),
+                    mail_rebuild_running: Mutex::new(HashSet::new()),
+                    mail_rebuild_cancellations: MailRebuildCancellations::default(),
                     account_operations: AccountOperationLocks::default(),
                     remote_operation_slots: Arc::new(Semaphore::new(MESSAGE_HYDRATION_CONCURRENCY)),
                     translation_downloads: Mutex::new(HashMap::new()),
@@ -4493,23 +5381,31 @@ pub fn run() {
             let realtime_app = app.handle().clone();
             tauri::async_runtime::spawn(async move {
                 kick_classification(state.clone());
-                let rebuilding: std::collections::HashSet<_> = state
+                let rebuilding: HashMap<_, _> = state
                     .mail_rebuilds
                     .lock()
                     .expect("mail rebuild lock poisoned")
-                    .keys()
-                    .copied()
+                    .iter()
+                    .map(|(account_id, job)| (*account_id, job.reset_before_sync))
                     .collect();
                 match state.store.accounts().await {
                     Ok(accounts) => {
                         for account in accounts {
-                            if rebuilding.contains(&account.id) {
+                            if let Some(reset_before_sync) = rebuilding.get(&account.id) {
                                 let rebuild_app = realtime_app.clone();
                                 let rebuild_state = state.clone();
+                                let reset_before_sync = *reset_before_sync;
+                                if !reserve_mail_rebuild(&rebuild_state, account.id) {
+                                    continue;
+                                }
                                 tauri::async_runtime::spawn(async move {
-                                    if let Err(error) =
-                                        run_mail_rebuild(rebuild_app, rebuild_state, account, false)
-                                            .await
+                                    if let Err(error) = run_mail_rebuild(
+                                        rebuild_app,
+                                        rebuild_state,
+                                        account,
+                                        reset_before_sync,
+                                    )
+                                    .await
                                     {
                                         tracing::error!(
                                             error = %error,

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -3571,7 +3571,7 @@ async fn add_account(
     let password_secret_name = credential_secret_name(&account);
     let previous_secret_name = previous_credential_secret_name(existing_account.as_ref(), &account);
     let replaced_credential = if let Some(existing) = existing_account.as_ref() {
-        let existing_secret_name = credential_secret_name(&existing);
+        let existing_secret_name = credential_secret_name(existing);
         if existing_secret_name == password_secret_name {
             state
                 .store
@@ -3709,7 +3709,7 @@ async fn add_oauth_account(
     let oauth_secret_name = credential_secret_name(&account);
     let previous_secret_name = previous_credential_secret_name(existing_account.as_ref(), &account);
     let replaced_credential = if let Some(existing) = existing_account.as_ref() {
-        let existing_secret_name = credential_secret_name(&existing);
+        let existing_secret_name = credential_secret_name(existing);
         if existing_secret_name == oauth_secret_name {
             state
                 .store
@@ -4493,7 +4493,7 @@ async fn run_mail_rebuild(
         Err(error) => {
             state.mail_rebuild_cancellations.clear(account.id);
             release_mail_rebuild(&state, account.id);
-            return Err(error.into());
+            return Err(error);
         }
         Ok(Some(account)) => account,
         Ok(None) => {
@@ -4625,7 +4625,7 @@ async fn run_mail_rebuild_locked(
     });
     if result.is_ok() {
         if let Err(error) = state.store.delete_mail_rebuild_job(account.id).await {
-            result = Err(error.into());
+            result = Err(error);
         }
         state
             .mail_rebuilds

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -13,6 +13,8 @@ import App from "./App";
 import { groupMessages } from "./threads";
 import type {
   Account,
+  AccountConnection,
+  MailRebuildFinished,
   MailRebuildProgress,
   MailSummary,
   SmartInboxPage,
@@ -28,6 +30,8 @@ const mocks = vi.hoisted(() => {
   const rebuildProgressHandlers: Array<
     (progress: MailRebuildProgress) => void
   > = [];
+  const rebuildFinishedHandlers: Array<(result: MailRebuildFinished) => void> =
+    [];
   const hydratedHandlers: Array<() => void> = [];
   const mailChangedHandlers: Array<() => void> = [];
   const nativeMenuHandlers: Array<(action: string) => void> = [];
@@ -44,6 +48,9 @@ const mocks = vi.hoisted(() => {
   const accountRemovedHandlers: Array<(event: { accountId: string }) => void> =
     [];
   const accountUpdatedHandlers: Array<(account: Account) => void> = [];
+  const accountConnectedHandlers: Array<
+    (connection: AccountConnection) => void
+  > = [];
   const account = {
     id: "account-1",
     email: "me@example.com",
@@ -149,9 +156,17 @@ const mocks = vi.hoisted(() => {
       accountUpdatedHandlers.push(handler);
       return unlisten;
     }),
+    onAccountConnected: vi.fn(
+      async (handler: (connection: AccountConnection) => void) => {
+        accountConnectedHandlers.push(handler);
+        return unlisten;
+      },
+    ),
+    accountConnectedHandlers,
     accountRemovedHandlers,
     accountUpdatedHandlers,
     rebuildProgressHandlers,
+    rebuildFinishedHandlers,
     hydratedHandlers,
     mailChangedHandlers,
     nativeMenuHandlers,
@@ -190,6 +205,12 @@ const mocks = vi.hoisted(() => {
     onMailRebuildProgress: vi.fn(
       async (handler: (progress: MailRebuildProgress) => void) => {
         rebuildProgressHandlers.push(handler);
+        return unlisten;
+      },
+    ),
+    onMailRebuildFinished: vi.fn(
+      async (handler: (result: MailRebuildFinished) => void) => {
+        rebuildFinishedHandlers.push(handler);
         return unlisten;
       },
     ),
@@ -247,7 +268,7 @@ vi.mock("./notifications", () => ({
 }));
 
 vi.mock("./nativeWindows", () => ({
-  onAccountConnected: mocks.noopListener,
+  onAccountConnected: mocks.onAccountConnected,
   onAccountRemoved: mocks.onAccountRemoved,
   onAccountUpdated: mocks.onAccountUpdated,
   onMailArrived: mocks.noopListener,
@@ -255,6 +276,7 @@ vi.mock("./nativeWindows", () => ({
   onMailHydrated: mocks.onMailHydrated,
   onMailIndexRebuilt: mocks.noopListener,
   onMailRebuildProgress: mocks.onMailRebuildProgress,
+  onMailRebuildFinished: mocks.onMailRebuildFinished,
   onMailSyncState: mocks.noopListener,
   onDesktopNotificationAction: mocks.onDesktopNotificationAction,
   onNativeMenuAction: mocks.onNativeMenuAction,
@@ -283,6 +305,7 @@ describe("App read state", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.rebuildProgressHandlers.length = 0;
+    mocks.rebuildFinishedHandlers.length = 0;
     mocks.hydratedHandlers.length = 0;
     mocks.mailChangedHandlers.length = 0;
     mocks.nativeMenuHandlers.length = 0;
@@ -293,6 +316,7 @@ describe("App read state", () => {
     mocks.openReaderWindow.mockClear();
     mocks.accountRemovedHandlers.length = 0;
     mocks.accountUpdatedHandlers.length = 0;
+    mocks.accountConnectedHandlers.length = 0;
     localStorage.clear();
     mocks.api.accounts.mockResolvedValue([mocks.account]);
     mocks.api.action.mockResolvedValue(undefined);
@@ -308,6 +332,54 @@ describe("App read state", () => {
       body_text: "Message body",
       attachments: [],
     });
+  });
+
+  it("observes an existing account connection without invoking a rebuild", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+    await waitFor(() =>
+      expect(mocks.accountConnectedHandlers.length).toBeGreaterThan(0),
+    );
+    mocks.api.sync.mockClear();
+
+    act(() => {
+      mocks.accountConnectedHandlers.at(-1)!({
+        account: { ...mocks.account, id: "existing-account" },
+        reusedExistingAccount: true,
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Unread thread")).toBeVisible(),
+    );
+    expect(mocks.api.sync).not.toHaveBeenCalled();
+  });
+
+  it("does not depend on the account-connected listener to start a fresh rebuild", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+    await waitFor(() =>
+      expect(mocks.accountConnectedHandlers.length).toBeGreaterThan(0),
+    );
+    mocks.api.sync.mockClear();
+
+    act(() => {
+      mocks.accountConnectedHandlers.at(-1)!({
+        account: { ...mocks.account, id: "new-account" },
+        reusedExistingAccount: false,
+      });
+    });
+
+    await waitFor(() =>
+      expect(screen.getByText("Unread thread")).toBeVisible(),
+    );
+    expect(mocks.api.sync).not.toHaveBeenCalled();
   });
 
   it("does not probe an AI provider while AI features are hidden", async () => {
@@ -2289,6 +2361,42 @@ describe("App read state", () => {
     );
 
     expect(await screen.findByText("Rebuilt message")).toBeVisible();
+  });
+
+  it("reloads committed rows when a rebuild is cancelled after finding", async () => {
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    await screen.findByText("Unread thread");
+    await waitFor(() =>
+      expect(mocks.rebuildProgressHandlers.length).toBeGreaterThan(0),
+    );
+    await waitFor(() =>
+      expect(mocks.rebuildFinishedHandlers.length).toBeGreaterThan(0),
+    );
+    const rebuildProgress =
+      mocks.rebuildProgressHandlers[mocks.rebuildProgressHandlers.length - 1];
+    const rebuildFinished =
+      mocks.rebuildFinishedHandlers[mocks.rebuildFinishedHandlers.length - 1];
+
+    act(() =>
+      rebuildProgress({
+        accountId: "account-1",
+        phase: "finding",
+        completed: 0,
+        total: null,
+      }),
+    );
+    expect(screen.queryByText("Unread thread")).not.toBeInTheDocument();
+
+    act(() =>
+      rebuildFinished({ accountId: "account-1", outcome: "cancelled" }),
+    );
+
+    expect(await screen.findByText("Unread thread")).toBeVisible();
   });
 
   it("purges a deleted account and reloads only the remaining account", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -56,6 +56,7 @@ import {
   onMailChanged,
   onMailHydrated,
   onMailIndexRebuilt,
+  onMailRebuildFinished,
   onMailRebuildProgress,
   onMailSyncState,
   onDesktopNotificationAction,
@@ -639,6 +640,25 @@ export default function App() {
       if (classificationRequestedRef.current) void classifyPending();
     }
   }, [loadMessages]);
+  useEffect(() => {
+    let disposed = false;
+    let dispose: () => void = () => undefined;
+    void onMailRebuildFinished(() => {
+      // A cancelled or failed rebuild can occur after the finding phase has
+      // optimistically removed this account's old rows from the list.
+      setActive(undefined);
+      setActiveThreadSnapshot(undefined);
+      setSelected(new Set());
+      void loadMessages().finally(() => setSyncStatus(undefined));
+    }).then((unlisten) => {
+      if (disposed) unlisten();
+      else dispose = unlisten;
+    });
+    return () => {
+      disposed = true;
+      dispose();
+    };
+  }, [loadMessages]);
   const loadMoreMessages = useCallback(async () => {
     if (loadingMoreRef.current || !hasMore) return;
     const currentView = currentViewRef.current;
@@ -761,7 +781,7 @@ export default function App() {
     let disposeAccount: () => void = () => undefined;
     let disposeSettings: () => void = () => undefined;
     let disposeNotifications: () => void = () => undefined;
-    void onAccountConnected((account) => {
+    void onAccountConnected(({ account }) => {
       accountStateGenerationRef.current += 1;
       setAccounts((current) => {
         const next = [
@@ -771,24 +791,19 @@ export default function App() {
         accountsRef.current = next;
         return next;
       });
-      void syncAccounts(
-        [account],
-        setSyncStatus,
-        () => void loadMessages(),
-        true,
-      )
-        .then(async () => {
-          markSynced();
-          await requestInitialNotificationAccess(notificationSettings);
-          await loadMessages(
+      // The native backend owns rebuild scheduling and execution. This event
+      // is best-effort across windows, so it only updates the visible account
+      // list; progress and terminal rebuild events drive the mail reload.
+      void requestInitialNotificationAccess(notificationSettings)
+        .then(() =>
+          loadMessages(
             selectedAccountId
               ? [selectedAccountId]
               : [...new Set([...activeAccounts, account.id])],
-          );
-          void classifyPending();
-        })
+          ),
+        )
         .catch(showError)
-        .finally(() => setSyncStatus(undefined));
+        .finally(() => void classifyPending());
     }).then((unlisten) => {
       if (disposed) unlisten();
       else disposeAccount = unlisten;

--- a/apps/desktop/src/UtilityApps.tsx
+++ b/apps/desktop/src/UtilityApps.tsx
@@ -25,6 +25,7 @@ import {
   notifyAccountUpdated,
   onMailSyncState,
   onMailIndexRebuilt,
+  onMailRebuildFinished,
   onMailRebuildProgress,
   openAccountWindow,
 } from "./nativeWindows";
@@ -66,11 +67,11 @@ export function AccountWindowApp() {
   const save = async (draft: Record<string, unknown>, password?: string) => {
     setSaving(true);
     try {
-      const account =
+      const connection =
         password === undefined
           ? await api.addOAuthAccount(draft)
           : await api.addAccount(draft, password);
-      await notifyAccountConnected(account);
+      await notifyAccountConnected(connection);
       await closeNativeWindow();
     } catch (error) {
       showError(error, t("account.setupError"));
@@ -156,10 +157,11 @@ export function SettingsWindowApp() {
     let disposeSyncState: () => void = () => undefined;
     let disposeRebuildProgress: () => void = () => undefined;
     let disposeRebuilt: () => void = () => undefined;
+    let disposeRebuildFinished: () => void = () => undefined;
     void onNativeMenuAction((action) => {
       if (action === "close-window") void closeNativeWindow();
     }).then((unlisten) => (dispose = unlisten));
-    void onAccountConnected((account) => {
+    void onAccountConnected(({ account }) => {
       setAccounts((current) => [
         ...current.filter((item) => item.id !== account.id),
         account,
@@ -182,12 +184,17 @@ export function SettingsWindowApp() {
       setAccountFullSyncing(false);
       setAccountFullSyncProgress(undefined);
     }).then((unlisten) => (disposeRebuilt = unlisten));
+    void onMailRebuildFinished(() => {
+      setAccountFullSyncing(false);
+      setAccountFullSyncProgress(undefined);
+    }).then((unlisten) => (disposeRebuildFinished = unlisten));
     return () => {
       dispose();
       disposeAccount();
       disposeSelectedAccount();
       disposeSyncState();
       disposeRebuildProgress();
+      disposeRebuildFinished();
       disposeRebuilt();
     };
   }, [t]);

--- a/apps/desktop/src/accountConnectionApi.test.ts
+++ b/apps/desktop/src/accountConnectionApi.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: apiMocks.invoke,
+  Channel: class {},
+}));
+
+describe("account connection API bridge", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    Object.defineProperty(window, "__TAURI_INTERNALS__", {
+      configurable: true,
+      value: {},
+    });
+  });
+
+  afterEach(() => {
+    Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  });
+
+  it("preserves whether an account connection reused an existing catalogue", async () => {
+    const response = {
+      account: { id: "account-1", email: "me@example.com" },
+      reusedExistingAccount: true,
+    };
+    apiMocks.invoke.mockResolvedValue(response);
+    const { api } = await import("./api");
+    const draft = { email: "me@example.com" };
+
+    await expect(api.addAccount(draft, "app-password")).resolves.toEqual(
+      response,
+    );
+    await expect(api.addOAuthAccount(draft)).resolves.toEqual(response);
+    expect(apiMocks.invoke.mock.calls).toEqual([
+      ["add_account", { input: { draft, password: "app-password" } }],
+      ["add_oauth_account", { draft }],
+    ]);
+  });
+});

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -3,6 +3,7 @@ import { mailboxFamily } from "./mailActions";
 import { groupMessages } from "./threads";
 import type {
   Account,
+  AccountConnection,
   Attachment,
   AiSettings,
   ComposeAttachment,
@@ -92,9 +93,9 @@ const desktopApi = {
   removeAccount: (accountId: string) =>
     invoke<void>("remove_account", { accountId }),
   addAccount: (draft: Record<string, unknown>, password: string) =>
-    invoke<Account>("add_account", { input: { draft, password } }),
+    invoke<AccountConnection>("add_account", { input: { draft, password } }),
   addOAuthAccount: (draft: Record<string, unknown>) =>
-    invoke<Account>("add_oauth_account", { draft }),
+    invoke<AccountConnection>("add_oauth_account", { draft }),
   search: (
     text = "",
     accountIds: string[] = [],
@@ -476,8 +477,14 @@ const demoApi: typeof desktopApi = {
       ? desktopApi.showEmailAddressContextMenu(...args)
       : Promise.resolve(),
   removeAccount: async () => undefined,
-  addAccount: async () => demoAccount,
-  addOAuthAccount: async () => demoAccount,
+  addAccount: async () => ({
+    account: demoAccount,
+    reusedExistingAccount: false,
+  }),
+  addOAuthAccount: async () => ({
+    account: demoAccount,
+    reusedExistingAccount: false,
+  }),
   search: async (
     text,
     accountIds,

--- a/apps/desktop/src/nativeWindows.ts
+++ b/apps/desktop/src/nativeWindows.ts
@@ -6,10 +6,12 @@ import {
 } from "@tauri-apps/api/webviewWindow";
 import type {
   Account,
+  AccountConnection,
   AiSettings,
   MailArrival,
   MailHydrated,
   MailRebuildProgress,
+  MailRebuildFinished,
   NotificationSettings,
   NotificationAction,
   RealtimeSyncStatus,
@@ -111,10 +113,10 @@ export function onNativeMenuAction(
 }
 
 export function onAccountConnected(
-  handler: (account: Account) => void,
+  handler: (connection: AccountConnection) => void,
 ): Promise<UnlistenFn> {
   if (!isTauri()) return Promise.resolve(() => undefined);
-  return listen<Account>("account-connected", (event) =>
+  return listen<AccountConnection>("account-connected", (event) =>
     handler(event.payload),
   );
 }
@@ -213,6 +215,15 @@ export function onMailRebuildProgress(
   );
 }
 
+export function onMailRebuildFinished(
+  handler: (result: MailRebuildFinished) => void,
+): Promise<UnlistenFn> {
+  if (!isTauri()) return Promise.resolve(() => undefined);
+  return listen<MailRebuildFinished>("mail-rebuild-finished", (event) =>
+    handler(event.payload),
+  );
+}
+
 export function onMailSyncState(
   handler: (status: RealtimeSyncStatus) => void,
 ): Promise<UnlistenFn> {
@@ -222,11 +233,11 @@ export function onMailSyncState(
   );
 }
 
-export async function notifyAccountConnected(account: Account) {
+export async function notifyAccountConnected(connection: AccountConnection) {
   if (isTauri()) {
     await Promise.allSettled([
-      emitTo("main", "account-connected", account),
-      emitTo("settings", "account-connected", account),
+      emitTo("main", "account-connected", connection),
+      emitTo("settings", "account-connected", connection),
     ]);
   }
 }

--- a/apps/desktop/src/types.ts
+++ b/apps/desktop/src/types.ts
@@ -21,6 +21,10 @@ export type Account = {
   spam_mailbox: string;
   enabled: boolean;
 };
+export type AccountConnection = {
+  account: Account;
+  reusedExistingAccount: boolean;
+};
 export type Provider = {
   id: string;
   name: string;
@@ -167,6 +171,10 @@ export type SyncStatus = SyncProgress & {
 };
 export type MailRebuildProgress = SyncProgress & {
   accountId: string;
+};
+export type MailRebuildFinished = {
+  accountId: string;
+  outcome: "completed" | "failed" | "cancelled";
 };
 export type SyncResult = {
   syncedCount: number;

--- a/apps/desktop/testdata/tauri-contract-origins.json
+++ b/apps/desktop/testdata/tauri-contract-origins.json
@@ -13,6 +13,7 @@
     "mail-changed": "native",
     "mail-hydrated": "native",
     "mail-index-rebuilt": "native",
+    "mail-rebuild-finished": "native",
     "mail-rebuild-progress": "native",
     "mail-sync-state": "native",
     "menu-action": "native",

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -84,7 +84,22 @@ const MAX_TARGETED_ATTACHMENT_ENCODED_BYTES: usize = 36 * 1024 * 1024;
 /// Do not let a malicious BODYSTRUCTURE response grow an unbounded String
 /// before the MIME parser has a chance to enforce its structural limits.
 const MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES: usize = MAX_MIME_HEADER_BYTES;
+/// Keep response work bounded independently from the byte limit. Catalogue
+/// discovery deliberately uses smaller pages, so a provider that emits an
+/// unreasonable number of untagged responses is treated as non-authoritative.
+const MAX_IMAP_RESPONSE_LINES: usize = 2_048;
 const MAX_IMAP_RESPONSE_LITERALS: usize = 64;
+const MAX_IMAP_COMMAND_BYTES: usize = 8 * 1024;
+const MAX_METADATA_FETCH_UIDS: usize = 25;
+/// Realtime remains responsive even when a mailbox has accumulated a large
+/// durable repair queue. Full rebuilds drain the complete queue separately.
+const REALTIME_FAILED_UID_RETRY_LIMIT: usize = 25;
+/// Sequence-number pages bound each flag response without imposing a global
+/// limit on the size of a mailbox.
+const MAILBOX_SNAPSHOT_PAGE_SIZE: u32 = 500;
+/// Dakia supports catalogues well beyond the six-figure mailbox acceptance
+/// case, but rejects implausible SELECT counts before allocating page work.
+const MAX_SUPPORTED_MAILBOX_MESSAGES: u32 = 1_000_000;
 /// Explicit raw export/full-forward operations may need transport encoding
 /// overhead beyond decoded attachment limits, but never receive an unbounded
 /// server response.
@@ -353,28 +368,17 @@ impl MailService {
         client.authenticate(account, &secret).await?;
         let capabilities = client.command("CAPABILITY").await?;
         let supports_idle = supports_idle(&capabilities);
-        let select = client.command("SELECT INBOX").await?;
-        let uid_validity = parse_uid_validity(&select);
+        client.command("SELECT INBOX").await?;
         let mut detected_at = Some(Utc::now());
         let mut new_messages = self
-            .fetch_new_inbox_headers(
-                &mut client,
-                account,
-                max_messages,
-                uid_validity.map(u64::from),
-            )
+            .fetch_new_inbox_headers(&mut client, account, max_messages)
             .await?;
         if new_messages.is_empty() && supports_idle {
             match client.idle_until_change(cancel).await? {
                 IdleOutcome::Changed => {
                     detected_at = Some(Utc::now());
                     new_messages = self
-                        .fetch_new_inbox_headers(
-                            &mut client,
-                            account,
-                            max_messages,
-                            uid_validity.map(u64::from),
-                        )
+                        .fetch_new_inbox_headers(&mut client, account, max_messages)
                         .await?;
                 }
                 IdleOutcome::Cancelled => {
@@ -389,12 +393,7 @@ impl MailService {
                 IdleOutcome::Renewed => {
                     detected_at = Some(Utc::now());
                     new_messages = self
-                        .fetch_new_inbox_headers(
-                            &mut client,
-                            account,
-                            max_messages,
-                            uid_validity.map(u64::from),
-                        )
+                        .fetch_new_inbox_headers(&mut client, account, max_messages)
                         .await?;
                 }
             }
@@ -419,33 +418,94 @@ impl MailService {
         })
     }
 
-    async fn fetch_new_inbox_headers(
+    async fn fetch_new_inbox_headers<S>(
         &self,
-        client: &mut ImapClient,
+        client: &mut ImapClient<S>,
         account: &Account,
         max_messages: u32,
-        uid_validity: Option<u64>,
-    ) -> Result<Vec<MailSummary>> {
+    ) -> Result<Vec<MailSummary>>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let selected = client.command("SELECT INBOX").await?;
+        let snapshot_identity = parse_mailbox_identity(&selected)?;
         let state = self
             .store
-            .prepare_mailbox_sync(account.id, "INBOX", uid_validity)
+            .prepare_mailbox_sync(
+                account.id,
+                "INBOX",
+                Some(u64::from(snapshot_identity.uid_validity)),
+            )
             .await?;
-        // Realtime sync must observe removals as well as arrivals. Searching
-        // only above the durable watermark leaves an archived UID in the
-        // local Inbox forever: the row can reappear after the optimistic UI
-        // update, but hydrating it then fails because the provider no longer
-        // has that UID in INBOX.
-        let search = client.command("UID SEARCH ALL").await?;
-        let remote_uids = parse_search_uids(&search);
-        let remote_set = remote_uids.iter().copied().collect();
-        self.store
-            .reconcile_mailbox_uids(account.id, "INBOX", &remote_set)
+        let snapshot_generation = self
+            .store
+            .begin_mailbox_snapshot(
+                account.id,
+                "INBOX",
+                "INBOX",
+                snapshot_identity.uid_validity,
+                snapshot_identity.exists,
+                snapshot_identity.uid_next,
+                snapshot_identity.highest_modseq,
+            )
             .await?;
-        let mut uids = sync_uids(remote_uids, state.highest_uid, max_messages);
-        let mut scheduled = uids
+        for (start, end) in mailbox_snapshot_page_ranges(snapshot_identity.exists) {
+            let page = fetch_mailbox_snapshot_range(client, start, end, None).await?;
+            let flags = page
+                .iter()
+                .map(|item| (item.uid, item.is_read, item.is_flagged))
+                .collect::<Vec<_>>();
+            self.store
+                .stage_mailbox_snapshot_page(account.id, "INBOX", &snapshot_generation, &flags)
+                .await?;
+        }
+        let mut remote_uids = self
+            .store
+            .staged_mailbox_snapshot_uids(account.id, "INBOX", &snapshot_generation)
+            .await?;
+        remote_uids.sort_unstable();
+        if remote_uids.len() != usize::try_from(snapshot_identity.exists)? {
+            bail!("IMAP mailbox snapshot repeated a UID across pages");
+        }
+        let remote_set: std::collections::HashSet<u32> = remote_uids.iter().copied().collect();
+        let local_uids = self.store.mailbox_uids(account.id, "INBOX").await?;
+        let mut durable_failures = self
+            .store
+            .mailbox_sync_failure_uids(account.id, "INBOX")
+            .await?;
+        durable_failures.retain(|uid| remote_set.contains(uid));
+        durable_failures.truncate(REALTIME_FAILED_UID_RETRY_LIMIT);
+        let force_replacement = state.uid_validity_changed;
+        let mut scheduled = durable_failures
             .iter()
             .copied()
             .collect::<std::collections::HashSet<_>>();
+        let limit = max_messages as usize;
+        let incremental_uids = if let Some(highest_uid) = state.highest_uid {
+            remote_uids
+                .iter()
+                .copied()
+                .filter(|uid| *uid > highest_uid)
+                .filter(|uid| !local_uids.contains(uid))
+                .filter(|uid| scheduled.insert(*uid))
+                .take(limit)
+                .collect::<Vec<_>>()
+        } else {
+            let mut newest = remote_uids
+                .iter()
+                .rev()
+                .copied()
+                .filter(|uid| force_replacement || !local_uids.contains(uid))
+                .filter(|uid| scheduled.insert(*uid))
+                .take(if force_replacement { usize::MAX } else { limit })
+                .collect::<Vec<_>>();
+            newest.reverse();
+            newest
+        };
+        // New unseen mail goes first. A known oversized or truncated UID may
+        // abort the connection again, but must not starve later arrivals.
+        let mut uids = incremental_uids.clone();
+        uids.extend(durable_failures.iter().copied());
         for uid in self
             .store
             .unscanned_recipient_header_uids(account.id, "INBOX", RECIPIENT_HEADER_BACKFILL_BATCH)
@@ -455,37 +515,255 @@ impl MailService {
                 uids.push(uid);
             }
         }
-        let mut messages = Vec::with_capacity(uids.len());
-        let highest_processed_uid = uids.iter().copied().max();
-        for uid in uids {
-            let fields = "FLAGS INTERNALDATE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)]";
-            let mut response = client
-                .command_with_literal_limited(
-                    &format!("UID FETCH {uid} ({fields})"),
-                    MAX_MIME_HEADER_BYTES,
+        if force_replacement {
+            uids = self
+                .store
+                .staged_mailbox_snapshot_uids_without_replacement_outcome(
+                    account.id,
+                    "INBOX",
+                    &snapshot_generation,
                 )
                 .await?;
-            if let Some(raw) = response.take_header_literal_for(uid) {
-                match parse_header_message(account, "INBOX", uid, &response.lines, &raw) {
-                    Ok(message) => messages.push(message),
-                    Err(error) => {
-                        eprintln!("Dakia rejected INBOX UID {uid} before persistence: {error}")
+        }
+        let mut messages: Vec<MailSummary> =
+            Vec::with_capacity(if force_replacement { 0 } else { uids.len() });
+        let mut replacement_successful = std::collections::HashSet::new();
+        let mut failed_uids = Vec::new();
+        let fields = "FLAGS INTERNALDATE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)]";
+        if force_replacement {
+            for uid_batch in uids.chunks(MAX_METADATA_FETCH_UIDS) {
+                let mut fetch =
+                    fetch_uid_data_batched(client, uid_batch, fields, MAX_MIME_HEADER_BYTES).await;
+                for (uid, error) in &fetch.failures {
+                    self.store
+                        .record_mailbox_sync_failure(account.id, "INBOX", *uid, "metadata", error)
+                        .await?;
+                    failed_uids.push((*uid, error.clone()));
+                }
+                let mut replacement_page = Vec::with_capacity(uid_batch.len());
+                for (uid, mut response) in fetch.responses.drain(..) {
+                    if let Some(raw) = response.take_header_literal_for(uid) {
+                        match parse_header_message(account, "INBOX", uid, &response.lines, &raw) {
+                            Ok(message) => {
+                                replacement_successful.insert(uid);
+                                replacement_page.push(message);
+                            }
+                            Err(error) => {
+                                eprintln!(
+                                    "Dakia rejected INBOX UID {uid} before persistence: {error}"
+                                );
+                                failed_uids.push((uid, error.to_string()));
+                            }
+                        }
+                    } else {
+                        failed_uids.push((
+                            uid,
+                            "IMAP server omitted the requested header literal".into(),
+                        ));
                     }
+                }
+                self.store
+                    .stage_mailbox_snapshot_message_page(
+                        account.id,
+                        "INBOX",
+                        &snapshot_generation,
+                        &replacement_page,
+                    )
+                    .await?;
+                if let Some(error) = fetch.fatal {
+                    return Err(error).context("could not fetch replacement INBOX metadata");
+                }
+            }
+        } else {
+            for uid in uids {
+                let mut response = match client
+                    .command_with_literal_limited(
+                        &format!("UID FETCH {uid} ({fields})"),
+                        MAX_MIME_HEADER_BYTES,
+                    )
+                    .await
+                {
+                    Ok(response) => response,
+                    Err(error) => {
+                        let successful = messages
+                            .iter()
+                            .map(|message| u32::try_from(message.uid))
+                            .collect::<std::result::Result<std::collections::HashSet<_>, _>>()?;
+                        if !force_replacement && !messages.is_empty() {
+                            let mut unresolved = durable_failures
+                                .iter()
+                                .copied()
+                                .collect::<std::collections::HashSet<_>>();
+                            unresolved.insert(uid);
+                            for successful_uid in &successful {
+                                unresolved.remove(successful_uid);
+                            }
+                            let mut persisted = local_uids.clone();
+                            persisted.extend(successful.iter().copied());
+                            let watermark = state.highest_uid.map(|highest_uid| {
+                                remote_uids
+                                    .iter()
+                                    .copied()
+                                    .filter(|candidate| *candidate > highest_uid)
+                                    .take_while(|candidate| {
+                                        !unresolved.contains(candidate)
+                                            && persisted.contains(candidate)
+                                    })
+                                    .last()
+                                    .unwrap_or(highest_uid)
+                            });
+                            self.store
+                                .save_synced_messages_through(
+                                    account.id, "INBOX", &messages, watermark,
+                                )
+                                .await?;
+                            for successful_uid in successful {
+                                self.store
+                                    .clear_mailbox_sync_failure(account.id, "INBOX", successful_uid)
+                                    .await?;
+                            }
+                        }
+                        self.store
+                            .record_mailbox_sync_failure(
+                                account.id,
+                                "INBOX",
+                                uid,
+                                "metadata",
+                                &error.to_string(),
+                            )
+                            .await?;
+                        self.store
+                            .discard_mailbox_snapshot(account.id, "INBOX", &snapshot_generation)
+                            .await?;
+                        return Err(error).context(format!("could not fetch INBOX UID {uid}"));
+                    }
+                };
+                if let Some(raw) = response.take_header_literal_for(uid) {
+                    match parse_header_message(account, "INBOX", uid, &response.lines, &raw) {
+                        Ok(message) => messages.push(message),
+                        Err(error) => {
+                            eprintln!("Dakia rejected INBOX UID {uid} before persistence: {error}");
+                            failed_uids.push((uid, error.to_string()));
+                        }
+                    }
+                } else {
+                    failed_uids.push((
+                        uid,
+                        "IMAP server omitted the requested header literal".into(),
+                    ));
                 }
             }
         }
-        let new_messages = self
-            .store
-            .save_synced_messages(account.id, "INBOX", &messages)
-            .await?;
-        if let Some(uid) = highest_processed_uid {
+        let mut successful = messages
+            .iter()
+            .map(|message| u32::try_from(message.uid))
+            .collect::<std::result::Result<std::collections::HashSet<_>, _>>()?;
+        successful.extend(replacement_successful);
+        let current_failures = failed_uids
+            .iter()
+            .map(|(uid, _)| *uid)
+            .collect::<std::collections::HashSet<_>>();
+        let mut unresolved_failures = durable_failures
+            .into_iter()
+            .chain(current_failures.iter().copied())
+            .collect::<std::collections::HashSet<_>>();
+        for uid in &successful {
+            unresolved_failures.remove(uid);
+        }
+        let mut persisted_uids = local_uids;
+        persisted_uids.extend(successful.iter().copied());
+        let contiguous_watermark = if force_replacement {
+            remote_uids.last().copied()
+        } else if let Some(highest_uid) = state.highest_uid {
+            let mut contiguous = Some(highest_uid);
+            for uid in remote_uids.iter().copied().filter(|uid| *uid > highest_uid) {
+                if unresolved_failures.contains(&uid) || !persisted_uids.contains(&uid) {
+                    break;
+                }
+                contiguous = Some(uid);
+            }
+            contiguous
+        } else {
+            let mut contiguous = None;
+            for uid in &incremental_uids {
+                if current_failures.contains(uid) || !successful.contains(uid) {
+                    break;
+                }
+                contiguous = Some(*uid);
+            }
+            contiguous
+        };
+        let new_messages = if force_replacement {
+            Vec::new()
+        } else {
             self.store
-                .advance_mailbox_sync_watermark(account.id, "INBOX", uid)
+                .save_synced_messages_through(account.id, "INBOX", &messages, contiguous_watermark)
+                .await?
+        };
+        for (uid, error) in &failed_uids {
+            self.store
+                .record_mailbox_sync_failure(account.id, "INBOX", *uid, "metadata", error)
                 .await?;
         }
-        self.store
-            .set_mailbox_uid_validity(account.id, "INBOX", uid_validity)
-            .await?;
+        for uid in &successful {
+            self.store
+                .clear_mailbox_sync_failure(account.id, "INBOX", *uid)
+                .await?;
+        }
+        if !failed_uids.is_empty() {
+            if !force_replacement {
+                self.store
+                    .discard_mailbox_snapshot(account.id, "INBOX", &snapshot_generation)
+                    .await?;
+            }
+            bail!("IMAP metadata remained incomplete for one or more messages");
+        }
+        let selected = client.command("SELECT INBOX").await?;
+        let final_identity = parse_mailbox_identity(&selected)?;
+        match verify_mailbox_snapshot_membership(
+            client,
+            &snapshot_identity,
+            &final_identity,
+            &remote_uids,
+        )
+        .await
+        {
+            Ok(Some(second)) => {
+                let flags = second
+                    .iter()
+                    .map(|item| (item.uid, item.is_read, item.is_flagged))
+                    .collect::<Vec<_>>();
+                self.store
+                    .stage_mailbox_snapshot_page(account.id, "INBOX", &snapshot_generation, &flags)
+                    .await?;
+            }
+            Ok(None) => {}
+            Err(error) => {
+                self.store
+                    .discard_mailbox_snapshot(account.id, "INBOX", &snapshot_generation)
+                    .await?;
+                return Err(error).context("IMAP inbox membership was not stable");
+            }
+        }
+        if force_replacement {
+            self.store
+                .finalize_mailbox_snapshot_with_staged_replacements_and_watermark(
+                    account.id,
+                    "INBOX",
+                    &snapshot_generation,
+                    contiguous_watermark,
+                )
+                .await?;
+        } else {
+            self.store
+                .finalize_mailbox_snapshot_with_watermark(
+                    account.id,
+                    "INBOX",
+                    &snapshot_generation,
+                    contiguous_watermark,
+                )
+                .await?;
+        }
         Ok(new_messages)
     }
 
@@ -661,11 +939,10 @@ impl MailService {
             completed: 0,
             total: None,
         });
-        let select = client.command("SELECT INBOX").await?;
-        let uid_validity = parse_uid_validity(&select).map(u64::from);
+        client.command("SELECT INBOX").await?;
         let before = self.store.mailbox_uids(account.id, "INBOX").await?;
         let new_messages = self
-            .fetch_new_inbox_headers(&mut client, account, max_messages, uid_validity)
+            .fetch_new_inbox_headers(&mut client, account, max_messages)
             .await?;
         let after = self.store.mailbox_uids(account.id, "INBOX").await?;
         let _ = client.command("LOGOUT").await;
@@ -737,15 +1014,31 @@ impl MailService {
         });
         let secret = self.credentials.secret(account).await?;
         client.authenticate(account, &secret).await?;
-        let listing = client.command("LIST \"\" \"*\"").await.unwrap_or_default();
+        let capabilities = client.command("CAPABILITY").await?;
+        let condstore = supports_condstore(&capabilities);
+        let requested_families = plans
+            .iter()
+            .filter_map(|plan| special_mailbox_family(plan.local))
+            .collect::<std::collections::HashSet<_>>();
+        let (listing, listing_authoritative) = match client.command("LIST \"\" \"*\"").await {
+            Ok(listing) => match validate_list_response(&listing) {
+                Ok(()) => (listing, true),
+                Err(error) if reset_before_sync => {
+                    return Err(error).context(
+                        "cannot replace mailbox families without a complete LIST response",
+                    );
+                }
+                Err(_) => (listing, false),
+            },
+            Err(error) if reset_before_sync => {
+                return Err(error)
+                    .context("cannot replace mailbox families because LIST discovery failed");
+            }
+            Err(_) => (Vec::new(), false),
+        };
         let plans = resolve_special_mailboxes(plans, &listing);
-        if reset_before_sync {
-            client
-                .command("SELECT INBOX")
-                .await
-                .context("cannot rebuild because the provider inbox is unavailable")?;
-            self.store.reset_account_mail_index(account.id).await?;
-        }
+        let mut family_keep = std::collections::HashMap::<&'static str, Vec<String>>::new();
+        let mut incomplete_families = std::collections::HashSet::<&'static str>::new();
         on_progress(SyncProgress {
             phase: "finding",
             completed: 0,
@@ -753,46 +1046,212 @@ impl MailService {
         });
         let mut work = Vec::new();
         for plan in plans {
-            let selected = match client
-                .command(&format!("SELECT {}", quote_imap(&plan.remote)))
-                .await
-            {
+            let mut mailbox_condstore = condstore;
+            let mut select_command = if mailbox_condstore {
+                format!("SELECT {} (CONDSTORE)", quote_imap(&plan.remote))
+            } else {
+                format!("SELECT {}", quote_imap(&plan.remote))
+            };
+            let selected = match client.command(&select_command).await {
                 Ok(selected) => selected,
-                Err(_) => {
+                Err(error)
+                    if mailbox_condstore
+                        && error.to_string().starts_with("IMAP command failed:") =>
+                {
+                    mailbox_condstore = false;
+                    select_command = format!("SELECT {}", quote_imap(&plan.remote));
+                    match client.command(&select_command).await {
+                        Ok(selected) => selected,
+                        Err(error) => {
+                            if plan.local == "INBOX" {
+                                return Err(error).context("IMAP server does not expose an inbox");
+                            }
+                            if reset_before_sync {
+                                if imap_error_confirms_nonexistent(&error) {
+                                    continue;
+                                }
+                                return Err(error).context(format!(
+                                    "cannot replace optional mailbox {} because SELECT failed",
+                                    plan.storage
+                                ));
+                            }
+                            if let Some(family) = special_mailbox_family(plan.local) {
+                                incomplete_families.insert(family);
+                            }
+                            continue;
+                        }
+                    }
+                }
+                Err(error) => {
                     if plan.local == "INBOX" {
-                        bail!("IMAP server does not expose an inbox");
+                        return Err(error).context("IMAP server does not expose an inbox");
+                    }
+                    if reset_before_sync {
+                        if imap_error_confirms_nonexistent(&error) {
+                            continue;
+                        }
+                        return Err(error).context(format!(
+                            "cannot replace optional mailbox {} because SELECT failed",
+                            plan.storage
+                        ));
+                    }
+                    if let Some(family) = special_mailbox_family(plan.local) {
+                        incomplete_families.insert(family);
                     }
                     continue;
                 }
             };
-            let uid_validity = parse_uid_validity(&selected)
-                .context("IMAP server omitted UIDVALIDITY after SELECT")?;
-            let previous_state = self
+            if let Some(family) = special_mailbox_family(plan.local) {
+                family_keep
+                    .entry(family)
+                    .or_default()
+                    .push(plan.storage.clone());
+            }
+            let mut snapshot_identity = parse_mailbox_identity(&selected)?;
+            let uid_validity = snapshot_identity.uid_validity;
+            let mut previous_state = self
                 .store
                 .mailbox_catalog_state(account.id, &plan.storage)
                 .await?;
-            if previous_state
+            let uid_validity_changed = previous_state
                 .as_ref()
-                .is_some_and(|state| state.uid_validity != i64::from(uid_validity))
+                .is_some_and(|state| state.uid_validity != i64::from(uid_validity));
+            if uid_validity_changed {
+                previous_state = None;
+            }
+            let has_pending_repairs = !self
+                .store
+                .mailbox_sync_failure_uids(account.id, &plan.storage)
+                .await?
+                .is_empty()
+                || !self
+                    .store
+                    .mime_encoded_snippet_uids(account.id, &plan.storage)
+                    .await?
+                    .is_empty()
+                || !self
+                    .store
+                    .unscanned_recipient_header_uids(
+                        account.id,
+                        &plan.storage,
+                        RECIPIENT_HEADER_BACKFILL_BATCH,
+                    )
+                    .await?
+                    .is_empty();
+            let saved_modseq = previous_state
+                .as_ref()
+                .filter(|_| !reset_before_sync)
+                .filter(|_| snapshot_identity.highest_modseq.is_some())
+                .filter(|state| state.historical_complete)
+                .filter(|state| state.remote_total == i64::from(snapshot_identity.exists))
+                .filter(|state| {
+                    state.uid_next.is_some()
+                        && state.uid_next == snapshot_identity.uid_next.map(i64::from)
+                })
+                .and_then(|state| state.highest_modseq.as_deref())
+                .and_then(|value| value.parse::<u64>().ok());
+            if let Some(saved_modseq) = saved_modseq
+                .filter(|_| mailbox_condstore)
+                .filter(|_| !has_pending_repairs)
             {
+                let mut delta = Vec::new();
+                let mut delta_rejected = false;
+                for (start, end) in mailbox_snapshot_page_ranges(snapshot_identity.exists) {
+                    match fetch_mailbox_snapshot_range(client, start, end, Some(saved_modseq)).await
+                    {
+                        Ok(page) => delta.extend(page),
+                        Err(error) if error.to_string().starts_with("IMAP command failed:") => {
+                            delta_rejected = true;
+                            break;
+                        }
+                        Err(error) => return Err(error),
+                    }
+                }
+                if !delta_rejected {
+                    let selected = client.command(&select_command).await?;
+                    let final_identity = parse_mailbox_identity(&selected)?;
+                    if mailbox_identity_is_stable(&snapshot_identity, &final_identity) {
+                        let flags = delta
+                            .iter()
+                            .map(|item| (item.uid, item.is_read, item.is_flagged))
+                            .collect::<Vec<_>>();
+                        self.store
+                            .apply_complete_mailbox_changed_since_flags(
+                                account.id,
+                                &plan.storage,
+                                &plan.remote,
+                                final_identity.uid_validity,
+                                usize::try_from(final_identity.exists)?,
+                                final_identity.uid_next,
+                                final_identity.highest_modseq,
+                                &flags,
+                            )
+                            .await?;
+                        continue;
+                    }
+                    // A concurrent flag change or mailbox mutation invalidates
+                    // the delta but the final SELECT provides a fresh identity
+                    // for the complete bounded snapshot below.
+                    snapshot_identity = final_identity;
+                }
+            }
+            let snapshot_generation = self
+                .store
+                .begin_mailbox_snapshot(
+                    account.id,
+                    &plan.storage,
+                    &plan.remote,
+                    snapshot_identity.uid_validity,
+                    snapshot_identity.exists,
+                    snapshot_identity.uid_next,
+                    snapshot_identity.highest_modseq,
+                )
+                .await?;
+            for (start, end) in mailbox_snapshot_page_ranges(snapshot_identity.exists) {
+                let page = fetch_mailbox_snapshot_range(client, start, end, None).await?;
+                let flags = page
+                    .iter()
+                    .map(|item| (item.uid, item.is_read, item.is_flagged))
+                    .collect::<Vec<_>>();
                 self.store
-                    .reset_mailbox_catalog(account.id, &plan.storage)
+                    .stage_mailbox_snapshot_page(
+                        account.id,
+                        &plan.storage,
+                        &snapshot_generation,
+                        &flags,
+                    )
                     .await?;
             }
-            let search = client.command("UID SEARCH ALL").await?;
-            let mut remote_uids = parse_search_uids(&search);
+            let mut remote_uids = self
+                .store
+                .staged_mailbox_snapshot_uids(account.id, &plan.storage, &snapshot_generation)
+                .await?;
             remote_uids.sort_unstable();
-            let current_flags = client.command("UID FETCH 1:* (UID FLAGS)").await?;
-            self.store
-                .update_mailbox_flags(account.id, &plan.storage, &parse_uid_flags(&current_flags))
-                .await?;
-            let remote_set = remote_uids.iter().copied().collect();
-            self.store
-                .reconcile_mailbox_uids(account.id, &plan.storage, &remote_set)
-                .await?;
-            let local_uids = self.store.mailbox_uids(account.id, &plan.storage).await?;
+            if remote_uids.len() != usize::try_from(snapshot_identity.exists)? {
+                bail!("IMAP mailbox snapshot repeated a UID across pages");
+            }
+            let remote_set: std::collections::HashSet<u32> = remote_uids.iter().copied().collect();
+            let local_uids = if reset_before_sync || uid_validity_changed {
+                std::collections::HashSet::new()
+            } else {
+                self.store.mailbox_uids(account.id, &plan.storage).await?
+            };
             let previous_highest = local_uids.iter().copied().max();
-            let mut missing = missing_uids_newest_first(&remote_uids, &local_uids);
+            let durable_failures = self
+                .store
+                .mailbox_sync_failure_uids(account.id, &plan.storage)
+                .await?
+                .into_iter()
+                .filter(|uid| remote_set.contains(uid))
+                .collect::<Vec<_>>();
+            let durable_failure_set = durable_failures
+                .iter()
+                .copied()
+                .collect::<std::collections::HashSet<_>>();
+            let mut missing = missing_uids_newest_first(&remote_uids, &local_uids)
+                .into_iter()
+                .filter(|uid| !durable_failure_set.contains(uid))
+                .collect::<Vec<_>>();
             let mut scheduled: std::collections::HashSet<_> = missing.iter().copied().collect();
             for uid in self
                 .store
@@ -816,27 +1275,35 @@ impl MailService {
                     missing.push(uid);
                 }
             }
-            // Newest-first means the useful end of every mailbox appears
-            // immediately. Every committed batch is resumable because the
-            // remaining work is derived from the catalogue on reconnect.
-            self.store
-                .save_mailbox_catalog_state(
-                    account.id,
-                    &plan.storage,
-                    &plan.remote,
-                    uid_validity,
-                    remote_uids.len(),
-                    missing.is_empty(),
-                )
-                .await?;
+            for uid in durable_failures {
+                if scheduled.insert(uid) {
+                    missing.push(uid);
+                }
+            }
+            let replace_namespace = reset_before_sync || uid_validity_changed;
+            if replace_namespace {
+                missing = self
+                    .store
+                    .staged_mailbox_snapshot_uids_without_replacement_outcome(
+                        account.id,
+                        &plan.storage,
+                        &snapshot_generation,
+                    )
+                    .await?;
+            }
             work.push(MailboxSyncWork {
                 plan,
-                uid_validity,
-                remote_total: remote_uids.len(),
-                initialized: previous_state.is_some(),
+                snapshot_generation,
+                snapshot_identity,
+                condstore: mailbox_condstore,
+                replace_namespace,
+                initialized: previous_state.is_some() && !reset_before_sync,
                 previous_highest,
+                inventory_uids: remote_uids,
                 uids: missing,
+                retry_uids: durable_failure_set,
                 offset: 0,
+                failed_uids: Vec::new(),
             });
         }
         let total = work.iter().map(|item| item.uids.len()).sum();
@@ -859,52 +1326,142 @@ impl MailService {
                 client
                     .command(&format!("SELECT {}", quote_imap(&item.plan.remote)))
                     .await?;
-                let end = (item.offset + batch_size).min(item.uids.len());
+                let end = if item.retry_uids.contains(&item.uids[item.offset]) {
+                    item.offset + 1
+                } else {
+                    let next_retry = item.uids[item.offset..]
+                        .iter()
+                        .position(|uid| item.retry_uids.contains(uid))
+                        .map(|position| item.offset + position)
+                        .unwrap_or(item.uids.len());
+                    (item.offset + batch_size).min(next_retry)
+                };
                 let batch = &item.uids[item.offset..end];
                 let mut messages = Vec::with_capacity(batch.len());
-                for uid in batch {
-                    let fields = if account.provider_id == "gmail" {
-                        "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE X-GM-LABELS BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
-                    } else {
-                        "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
-                    };
-                    let mut response = client
-                        .command_with_literal_limited(
-                            &format!("UID FETCH {uid} ({fields})"),
-                            MAX_MIME_HEADER_BYTES,
+                let fields = if account.provider_id == "gmail" {
+                    "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE X-GM-LABELS BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
+                } else {
+                    "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]"
+                };
+                let mut header_fetch =
+                    fetch_uid_data_batched(client, batch, fields, MAX_MIME_HEADER_BYTES).await;
+                for (uid, error) in &header_fetch.failures {
+                    self.store
+                        .record_mailbox_sync_failure(
+                            account.id,
+                            &item.plan.storage,
+                            *uid,
+                            "metadata",
+                            error,
                         )
                         .await?;
-                    if let Some(headers) = response.take_header_literal_for(*uid) {
+                    item.failed_uids.push(*uid);
+                }
+                let mut metadata = Vec::new();
+                let mut excluded_uids = Vec::new();
+                for (uid, mut response) in header_fetch.responses.drain(..) {
+                    if let Some(headers) = response.take_header_literal_for(uid) {
                         if !item.plan.skip_gmail_system_labels
                             || gmail_all_mail_is_archive(&response.lines)
                         {
-                            let snippet = client
-                                .command_with_literal(&format!(
-                                    "UID FETCH {uid} (BODY.PEEK[]<0.8192>)"
-                                ))
-                                .await
-                                .ok()
-                                .and_then(|mut response| {
-                                    response.take_body_literal_for(*uid, "TEXT")
-                                })
-                                .map(|raw| snippet_from_partial(&raw))
-                                .unwrap_or_default();
-                            match parse_catalog_message(
-                                account,
+                            metadata.push((uid, response.lines, headers));
+                        } else if item.replace_namespace {
+                            excluded_uids.push(uid);
+                        }
+                    } else {
+                        let error = "IMAP server omitted the requested header literal";
+                        self.store
+                            .record_mailbox_sync_failure(
+                                account.id,
                                 &item.plan.storage,
-                                *uid,
-                                &response.lines,
-                                &headers,
-                                snippet,
-                            ) {
-                                Ok(message) => messages.push(message),
-                                Err(error) => eprintln!(
-                                    "Dakia rejected {} UID {} before persistence: {error}",
-                                    item.plan.storage, uid
-                                ),
-                            }
+                                uid,
+                                "metadata",
+                                error,
+                            )
+                            .await?;
+                        item.failed_uids.push(uid);
+                    }
+                }
+                if !excluded_uids.is_empty() {
+                    self.store
+                        .stage_mailbox_snapshot_excluded_uids(
+                            account.id,
+                            &item.plan.storage,
+                            &item.snapshot_generation,
+                            &excluded_uids,
+                        )
+                        .await?;
+                }
+                let snippet_uids = metadata.iter().map(|(uid, _, _)| *uid).collect::<Vec<_>>();
+                let mut snippet_fetch =
+                    fetch_uid_data_batched(client, &snippet_uids, "BODY.PEEK[]<0.8192>", 8_192)
+                        .await;
+                let mut snippets = std::collections::HashMap::new();
+                for (uid, mut response) in snippet_fetch.responses.drain(..) {
+                    if let Some(raw) = response.take_body_literal_for(uid, "") {
+                        snippets.insert(uid, snippet_from_partial(&raw));
+                    } else {
+                        let error = "IMAP server omitted the requested snippet literal";
+                        self.store
+                            .record_mailbox_sync_failure(
+                                account.id,
+                                &item.plan.storage,
+                                uid,
+                                "snippet",
+                                error,
+                            )
+                            .await?;
+                        item.failed_uids.push(uid);
+                    }
+                }
+                for (uid, error) in &snippet_fetch.failures {
+                    self.store
+                        .record_mailbox_sync_failure(
+                            account.id,
+                            &item.plan.storage,
+                            *uid,
+                            "snippet",
+                            error,
+                        )
+                        .await?;
+                    item.failed_uids.push(*uid);
+                }
+                for (uid, lines, headers) in metadata {
+                    let Some(snippet) = snippets.remove(&uid) else {
+                        // Missing, rejected, or truncated snippet data leaves
+                        // this UID retryable. An explicit zero-length literal
+                        // is present in the map and remains a valid empty
+                        // snippet.
+                        continue;
+                    };
+                    match parse_catalog_message(
+                        account,
+                        &item.plan.storage,
+                        uid,
+                        &lines,
+                        &headers,
+                        snippet,
+                    ) {
+                        Ok(message) => messages.push(message),
+                        Err(error) => {
+                            eprintln!(
+                                "Dakia rejected {} UID {} before persistence: {error}",
+                                item.plan.storage, uid
+                            );
+                            self.store
+                                .record_mailbox_sync_failure(
+                                    account.id,
+                                    &item.plan.storage,
+                                    uid,
+                                    "metadata",
+                                    &error.to_string(),
+                                )
+                                .await?;
+                            item.failed_uids.push(uid);
                         }
                     }
+                }
+                for _ in batch {
                     completed += 1;
                     on_progress(SyncProgress {
                         phase: "downloading",
@@ -912,7 +1469,32 @@ impl MailService {
                         total: Some(total),
                     });
                 }
-                self.store.upsert_catalog_messages(&messages).await?;
+                if item.replace_namespace {
+                    self.store
+                        .stage_mailbox_snapshot_message_page(
+                            account.id,
+                            &item.plan.storage,
+                            &item.snapshot_generation,
+                            &messages,
+                        )
+                        .await?;
+                } else {
+                    self.store.upsert_catalog_messages(&messages).await?;
+                }
+                for message in &messages {
+                    let uid = u32::try_from(message.uid)?;
+                    if !item.failed_uids.contains(&uid) {
+                        self.store
+                            .clear_mailbox_sync_failure(account.id, &item.plan.storage, uid)
+                            .await?;
+                    }
+                }
+                if let Some(error) = header_fetch.fatal.or(snippet_fetch.fatal) {
+                    return Err(error).context(format!(
+                        "could not fetch {} metadata batch",
+                        item.plan.storage
+                    ));
+                }
                 if item.initialized && item.plan.local == "INBOX" {
                     new_messages.extend(
                         messages
@@ -938,21 +1520,107 @@ impl MailService {
                     total: Some(total),
                 });
                 item.offset = end;
-                if item.offset == item.uids.len() {
+            }
+            if !published {
+                break;
+            }
+        }
+        if work.iter().any(|item| !item.failed_uids.is_empty()) {
+            for item in &work {
+                if !item.replace_namespace {
                     self.store
-                        .save_mailbox_catalog_state(
+                        .discard_mailbox_snapshot(
                             account.id,
                             &item.plan.storage,
-                            &item.plan.remote,
-                            item.uid_validity,
-                            item.remote_total,
-                            true,
+                            &item.snapshot_generation,
                         )
                         .await?;
                 }
             }
-            if !published {
-                break;
+            let failed = work
+                .iter()
+                .flat_map(|item| item.failed_uids.iter().copied())
+                .collect::<Vec<_>>();
+            bail!("IMAP metadata remained incomplete for UIDs {failed:?}");
+        }
+        // SELECT is intentionally repeated after metadata downloads because
+        // sequence numbers can shift while the catalogue is being built. Each
+        // mailbox is finalized immediately after its identity check to keep
+        // the unavoidable remote-to-local race window as small as possible.
+        for (index, item) in work.iter().enumerate() {
+            let select_command = if item.condstore {
+                format!("SELECT {} (CONDSTORE)", quote_imap(&item.plan.remote))
+            } else {
+                format!("SELECT {}", quote_imap(&item.plan.remote))
+            };
+            let selected = client.command(&select_command).await?;
+            let final_identity = parse_mailbox_identity(&selected)?;
+            match verify_mailbox_snapshot_membership(
+                client,
+                &item.snapshot_identity,
+                &final_identity,
+                &item.inventory_uids,
+            )
+            .await
+            {
+                Ok(Some(second)) => {
+                    let flags = second
+                        .iter()
+                        .map(|entry| (entry.uid, entry.is_read, entry.is_flagged))
+                        .collect::<Vec<_>>();
+                    self.store
+                        .stage_mailbox_snapshot_page(
+                            account.id,
+                            &item.plan.storage,
+                            &item.snapshot_generation,
+                            &flags,
+                        )
+                        .await?;
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    for staged in &work[index..] {
+                        self.store
+                            .discard_mailbox_snapshot(
+                                account.id,
+                                &staged.plan.storage,
+                                &staged.snapshot_generation,
+                            )
+                            .await?;
+                    }
+                    return Err(error)
+                        .context("IMAP mailbox membership was not stable at finalization");
+                }
+            }
+            if item.replace_namespace {
+                self.store
+                    .finalize_mailbox_snapshot_with_staged_replacements(
+                        account.id,
+                        &item.plan.storage,
+                        &item.snapshot_generation,
+                    )
+                    .await?;
+            } else {
+                self.store
+                    .finalize_mailbox_snapshot(
+                        account.id,
+                        &item.plan.storage,
+                        &item.snapshot_generation,
+                    )
+                    .await?;
+            }
+        }
+        if listing_authoritative {
+            for family in requested_families {
+                if incomplete_families.contains(family) {
+                    continue;
+                }
+                let mut keep = family_keep.remove(family).unwrap_or_default();
+                keep.sort();
+                keep.dedup();
+                self.store
+                    .prune_obsolete_mailbox_family_namespaces(account.id, family, &keep)
+                    .await?;
             }
         }
         if synced > 0 {
@@ -1035,7 +1703,7 @@ impl MailService {
                 plan,
                 state,
                 uid_validity,
-                uids: recent_uids_newest_first(parse_search_uids(&search)),
+                uids: recent_uids_newest_first(parse_search_uids(&search)?),
                 selected_uids: Vec::new(),
             });
         }
@@ -1347,7 +2015,7 @@ impl MailService {
                     .command(&format!("UID SEARCH {text_criterion}"))
                     .await?
             };
-            let mut uids = parse_search_uids(&response);
+            let mut uids = parse_search_uids(&response)?;
             uids.sort_unstable_by(|left, right| right.cmp(left));
             for uid in uids {
                 if let Some(message) = self
@@ -2396,12 +3064,38 @@ struct MailboxPlan {
 
 struct MailboxSyncWork {
     plan: MailboxPlan,
-    uid_validity: u32,
-    remote_total: usize,
+    snapshot_generation: String,
+    snapshot_identity: MailboxIdentity,
+    condstore: bool,
+    replace_namespace: bool,
     initialized: bool,
     previous_highest: Option<u32>,
+    inventory_uids: Vec<u32>,
     uids: Vec<u32>,
+    retry_uids: std::collections::HashSet<u32>,
     offset: usize,
+    failed_uids: Vec<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct MailboxIdentity {
+    exists: u32,
+    uid_validity: u32,
+    uid_next: Option<u32>,
+    highest_modseq: Option<u64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct MailboxSnapshotItem {
+    uid: u32,
+    is_read: bool,
+    is_flagged: bool,
+}
+
+struct BatchedUidFetch {
+    responses: Vec<(u32, ImapResponse)>,
+    failures: Vec<(u32, String)>,
+    fatal: Option<anyhow::Error>,
 }
 
 struct RecentRefreshWork {
@@ -2444,6 +3138,10 @@ impl MailboxPlan {
             skip_gmail_system_labels: self.skip_gmail_system_labels,
         }
     }
+}
+
+fn special_mailbox_family(local: &'static str) -> Option<&'static str> {
+    matches!(local, "Sent" | "Archive" | "Spam" | "Trash").then_some(local)
 }
 
 fn resolve_special_mailboxes(plans: Vec<MailboxPlan>, lines: &[String]) -> Vec<MailboxPlan> {
@@ -2490,17 +3188,42 @@ fn resolve_special_mailboxes(plans: Vec<MailboxPlan>, lines: &[String]) -> Vec<M
 }
 
 fn parse_list_mailbox(line: &str) -> Option<(Vec<String>, String)> {
-    let list = line.find("LIST (")? + "LIST ".len();
-    let attributes_end = line[list..].find(')')? + list;
-    let flags = line[list + 1..attributes_end]
+    let line = line.trim_start();
+    let prefix = "* LIST ";
+    if line.len() < prefix.len() || !line[..prefix.len()].eq_ignore_ascii_case(prefix) {
+        return None;
+    }
+    let attributes = &line[prefix.len()..];
+    if !attributes.starts_with('(') {
+        return None;
+    }
+    let attributes_end = attributes.find(')')?;
+    let flags = attributes[1..attributes_end]
         .split_whitespace()
         .map(str::to_ascii_lowercase)
         .collect::<Vec<_>>();
-    let mut remainder = line[attributes_end + 1..].trim_start();
+    let mut remainder = attributes[attributes_end + 1..].trim_start();
     let (_, rest) = parse_imap_astring(remainder)?;
     remainder = rest.trim_start();
     let (mailbox, _) = parse_imap_astring(remainder)?;
     Some((flags, mailbox))
+}
+
+fn validate_list_response(lines: &[String]) -> Result<()> {
+    for line in lines {
+        let trimmed = line.trim_start();
+        let Some(first) = trimmed.split_whitespace().next() else {
+            continue;
+        };
+        if first != "*" {
+            continue;
+        }
+        let response_kind = trimmed.split_whitespace().nth(1).unwrap_or_default();
+        if response_kind.eq_ignore_ascii_case("LIST") && parse_list_mailbox(trimmed).is_none() {
+            bail!("IMAP LIST response is malformed");
+        }
+    }
+    Ok(())
 }
 
 fn parse_imap_astring(value: &str) -> Option<(String, &str)> {
@@ -2522,6 +3245,12 @@ fn parse_imap_astring(value: &str) -> Option<(String, &str)> {
         }
         None
     } else {
+        // LIST literals are valid IMAP, but command responses currently keep
+        // their bytes separate from the response line. Treating the marker as
+        // an atom could select or prune the wrong mailbox during a reset.
+        if value.starts_with('{') || value.starts_with("~{") {
+            return None;
+        }
         let end = value.find(char::is_whitespace).unwrap_or(value.len());
         (end > 0).then(|| (value[..end].to_owned(), &value[end..]))
     }
@@ -4000,20 +4729,17 @@ where
         self.reader.get_mut().flush().await?;
         let mut pending_change = false;
         loop {
-            let mut continuation = String::new();
-            let read = timeout(
+            let continuation = timeout(
                 IMAP_COMMAND_TIMEOUT,
-                self.reader.read_line(&mut continuation),
+                read_imap_line_limited(&mut self.reader, MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES),
             )
             .await
-            .context("IMAP IDLE continuation timed out")??;
-            if read == 0 {
-                bail!("IMAP connection closed before IDLE continuation");
-            }
+            .context("IMAP IDLE continuation timed out")?
+            .context("IMAP connection closed before IDLE continuation")?;
             if continuation.starts_with('+') {
                 break;
             }
-            if continuation.to_ascii_uppercase().contains(" EXISTS") {
+            if is_idle_invalidation(&continuation) {
                 pending_change = true;
                 continue;
             }
@@ -4029,7 +4755,6 @@ where
             IdleOutcome::Changed
         } else {
             loop {
-                let mut line = String::new();
                 tokio::select! {
                     changed = cancel.changed() => {
                         if changed.is_err() || *cancel.borrow() {
@@ -4037,11 +4762,9 @@ where
                         }
                     }
                     _ = &mut renewal => break IdleOutcome::Renewed,
-                    read = self.reader.read_line(&mut line) => {
-                        if read? == 0 {
-                            bail!("IMAP connection closed while idling");
-                        }
-                        if line.to_ascii_uppercase().contains(" EXISTS") {
+                    read = read_imap_line_limited(&mut self.reader, MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES) => {
+                        let line = read.context("IMAP connection closed while idling")?;
+                        if is_idle_invalidation(&line) {
                             break IdleOutcome::Changed;
                         }
                         if line.to_ascii_uppercase().starts_with("* BYE") {
@@ -4054,18 +4777,18 @@ where
         self.reader.get_mut().write_all(b"DONE\r\n").await?;
         self.reader.get_mut().flush().await?;
         loop {
-            let mut line = String::new();
-            let read = timeout(IMAP_COMMAND_TIMEOUT, self.reader.read_line(&mut line))
-                .await
-                .context("IMAP IDLE termination timed out")??;
-            if read == 0 {
-                bail!("IMAP connection closed during IDLE termination");
-            }
+            let line = timeout(
+                IMAP_COMMAND_TIMEOUT,
+                read_imap_line_limited(&mut self.reader, MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES),
+            )
+            .await
+            .context("IMAP IDLE termination timed out")?
+            .context("IMAP connection closed during IDLE termination")?;
             if line.to_ascii_uppercase().starts_with("* BYE") {
                 bail!("IMAP server closed the connection during IDLE termination");
             }
             if line.starts_with(&tag) {
-                if !line[tag.len()..].trim_start().starts_with("OK") {
+                if !tagged_status_is_ok(&line[tag.len()..]) {
                     bail!("IMAP IDLE termination failed: {}", line.trim());
                 }
                 break;
@@ -4124,7 +4847,7 @@ where
                 bail!("IMAP connection closed during APPEND");
             }
             if line.starts_with(&tag) {
-                if !line[tag.len()..].trim_start().starts_with("OK") {
+                if !tagged_status_is_ok(&line[tag.len()..]) {
                     bail!("IMAP APPEND failed: {}", line.trim());
                 }
                 break;
@@ -4146,9 +4869,19 @@ where
         command: &str,
         max_literal_bytes: usize,
     ) -> Result<ImapResponse> {
+        self.command_with_literal_budgets(command, max_literal_bytes, max_literal_bytes)
+            .await
+    }
+
+    async fn command_with_literal_budgets(
+        &mut self,
+        command: &str,
+        max_literal_bytes: usize,
+        max_total_literal_bytes: usize,
+    ) -> Result<ImapResponse> {
         timeout(
             IMAP_COMMAND_TIMEOUT,
-            self.command_with_literal_inner(command, max_literal_bytes),
+            self.command_with_literal_inner(command, max_literal_bytes, max_total_literal_bytes),
         )
         .await
         .context("IMAP command timed out")?
@@ -4158,7 +4891,11 @@ where
         &mut self,
         command: &str,
         max_literal_bytes: usize,
+        max_total_literal_bytes: usize,
     ) -> Result<ImapResponse> {
+        if command.len() > MAX_IMAP_COMMAND_BYTES {
+            bail!("IMAP command exceeds safety limit");
+        }
         self.tag += 1;
         let tag = format!("D{:04}", self.tag);
         self.reader
@@ -4177,6 +4914,9 @@ where
         let mut current_fetch_uid = None;
         let mut pending_fetch_literals = Vec::new();
         loop {
+            if lines.len() >= MAX_IMAP_RESPONSE_LINES {
+                bail!("IMAP response contains too many lines");
+            }
             let line = self
                 .read_command_line_limited(MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES)
                 .await?;
@@ -4209,8 +4949,11 @@ where
                     literals.len(),
                     literal_bytes,
                     length,
-                    max_literal_bytes,
+                    max_total_literal_bytes,
                 )?;
+                if length > max_literal_bytes {
+                    bail!("IMAP literal exceeds per-message safety limit");
+                }
                 let mut bytes = vec![0; length];
                 self.reader.read_exact(&mut bytes).await?;
                 literal_bytes += length;
@@ -4225,7 +4968,7 @@ where
                 }
             }
             if line.starts_with(&tag) {
-                if !line[tag.len()..].trim_start().starts_with("OK") {
+                if !tagged_status_is_ok(&line[tag.len()..]) {
                     bail!("IMAP command failed: {}", line.trim());
                 }
                 break;
@@ -4239,6 +4982,167 @@ where
             .await
             .context("IMAP connection closed during command")
     }
+}
+
+fn uid_fetch_command_batches(uids: &[u32], fields: &str) -> Vec<Vec<u32>> {
+    let fixed_bytes = "UID FETCH  ()".len() + fields.len();
+    let mut batches = Vec::new();
+    let mut current = Vec::new();
+    let mut bytes = fixed_bytes;
+    for uid in uids {
+        let encoded = uid.to_string();
+        let additional = encoded.len() + usize::from(!current.is_empty());
+        if !current.is_empty()
+            && (current.len() >= MAX_METADATA_FETCH_UIDS
+                || bytes + additional > MAX_IMAP_COMMAND_BYTES)
+        {
+            batches.push(std::mem::take(&mut current));
+            bytes = fixed_bytes;
+        }
+        current.push(*uid);
+        bytes += encoded.len() + usize::from(current.len() > 1);
+    }
+    if !current.is_empty() {
+        batches.push(current);
+    }
+    batches
+}
+
+fn isolate_fetch_response_for_uid(response: &mut ImapResponse, uid: u32) -> ImapResponse {
+    let mut owner = None;
+    let mut lines = Vec::new();
+    for line in &response.lines {
+        if is_untagged_fetch_start(line) {
+            owner = fetch_uid_from_line(line);
+        } else if let Some(line_uid) = fetch_uid_from_line(line) {
+            owner = Some(line_uid);
+        }
+        if owner == Some(uid) {
+            lines.push(line.clone());
+        }
+    }
+    let mut literals = Vec::new();
+    let mut index = 0;
+    while index < response.literals.len() {
+        if response.literals[index].uid == Some(uid) {
+            literals.push(response.literals.remove(index));
+        } else {
+            index += 1;
+        }
+    }
+    ImapResponse { lines, literals }
+}
+
+async fn fetch_uid_data_batched<S>(
+    client: &mut ImapClient<S>,
+    uids: &[u32],
+    fields: &str,
+    literal_limit: usize,
+) -> BatchedUidFetch
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut pending = std::collections::VecDeque::from(uid_fetch_command_batches(uids, fields));
+    let mut result = BatchedUidFetch {
+        responses: Vec::new(),
+        failures: Vec::new(),
+        fatal: None,
+    };
+    while let Some(batch) = pending.pop_front() {
+        let uid_set = batch
+            .iter()
+            .map(u32::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+        let command = format!("UID FETCH {uid_set} ({fields})");
+        match client
+            .command_with_literal_budgets(
+                &command,
+                literal_limit,
+                literal_limit.saturating_mul(batch.len()),
+            )
+            .await
+        {
+            Ok(mut response) => {
+                for uid in batch {
+                    result
+                        .responses
+                        .push((uid, isolate_fetch_response_for_uid(&mut response, uid)));
+                }
+            }
+            Err(error)
+                if error.to_string().starts_with("IMAP command failed:") && batch.len() > 1 =>
+            {
+                let midpoint = (batch.len() + 1) / 2;
+                let older = batch[midpoint..].to_vec();
+                let newer = batch[..midpoint].to_vec();
+                if !older.is_empty() {
+                    pending.push_front(older);
+                }
+                pending.push_front(newer);
+            }
+            Err(error) if error.to_string().starts_with("IMAP command failed:") => {
+                result.failures.push((batch[0], error.to_string()));
+            }
+            Err(error) => {
+                let description = error.to_string();
+                result
+                    .failures
+                    .extend(batch.into_iter().map(|uid| (uid, description.clone())));
+                result.fatal = Some(error);
+                break;
+            }
+        }
+    }
+    result
+}
+
+/// Fetches one bounded sequence-number range. Providers sometimes impose a
+/// smaller response or command-item limit than they advertise, so a tagged
+/// rejection is retried as two smaller ranges. Transport errors and malformed
+/// successful responses remain fatal because the connection or snapshot can
+/// no longer be considered authoritative.
+async fn fetch_mailbox_snapshot_range<S>(
+    client: &mut ImapClient<S>,
+    start: u32,
+    end: u32,
+    changed_since: Option<u64>,
+) -> Result<Vec<MailboxSnapshotItem>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut pending = std::collections::VecDeque::from([(start, end)]);
+    let mut items = Vec::new();
+    while let Some((range_start, range_end)) = pending.pop_front() {
+        let command = match changed_since {
+            Some(modseq) => format!(
+                "FETCH {range_start}:{range_end} (UID FLAGS MODSEQ) (CHANGEDSINCE {modseq})"
+            ),
+            None => format!("FETCH {range_start}:{range_end} (UID FLAGS)"),
+        };
+        match client.command(&command).await {
+            Ok(response) => {
+                let maximum_count = usize::try_from(range_end - range_start + 1)?;
+                let mut page = if changed_since.is_some() {
+                    parse_mailbox_delta_page(&response, maximum_count)?
+                } else {
+                    parse_mailbox_snapshot_page(&response, maximum_count)?
+                };
+                items.append(&mut page);
+            }
+            Err(error)
+                if error.to_string().starts_with("IMAP command failed:")
+                    && changed_since.is_none()
+                    && range_start < range_end =>
+            {
+                let midpoint = range_start + (range_end - range_start) / 2;
+                pending.push_front((range_start, midpoint));
+                pending.push_front((midpoint + 1, range_end));
+            }
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(items)
 }
 
 async fn read_imap_line_limited<R>(reader: &mut R, max_bytes: usize) -> Result<String>
@@ -4411,25 +5315,138 @@ fn quote_imap(value: &str) -> String {
     format!("\"{}\"", value.replace('\\', "\\\\").replace('"', "\\\""))
 }
 
-fn parse_search_uids(lines: &[String]) -> Vec<u32> {
-    lines
-        .iter()
-        .find_map(|line| line.strip_prefix("* SEARCH "))
-        .map(|value| {
-            value
-                .split_whitespace()
-                .filter_map(|uid| uid.parse().ok())
-                .collect()
+fn parse_search_uids(lines: &[String]) -> Result<Vec<u32>> {
+    let mut search_values = lines.iter().filter_map(|line| {
+        let trimmed = line.trim();
+        let prefix = "* SEARCH";
+        (trimmed.len() >= prefix.len()
+            && trimmed[..prefix.len()].eq_ignore_ascii_case(prefix)
+            && trimmed[prefix.len()..]
+                .chars()
+                .next()
+                .is_none_or(char::is_whitespace))
+        .then_some(trimmed[prefix.len()..].trim())
+    });
+    let value = search_values
+        .next()
+        .context("IMAP server omitted SEARCH results")?;
+    if search_values.next().is_some() {
+        bail!("IMAP server returned multiple SEARCH results");
+    }
+    value
+        .split_whitespace()
+        .map(|token| {
+            let uid = token
+                .parse::<u32>()
+                .with_context(|| format!("IMAP SEARCH returned malformed UID {token:?}"))?;
+            if uid == 0 {
+                bail!("IMAP SEARCH returned invalid UID 0");
+            }
+            Ok(uid)
         })
-        .unwrap_or_default()
+        .collect()
 }
 
 fn parse_uid_validity(lines: &[String]) -> Option<u32> {
+    parse_imap_response_code_number(lines, "UIDVALIDITY")
+        .and_then(|value| u32::try_from(value).ok())
+}
+
+fn parse_mailbox_identity(lines: &[String]) -> Result<MailboxIdentity> {
+    let exists = lines
+        .iter()
+        .find_map(|line| {
+            let mut tokens = line.split_whitespace();
+            if tokens.next()? != "*" {
+                return None;
+            }
+            let count = tokens.next()?.parse::<u32>().ok()?;
+            tokens
+                .next()
+                .is_some_and(|token| token.eq_ignore_ascii_case("EXISTS"))
+                .then_some(count)
+        })
+        .context("IMAP server omitted EXISTS after SELECT")?;
+    if exists > MAX_SUPPORTED_MAILBOX_MESSAGES {
+        bail!(
+            "IMAP mailbox contains more than the supported {} messages",
+            MAX_SUPPORTED_MAILBOX_MESSAGES
+        );
+    }
+    let uid_validity =
+        parse_uid_validity(lines).context("IMAP server omitted UIDVALIDITY after SELECT")?;
+    Ok(MailboxIdentity {
+        exists,
+        uid_validity,
+        uid_next: parse_imap_response_code_number(lines, "UIDNEXT")
+            .and_then(|value| u32::try_from(value).ok()),
+        highest_modseq: parse_imap_response_code_number(lines, "HIGHESTMODSEQ"),
+    })
+}
+
+fn parse_imap_response_code_number(lines: &[String], code: &str) -> Option<u64> {
     lines.iter().find_map(|line| {
-        let start = line.find("[UIDVALIDITY ")? + "[UIDVALIDITY ".len();
-        let end = line[start..].find(']')? + start;
+        let upper = line.to_ascii_uppercase();
+        let marker = format!("[{code} ");
+        let start = upper.find(&marker)? + marker.len();
+        let end = upper[start..].find(']')? + start;
         line[start..end].trim().parse().ok()
     })
+}
+
+fn mailbox_identity_is_stable(initial: &MailboxIdentity, final_state: &MailboxIdentity) -> bool {
+    mailbox_membership_is_stable(initial, final_state)
+        && match (initial.highest_modseq, final_state.highest_modseq) {
+            (Some(initial), Some(final_state)) => initial == final_state,
+            _ => true,
+        }
+}
+
+fn mailbox_membership_is_stable(initial: &MailboxIdentity, final_state: &MailboxIdentity) -> bool {
+    initial.exists == final_state.exists
+        && initial.uid_validity == final_state.uid_validity
+        && matches!(
+            (initial.uid_next, final_state.uid_next),
+            (Some(initial), Some(final_state)) if initial == final_state
+        )
+}
+
+fn imap_error_confirms_nonexistent(error: &anyhow::Error) -> bool {
+    error
+        .to_string()
+        .to_ascii_uppercase()
+        .contains("[NONEXISTENT]")
+}
+
+async fn verify_mailbox_snapshot_membership<S>(
+    client: &mut ImapClient<S>,
+    initial: &MailboxIdentity,
+    final_state: &MailboxIdentity,
+    first_uids: &[u32],
+) -> Result<Option<Vec<MailboxSnapshotItem>>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    if mailbox_membership_is_stable(initial, final_state) {
+        return Ok(None);
+    }
+    if initial.exists != final_state.exists || initial.uid_validity != final_state.uid_validity {
+        bail!("IMAP mailbox changed while its catalogue was being synchronized");
+    }
+    if initial.uid_next.is_some() && final_state.uid_next.is_some() {
+        bail!("IMAP mailbox changed while its catalogue was being synchronized");
+    }
+
+    let mut second = Vec::new();
+    for (start, end) in mailbox_snapshot_page_ranges(final_state.exists) {
+        second.extend(fetch_mailbox_snapshot_range(client, start, end, None).await?);
+    }
+    let mut second_uids = second.iter().map(|item| item.uid).collect::<Vec<_>>();
+    second_uids.sort_unstable();
+    if second_uids != first_uids {
+        bail!("IMAP mailbox membership changed between bounded inventories");
+    }
+    Ok(Some(second))
 }
 
 fn verify_mailbox_uid_validity(current: u32, catalogued: i64, action: &str) -> Result<()> {
@@ -4440,19 +5457,102 @@ fn verify_mailbox_uid_validity(current: u32, catalogued: i64, action: &str) -> R
 }
 
 fn parse_uid_flags(lines: &[String]) -> Vec<(u32, bool, bool)> {
-    lines
+    lines.iter().filter_map(parse_uid_flags_line).collect()
+}
+
+fn parse_uid_flags_line(line: &String) -> Option<(u32, bool, bool)> {
+    if !is_untagged_fetch_start(line) {
+        return None;
+    }
+    let uid = fetch_uid_from_line(line)?;
+    let upper = line.to_ascii_uppercase();
+    let marker = "FLAGS (";
+    let start = upper.find(marker)? + marker.len();
+    let end = upper[start..].find(')')? + start;
+    let flags = &upper[start..end];
+    Some((uid, flags.contains("\\SEEN"), flags.contains("\\FLAGGED")))
+}
+
+fn parse_mailbox_snapshot_page(
+    lines: &[String],
+    expected_count: usize,
+) -> Result<Vec<MailboxSnapshotItem>> {
+    let parsed = parse_uid_flags(lines);
+    if parsed.len() != expected_count {
+        bail!(
+            "IMAP mailbox snapshot page was incomplete: expected {expected_count} messages, received {}",
+            parsed.len()
+        );
+    }
+    let mut seen = std::collections::HashSet::with_capacity(parsed.len());
+    let mut items = Vec::with_capacity(parsed.len());
+    for (uid, is_read, is_flagged) in parsed {
+        if !seen.insert(uid) {
+            bail!("IMAP mailbox snapshot page repeated UID {uid}");
+        }
+        items.push(MailboxSnapshotItem {
+            uid,
+            is_read,
+            is_flagged,
+        });
+    }
+    Ok(items)
+}
+
+fn parse_mailbox_delta_page(
+    lines: &[String],
+    maximum_count: usize,
+) -> Result<Vec<MailboxSnapshotItem>> {
+    let fetch_count = lines
         .iter()
-        .filter_map(|line| {
-            let uid_start = line.find("UID ")? + "UID ".len();
-            let uid_end =
-                line[uid_start..].find(|character: char| !character.is_ascii_digit())? + uid_start;
-            let uid = line[uid_start..uid_end].parse().ok()?;
-            let flags_start = line.find("FLAGS (")? + "FLAGS (".len();
-            let flags_end = line[flags_start..].find(')')? + flags_start;
-            let flags = &line[flags_start..flags_end];
-            Some((uid, flags.contains("\\Seen"), flags.contains("\\Flagged")))
-        })
-        .collect()
+        .filter(|line| is_untagged_fetch_start(line))
+        .count();
+    let parsed = parse_uid_flags(lines);
+    if parsed.len() != fetch_count || parsed.len() > maximum_count {
+        bail!("IMAP CONDSTORE flag delta page was malformed");
+    }
+    let mut seen = std::collections::HashSet::with_capacity(parsed.len());
+    let mut items = Vec::with_capacity(parsed.len());
+    for (uid, is_read, is_flagged) in parsed {
+        if !seen.insert(uid) {
+            bail!("IMAP CONDSTORE flag delta repeated UID {uid}");
+        }
+        items.push(MailboxSnapshotItem {
+            uid,
+            is_read,
+            is_flagged,
+        });
+    }
+    Ok(items)
+}
+
+fn mailbox_snapshot_page_ranges(exists: u32) -> Vec<(u32, u32)> {
+    let mut ranges = Vec::new();
+    let mut end = exists;
+    while end > 0 {
+        let start = end.saturating_sub(MAILBOX_SNAPSHOT_PAGE_SIZE - 1).max(1);
+        ranges.push((start, end));
+        end = start - 1;
+    }
+    ranges
+}
+
+fn is_idle_invalidation(line: &str) -> bool {
+    let upper = line.trim_start().to_ascii_uppercase();
+    if !upper.starts_with('*') {
+        return false;
+    }
+    upper.contains(" EXISTS")
+        || upper.contains(" EXPUNGE")
+        || upper.contains(" FETCH ") && upper.contains("FLAGS")
+        || upper.starts_with("* VANISHED")
+}
+
+fn tagged_status_is_ok(suffix: &str) -> bool {
+    suffix
+        .split_whitespace()
+        .next()
+        .is_some_and(|status| status.eq_ignore_ascii_case("OK"))
 }
 
 fn missing_uids_newest_first(remote: &[u32], local: &std::collections::HashSet<u32>) -> Vec<u32> {
@@ -4470,6 +5570,14 @@ fn supports_idle(lines: &[String]) -> bool {
         line.to_ascii_uppercase()
             .split_whitespace()
             .any(|item| item == "IDLE")
+    })
+}
+
+fn supports_condstore(lines: &[String]) -> bool {
+    lines.iter().any(|line| {
+        line.to_ascii_uppercase()
+            .split_whitespace()
+            .any(|item| item == "CONDSTORE")
     })
 }
 
@@ -4671,22 +5779,6 @@ fn message_received_at(
     parse_internal_date(response_lines).context(
         "message has no valid Date header and the IMAP server omitted a valid INTERNALDATE",
     )
-}
-
-fn sync_uids(mut uids: Vec<u32>, highest_uid: Option<u32>, max_messages: u32) -> Vec<u32> {
-    uids.sort_unstable();
-    let limit = max_messages as usize;
-    if let Some(highest_uid) = highest_uid {
-        // Drain incremental batches from the oldest unseen UID so advancing
-        // the durable watermark cannot skip messages beyond this batch.
-        uids.retain(|uid| *uid > highest_uid);
-        uids.truncate(limit);
-        uids
-    } else {
-        // Initial sync remains silent and starts with the newest messages.
-        let offset = uids.len().saturating_sub(limit);
-        uids.split_off(offset)
-    }
 }
 
 fn parse_copy_uid(lines: &[String]) -> Option<u32> {
@@ -6329,7 +7421,7 @@ mod tests {
     use tokio::{
         io::{duplex, split, AsyncBufReadExt, AsyncWriteExt, BufReader, DuplexStream},
         net::{TcpListener, TcpStream},
-        sync::watch,
+        sync::{oneshot, watch},
     };
     use tokio_rustls::{
         rustls::{
@@ -6365,6 +7457,369 @@ mod tests {
             },
             server,
         )
+    }
+
+    fn snapshot_test_message(account: &Account, uid: u32) -> MailSummary {
+        let headers = format!(
+            "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Snapshot {uid}\r\nMessage-ID: <{uid}@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
+        );
+        parse_catalog_message(
+            account,
+            "INBOX",
+            uid,
+            &[format!(
+                "* 1 FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\")\r\n"
+            )],
+            headers.as_bytes(),
+            String::new(),
+        )
+        .unwrap()
+    }
+
+    async fn seed_condstore_catalog(store: &Store, account: &Account) {
+        store.save_account(account).await.unwrap();
+        store
+            .upsert_catalog_messages(&[
+                snapshot_test_message(account, 1),
+                snapshot_test_message(account, 2),
+            ])
+            .await
+            .unwrap();
+        let generation = store
+            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 77, 2, Some(3), Some(100))
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account.id,
+                "INBOX",
+                &generation,
+                &[(1, false, false), (2, false, true)],
+            )
+            .await
+            .unwrap();
+        store
+            .finalize_mailbox_snapshot(account.id, "INBOX", &generation)
+            .await
+            .unwrap();
+    }
+
+    #[derive(Clone, Copy)]
+    enum CondstoreScript {
+        StableDelta,
+        NoModseq,
+        UidNextDrift,
+        ExistsDrift,
+    }
+
+    async fn scripted_condstore_sync_server(
+        server: DuplexStream,
+        scenario: CondstoreScript,
+    ) -> Vec<String> {
+        let (read, mut write) = split(server);
+        let mut read = BufReader::new(read);
+        let mut transcript = Vec::new();
+
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            "LOGIN \"reader@example.test\" \"sync secret\"",
+        )
+        .await;
+        write
+            .write_all(format!("{tag} OK authenticated\r\n").as_bytes())
+            .await
+            .unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "CAPABILITY").await;
+        write
+            .write_all(
+                format!("* CAPABILITY IMAP4rev1 CONDSTORE\r\n{tag} OK capability\r\n").as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+        write
+            .write_all(
+                format!("* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n{tag} OK listed\r\n")
+                    .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let initial_identity = match scenario {
+            CondstoreScript::NoModseq => {
+                "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 3] Predicted next UID\r\n* OK [NOMODSEQ] No persistent mod-sequences\r\n"
+            }
+            _ => {
+                "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 3] Predicted next UID\r\n* OK [HIGHESTMODSEQ 200] Mod-sequence\r\n"
+            }
+        };
+        let tag =
+            scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                .await;
+        write
+            .write_all(format!("{initial_identity}{tag} OK selected\r\n").as_bytes())
+            .await
+            .unwrap();
+
+        if !matches!(scenario, CondstoreScript::NoModseq) {
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "FETCH 1:2 (UID FLAGS MODSEQ) (CHANGEDSINCE 100)",
+            )
+            .await;
+            write
+                .write_all(
+                    format!("* 1 FETCH (UID 1 FLAGS (\\Seen) MODSEQ (200))\r\n{tag} OK delta\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            let delta_final_identity = match scenario {
+                CondstoreScript::StableDelta => initial_identity,
+                CondstoreScript::UidNextDrift => {
+                    "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 4] Predicted next UID\r\n* OK [HIGHESTMODSEQ 201] Mod-sequence\r\n"
+                }
+                CondstoreScript::ExistsDrift => {
+                    "* 1 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 2] Predicted next UID\r\n* OK [HIGHESTMODSEQ 201] Mod-sequence\r\n"
+                }
+                CondstoreScript::NoModseq => unreachable!(),
+            };
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                    .await;
+            write
+                .write_all(format!("{delta_final_identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            if matches!(scenario, CondstoreScript::StableDelta) {
+                let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+                write
+                    .write_all(format!("* BYE done\r\n{tag} OK logout\r\n").as_bytes())
+                    .await
+                    .unwrap();
+                return transcript;
+            }
+        }
+
+        let (exists, final_identity) = match scenario {
+            CondstoreScript::NoModseq => (2, initial_identity),
+            CondstoreScript::UidNextDrift => (
+                2,
+                "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 4] Predicted next UID\r\n* OK [HIGHESTMODSEQ 201] Mod-sequence\r\n",
+            ),
+            CondstoreScript::ExistsDrift => (
+                1,
+                "* 1 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 2] Predicted next UID\r\n* OK [HIGHESTMODSEQ 201] Mod-sequence\r\n",
+            ),
+            CondstoreScript::StableDelta => unreachable!(),
+        };
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            &format!("FETCH 1:{exists} (UID FLAGS)"),
+        )
+        .await;
+        write
+            .write_all(b"* 1 FETCH (UID 1 FLAGS (\\Seen))\r\n")
+            .await
+            .unwrap();
+        if exists == 2 {
+            write
+                .write_all(b"* 2 FETCH (UID 2 FLAGS (\\Flagged))\r\n")
+                .await
+                .unwrap();
+        }
+        write
+            .write_all(format!("{tag} OK full snapshot\r\n").as_bytes())
+            .await
+            .unwrap();
+
+        let tag =
+            scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                .await;
+        write
+            .write_all(format!("{final_identity}{tag} OK selected\r\n").as_bytes())
+            .await
+            .unwrap();
+        let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+        write
+            .write_all(format!("* BYE done\r\n{tag} OK logout\r\n").as_bytes())
+            .await
+            .unwrap();
+        transcript
+    }
+
+    async fn scripted_realtime_gap_server(server: DuplexStream, fail_uid_100: bool) -> Vec<String> {
+        let (read, mut write) = split(server);
+        let mut read = BufReader::new(read);
+        let mut transcript = Vec::new();
+
+        let select_response = |tag: &str| {
+            format!(
+                "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 102] Predicted next UID\r\n{tag} OK selected\r\n"
+            )
+        };
+        let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+        write
+            .write_all(select_response(&tag).as_bytes())
+            .await
+            .unwrap();
+
+        let tag =
+            scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+        write
+            .write_all(
+                format!(
+                    "* 1 FETCH (UID 100 FLAGS ())\r\n* 2 FETCH (UID 101 FLAGS ())\r\n{tag} OK snapshot\r\n"
+                )
+                .as_bytes(),
+            )
+            .await
+            .unwrap();
+
+        let metadata_uids: &[u32] = if fail_uid_100 { &[100, 101] } else { &[100] };
+        for uid in metadata_uids.iter().copied() {
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(
+                command.starts_with(&format!("UID FETCH {uid} (FLAGS INTERNALDATE ")),
+                "unexpected metadata command: {command}"
+            );
+            if uid == 100 && fail_uid_100 {
+                // Tagged success without the requested literal is a faithful
+                // provider failure that must leave this UID retryable.
+                write
+                    .write_all(
+                        format!("* 1 FETCH (UID 100 FLAGS ())\r\n{tag} OK incomplete\r\n")
+                            .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                continue;
+            }
+            let headers = format!(
+                "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Realtime {uid}\r\nMessage-ID: <{uid}@realtime.example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
+            );
+            write
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)] {{{}}}\r\n",
+                        headers.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            write.write_all(headers.as_bytes()).await.unwrap();
+            write
+                .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+        }
+
+        if !fail_uid_100 {
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(select_response(&tag).as_bytes())
+                .await
+                .unwrap();
+        }
+        transcript
+    }
+
+    async fn scripted_realtime_starvation_server(
+        server: DuplexStream,
+        metadata_uids: Vec<u32>,
+        fail_uid_100: bool,
+        oversize_uid_100: bool,
+    ) -> Vec<String> {
+        let (read, mut write) = split(server);
+        let mut read = BufReader::new(read);
+        let mut transcript = Vec::new();
+        let select_response = |tag: &str| {
+            format!(
+                "* 26 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 126] Predicted next UID\r\n{tag} OK selected\r\n"
+            )
+        };
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+        write
+            .write_all(select_response(&tag).as_bytes())
+            .await
+            .unwrap();
+        let tag =
+            scripted_expect_command(&mut read, &mut transcript, "FETCH 1:26 (UID FLAGS)").await;
+        for (sequence, uid) in (100..=125).enumerate() {
+            write
+                .write_all(format!("* {} FETCH (UID {uid} FLAGS ())\r\n", sequence + 1).as_bytes())
+                .await
+                .unwrap();
+        }
+        write
+            .write_all(format!("{tag} OK snapshot\r\n").as_bytes())
+            .await
+            .unwrap();
+
+        for uid in metadata_uids {
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(command.starts_with(&format!("UID FETCH {uid} (FLAGS INTERNALDATE ")));
+            if uid == 100 && oversize_uid_100 {
+                write
+                    .write_all(
+                        format!(
+                            "* 1 FETCH (UID 100 FLAGS () BODY[HEADER.FIELDS (SUBJECT)] {{{}}}\r\n",
+                            MAX_MIME_HEADER_BYTES + 1
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                return transcript;
+            }
+            if uid == 100 && fail_uid_100 {
+                write
+                    .write_all(
+                        format!("* 1 FETCH (UID 100 FLAGS ())\r\n{tag} OK incomplete\r\n")
+                            .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                continue;
+            }
+            let headers = format!(
+                "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Realtime {uid}\r\nMessage-ID: <{uid}@realtime.example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
+            );
+            write
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)] {{{}}}\r\n",
+                        headers.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            write.write_all(headers.as_bytes()).await.unwrap();
+            write
+                .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+        }
+        if !fail_uid_100 {
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(select_response(&tag).as_bytes())
+                .await
+                .unwrap();
+        }
+        transcript
     }
 
     async fn scripted_command<R>(reader: &mut BufReader<R>) -> (String, String)
@@ -6420,43 +7875,43 @@ mod tests {
         let response = format!("{tag} OK authenticated\r\n");
         write.write_all(response.as_bytes()).await.unwrap();
 
+        let tag = scripted_expect_command(&mut read, &mut transcript, "CAPABILITY").await;
+        write
+            .write_all(format!("* CAPABILITY IMAP4rev1\r\n{tag} OK capability\r\n").as_bytes())
+            .await
+            .unwrap();
+
         let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
         let response = format!("* LIST (\\\\HasNoChildren) \"/\" \"INBOX\"\r\n{tag} OK listed\r\n");
         write.write_all(response.as_bytes()).await.unwrap();
 
         let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
         let response = format!(
-            "* {} EXISTS\r\n* OK [UIDVALIDITY {uid_validity}] UIDs valid\r\n{tag} OK selected\r\n",
-            remote_uids.len()
+            "* {} EXISTS\r\n* OK [UIDVALIDITY {uid_validity}] UIDs valid\r\n* OK [UIDNEXT {}] next\r\n{tag} OK selected\r\n",
+            remote_uids.len(),
+            remote_uids.iter().copied().max().unwrap_or(0) + 1
         );
         write.write_all(response.as_bytes()).await.unwrap();
 
-        let tag = scripted_expect_command(&mut read, &mut transcript, "UID SEARCH ALL").await;
-        let response = format!(
-            "* SEARCH {}\r\n{tag} OK searched\r\n",
-            remote_uids
-                .iter()
-                .map(u32::to_string)
-                .collect::<Vec<_>>()
-                .join(" ")
-        );
-        write.write_all(response.as_bytes()).await.unwrap();
-
-        // Keep this exact single exchange in the transcript: a duplicate
-        // flags request previously doubled the provider work before download.
-        let tag =
-            scripted_expect_command(&mut read, &mut transcript, "UID FETCH 1:* (UID FLAGS)").await;
+        let tag = scripted_expect_command(
+            &mut read,
+            &mut transcript,
+            &format!("FETCH 1:{} (UID FLAGS)", remote_uids.len()),
+        )
+        .await;
         let flags = remote_uids
             .iter()
-            .map(|uid| format!("* 1 FETCH (UID {uid} FLAGS ())\r\n"))
+            .enumerate()
+            .map(|(index, uid)| format!("* {} FETCH (UID {uid} FLAGS ())\r\n", index + 1))
             .collect::<String>();
         let response = format!("{flags}{tag} OK flags\r\n");
         write.write_all(response.as_bytes()).await.unwrap();
 
         let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
         let response = format!(
-            "* {} EXISTS\r\n* OK [UIDVALIDITY {uid_validity}] UIDs valid\r\n{tag} OK selected\r\n",
-            remote_uids.len()
+            "* {} EXISTS\r\n* OK [UIDVALIDITY {uid_validity}] UIDs valid\r\n* OK [UIDNEXT {}] next\r\n{tag} OK selected\r\n",
+            remote_uids.len(),
+            remote_uids.iter().copied().max().unwrap_or(0) + 1
         );
         write.write_all(response.as_bytes()).await.unwrap();
 
@@ -6487,6 +7942,14 @@ mod tests {
         .await;
         let response = format!(
             "* 1 FETCH (UID {fetched_uid} BODY[]<0> {{5}}\r\nhello)\r\n{tag} OK preview\r\n"
+        );
+        write.write_all(response.as_bytes()).await.unwrap();
+
+        let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+        let response = format!(
+            "* {} EXISTS\r\n* OK [UIDVALIDITY {uid_validity}] UIDs valid\r\n* OK [UIDNEXT {}] next\r\n{tag} OK selected\r\n",
+            remote_uids.len(),
+            remote_uids.iter().copied().max().unwrap_or(0) + 1
         );
         write.write_all(response.as_bytes()).await.unwrap();
 
@@ -6705,13 +8168,14 @@ mod tests {
             first_server.await.unwrap(),
             vec![
                 "LOGIN \"reader@example.test\" \"sync secret\"",
+                "CAPABILITY",
                 "LIST \"\" \"*\"",
                 "SELECT \"INBOX\"",
-                "UID SEARCH ALL",
-                "UID FETCH 1:* (UID FLAGS)",
+                "FETCH 1:1 (UID FLAGS)",
                 "SELECT \"INBOX\"",
                 "UID FETCH 42 (FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)])",
                 "UID FETCH 42 (BODY.PEEK[]<0.8192>)",
+                "SELECT \"INBOX\"",
                 "LOGOUT",
             ]
         );
@@ -6782,13 +8246,14 @@ mod tests {
             second_server.await.unwrap(),
             vec![
                 "LOGIN \"reader@example.test\" \"sync secret\"",
+                "CAPABILITY",
                 "LIST \"\" \"*\"",
                 "SELECT \"INBOX\"",
-                "UID SEARCH ALL",
-                "UID FETCH 1:* (UID FLAGS)",
+                "FETCH 1:2 (UID FLAGS)",
                 "SELECT \"INBOX\"",
                 "UID FETCH 43 (FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)])",
                 "UID FETCH 43 (BODY.PEEK[]<0.8192>)",
+                "SELECT \"INBOX\"",
                 "LOGOUT",
             ]
         );
@@ -6813,6 +8278,2979 @@ mod tests {
                 .unwrap()
                 .subject,
             "Incremental transcript message"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_incomplete_snapshot_preserves_preexisting_mailbox_rows() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        let mut messages = vec![
+            snapshot_test_message(&account, 41),
+            snapshot_test_message(&account, 42),
+        ];
+        messages[1].is_flagged = true;
+        store.upsert_catalog_messages(&messages).await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(
+                    format!(
+                        "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 43] Predicted next UID\r\n{tag} OK selected\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            // EXISTS promised two rows, but the tagged-successful page only
+            // contains one. UID 41 must not be inferred as remotely deleted.
+            write
+                .write_all(
+                    format!("* 2 FETCH (UID 42 FLAGS ())\r\n{tag} OK partial flags\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            transcript
+        });
+
+        let error = service
+            .fetch_new_inbox_headers(&mut client, &account, 50)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("snapshot page was incomplete"),
+            "{error:#}"
+        );
+        assert_eq!(
+            server.await.unwrap(),
+            vec!["SELECT INBOX", "FETCH 1:2 (UID FLAGS)"]
+        );
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [41, 42].into()
+        );
+        assert!(
+            store
+                .message_by_locator(account.id, "INBOX", 42)
+                .await
+                .unwrap()
+                .unwrap()
+                .is_flagged
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_empty_snapshot_deletes_only_after_stable_final_identity() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        store
+            .upsert_catalog_messages(&[snapshot_test_message(&account, 41)])
+            .await
+            .unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let (final_select_reached, final_select_wait) = oneshot::channel();
+        let (finish_final_select, finish_final_select_wait) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let response = |tag: &str| {
+                format!(
+                    "* 0 EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT 1] Predicted next UID\r\n{tag} OK selected\r\n"
+                )
+            };
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write.write_all(response(&tag).as_bytes()).await.unwrap();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            final_select_reached.send(()).unwrap();
+            finish_final_select_wait.await.unwrap();
+            write.write_all(response(&tag).as_bytes()).await.unwrap();
+            transcript
+        });
+
+        let synced_account = account.clone();
+        let sync = tokio::spawn(async move {
+            service
+                .fetch_new_inbox_headers(&mut client, &synced_account, 50)
+                .await
+        });
+        final_select_wait.await.unwrap();
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [41].into(),
+            "a staged empty page must not delete mail before final identity validation"
+        );
+        finish_final_select.send(()).unwrap();
+        assert!(sync.await.unwrap().unwrap().is_empty());
+        assert_eq!(server.await.unwrap(), vec!["SELECT INBOX", "SELECT INBOX"]);
+        assert!(store
+            .mailbox_uids(account.id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    async fn assert_large_message_snapshot_is_bounded(message_count: u32) {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+
+        let template = snapshot_test_message(&account, 1);
+        let messages = (1..=message_count)
+            .map(|uid| {
+                let mut message = template.clone();
+                message.id = stable_message_id(account.id, "INBOX", uid);
+                message.thread_id = message.id.clone();
+                message.uid = i64::from(uid);
+                message.message_id = Some(format!("<{uid}@snapshot.example.test>"));
+                message.subject = format!("Snapshot {uid}");
+                message
+            })
+            .collect::<Vec<_>>();
+        store.upsert_catalog_messages(&messages).await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "LOGIN \"reader@example.test\" \"sync secret\"",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} OK authenticated\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "CAPABILITY").await;
+            write
+                .write_all(format!("* CAPABILITY IMAP4rev1\r\n{tag} OK capability\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+            write
+                .write_all(
+                    format!("* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n{tag} OK listed\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            let select_response = |tag: &str| {
+                format!(
+                    "* {message_count} EXISTS\r\n* OK [UIDVALIDITY 77] UIDs valid\r\n* OK [UIDNEXT {}] Predicted next UID\r\n* OK [HIGHESTMODSEQ 900] Mod-sequence\r\n{tag} OK selected\r\n",
+                    message_count + 1
+                )
+            };
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(select_response(&tag).as_bytes())
+                .await
+                .unwrap();
+
+            for (start, end) in mailbox_snapshot_page_ranges(message_count) {
+                let tag = scripted_expect_command(
+                    &mut read,
+                    &mut transcript,
+                    &format!("FETCH {start}:{end} (UID FLAGS)"),
+                )
+                .await;
+                for sequence in start..=end {
+                    write
+                        .write_all(
+                            format!("* {sequence} FETCH (UID {sequence} FLAGS ())\r\n").as_bytes(),
+                        )
+                        .await
+                        .unwrap();
+                }
+                write
+                    .write_all(format!("{tag} OK page complete\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(select_response(&tag).as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("* BYE done\r\n{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        let result = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.synced_count, 0, "the catalogue was already complete");
+
+        let transcript = server.await.unwrap();
+        let page_commands = transcript
+            .iter()
+            .filter(|command| command.starts_with("FETCH "))
+            .collect::<Vec<_>>();
+        assert_eq!(
+            page_commands.len(),
+            usize::try_from(message_count.div_ceil(MAILBOX_SNAPSHOT_PAGE_SIZE)).unwrap()
+        );
+        assert_eq!(
+            page_commands.first().unwrap().as_str(),
+            format!(
+                "FETCH {}:{message_count} (UID FLAGS)",
+                message_count - MAILBOX_SNAPSHOT_PAGE_SIZE + 1
+            )
+        );
+        assert_eq!(
+            page_commands.last().unwrap().as_str(),
+            "FETCH 1:500 (UID FLAGS)"
+        );
+        assert!(!transcript.iter().any(|command| command == "UID SEARCH ALL"));
+        assert!(!transcript.iter().any(|command| command.contains("1:*")));
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap().len(),
+            message_count as usize
+        );
+        assert!(
+            store
+                .mailbox_catalog_state(account.id, "INBOX")
+                .await
+                .unwrap()
+                .unwrap()
+                .historical_complete
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_thirty_thousand_message_snapshot_uses_sixty_bounded_pages() {
+        assert_large_message_snapshot_is_bounded(30_000).await;
+    }
+
+    #[tokio::test]
+    async fn scripted_one_hundred_thousand_message_snapshot_uses_bounded_pages() {
+        assert_large_message_snapshot_is_bounded(100_000).await;
+    }
+
+    #[tokio::test]
+    async fn scripted_condstore_delta_updates_only_returned_uid_and_persists_modseq() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(scripted_condstore_sync_server(
+            server,
+            CondstoreScript::StableDelta,
+        ));
+
+        let result = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.synced_count, 0);
+
+        let transcript = server.await.unwrap();
+        assert!(transcript
+            .iter()
+            .any(|command| command == "FETCH 1:2 (UID FLAGS MODSEQ) (CHANGEDSINCE 100)"));
+        assert!(!transcript
+            .iter()
+            .any(|command| command == "FETCH 1:2 (UID FLAGS)"));
+        assert!(!transcript.iter().any(|command| command == "UID SEARCH ALL"));
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1, 2].into(),
+            "UIDs omitted from a CHANGEDSINCE result are not deletions"
+        );
+        let changed = store
+            .message_by_locator(account.id, "INBOX", 1)
+            .await
+            .unwrap()
+            .unwrap();
+        let omitted = store
+            .message_by_locator(account.id, "INBOX", 2)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(changed.is_read);
+        assert!(!changed.is_flagged);
+        assert!(!omitted.is_read);
+        assert!(omitted.is_flagged);
+        let state = store
+            .mailbox_catalog_state(account.id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.uid_next, Some(3));
+        assert_eq!(state.highest_modseq.as_deref(), Some("200"));
+    }
+
+    #[tokio::test]
+    async fn scripted_fresh_catalogue_batches_headers_and_snippets_by_uid_set() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let identity = "* 3 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 4] next\r\n";
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:3 (UID FLAGS)").await;
+            write.write_all(format!("* 1 FETCH (UID 1 FLAGS ())\r\n* 2 FETCH (UID 2 FLAGS (\\Seen))\r\n* 3 FETCH (UID 3 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes()).await.unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let metadata_fields = "FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES LIST-ID LIST-UNSUBSCRIBE LIST-UNSUBSCRIBE-POST PRECEDENCE AUTO-SUBMITTED)]";
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                &format!("UID FETCH 3,2,1 ({metadata_fields})"),
+            )
+            .await;
+            for uid in [3, 2, 1] {
+                let headers = format!("Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Batched {uid}\r\nMessage-ID: <batch-{uid}@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n");
+                write.write_all(format!("* {uid} FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" RFC822.SIZE 5 BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes()).await.unwrap();
+                write.write_all(headers.as_bytes()).await.unwrap();
+                write.write_all(b")\r\n").await.unwrap();
+            }
+            write
+                .write_all(format!("{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID FETCH 3,2,1 (BODY.PEEK[]<0.8192>)",
+            )
+            .await;
+            for uid in [3, 2, 1] {
+                write
+                    .write_all(
+                        format!("* {uid} FETCH (UID {uid} BODY[]<0> {{5}}\r\nhello)\r\n")
+                            .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+            write
+                .write_all(format!("{tag} OK snippets\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+        let result = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.synced_count, 3);
+        let transcript = server.await.unwrap();
+        assert_eq!(
+            transcript
+                .iter()
+                .filter(
+                    |command| command.starts_with("UID FETCH") && command.contains("HEADER.FIELDS")
+                )
+                .count(),
+            1
+        );
+        assert_eq!(
+            transcript
+                .iter()
+                .filter(
+                    |command| command.starts_with("UID FETCH") && command.contains("BODY.PEEK[]<")
+                )
+                .count(),
+            1
+        );
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1, 2, 3].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_condstore_nomodseq_falls_back_to_complete_bounded_snapshot() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(scripted_condstore_sync_server(
+            server,
+            CondstoreScript::NoModseq,
+        ));
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+
+        let transcript = server.await.unwrap();
+        assert!(transcript
+            .iter()
+            .any(|command| command == "FETCH 1:2 (UID FLAGS)"));
+        assert!(!transcript
+            .iter()
+            .any(|command| command.contains("CHANGEDSINCE")));
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1, 2].into()
+        );
+        let state = store
+            .mailbox_catalog_state(account.id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.uid_next, Some(3));
+        assert_eq!(state.highest_modseq, None);
+    }
+
+    #[tokio::test]
+    async fn scripted_condstore_uidnext_drift_falls_back_without_deleting_omitted_delta_uids() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(scripted_condstore_sync_server(
+            server,
+            CondstoreScript::UidNextDrift,
+        ));
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+
+        let transcript = server.await.unwrap();
+        assert!(transcript
+            .iter()
+            .any(|command| command.contains("CHANGEDSINCE 100")));
+        assert!(transcript
+            .iter()
+            .any(|command| command == "FETCH 1:2 (UID FLAGS)"));
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1, 2].into()
+        );
+        let omitted = store
+            .message_by_locator(account.id, "INBOX", 2)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!omitted.is_read);
+        assert!(omitted.is_flagged);
+        let state = store
+            .mailbox_catalog_state(account.id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.uid_next, Some(4));
+        assert_eq!(state.highest_modseq.as_deref(), Some("201"));
+    }
+
+    #[tokio::test]
+    async fn scripted_condstore_exists_drift_deletes_only_from_complete_fallback_snapshot() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(scripted_condstore_sync_server(
+            server,
+            CondstoreScript::ExistsDrift,
+        ));
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+
+        let transcript = server.await.unwrap();
+        let delta_index = transcript
+            .iter()
+            .position(|command| command.contains("CHANGEDSINCE 100"))
+            .unwrap();
+        let snapshot_index = transcript
+            .iter()
+            .position(|command| command == "FETCH 1:1 (UID FLAGS)")
+            .unwrap();
+        assert!(delta_index < snapshot_index);
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1].into(),
+            "UID 2 is deleted only after the complete fallback snapshot omits it"
+        );
+        let state = store
+            .mailbox_catalog_state(account.id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.remote_total, 1);
+        assert_eq!(state.uid_next, Some(2));
+        assert_eq!(state.highest_modseq.as_deref(), Some("201"));
+    }
+
+    #[tokio::test]
+    async fn scripted_condstore_select_rejection_retries_plain_full_snapshot() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, response) in [
+                (
+                    "LOGIN \"reader@example.test\" \"sync secret\"",
+                    "OK authenticated",
+                ),
+                ("CAPABILITY", "OK capability"),
+                ("LIST \"\" \"*\"", "OK listed"),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                let untagged = match expected {
+                    "CAPABILITY" => "* CAPABILITY IMAP4rev1 CONDSTORE\r\n",
+                    value if value.starts_with("LIST") => {
+                        "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n"
+                    }
+                    _ => "",
+                };
+                write
+                    .write_all(format!("{untagged}{tag} {response}\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                    .await;
+            write
+                .write_all(format!("{tag} BAD unsupported select parameter\r\n").as_bytes())
+                .await
+                .unwrap();
+            let identity = "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 3] next\r\n";
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            write
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID 1 FLAGS ())\r\n* 2 FETCH (UID 2 FLAGS (\\Flagged))\r\n{tag} OK snapshot\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert_eq!(
+            transcript
+                .iter()
+                .filter(|command| command.starts_with("SELECT"))
+                .map(String::as_str)
+                .collect::<Vec<_>>(),
+            vec![
+                "SELECT \"INBOX\" (CONDSTORE)",
+                "SELECT \"INBOX\"",
+                "SELECT \"INBOX\"",
+            ]
+        );
+        assert!(transcript
+            .iter()
+            .any(|command| command == "FETCH 1:2 (UID FLAGS)"));
+        assert!(!transcript
+            .iter()
+            .any(|command| command.contains("CHANGEDSINCE")));
+    }
+
+    #[tokio::test]
+    async fn scripted_changed_since_rejection_falls_back_without_recursive_splitting() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1 CONDSTORE\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let identity = "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 3] next\r\n* OK [HIGHESTMODSEQ 200] modseq\r\n";
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                    .await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "FETCH 1:2 (UID FLAGS MODSEQ) (CHANGEDSINCE 100)",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} NO CHANGEDSINCE unsupported\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            write
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID 1 FLAGS ())\r\n* 2 FETCH (UID 2 FLAGS (\\Flagged))\r\n{tag} OK snapshot\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                    .await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert_eq!(
+            transcript
+                .iter()
+                .filter(|command| command.contains("CHANGEDSINCE"))
+                .count(),
+            1,
+            "delta rejection must not be recursively split"
+        );
+        assert!(transcript
+            .iter()
+            .any(|command| command == "FETCH 1:2 (UID FLAGS)"));
+    }
+
+    #[tokio::test]
+    async fn scripted_condstore_empty_delta_does_not_skip_pending_metadata_repair() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        store
+            .record_mailbox_sync_failure(account.id, "INBOX", 1, "metadata", "retry")
+            .await
+            .unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1 CONDSTORE\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let identity = "* 2 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 3] next\r\n* OK [HIGHESTMODSEQ 100] modseq\r\n";
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                    .await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            write
+                .write_all(
+                    format!("* 1 FETCH (UID 1 FLAGS ())\r\n* 2 FETCH (UID 2 FLAGS (\\Flagged))\r\n{tag} OK snapshot\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(command.starts_with("UID FETCH 1 (FLAGS INTERNALDATE "));
+            let headers = "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Repaired\r\nMessage-ID: <1@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n";
+            write
+                .write_all(format!("* 1 FETCH (UID 1 FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" RFC822.SIZE 5 BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes())
+                .await
+                .unwrap();
+            write.write_all(headers.as_bytes()).await.unwrap();
+            write
+                .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID FETCH 1 (BODY.PEEK[]<0.8192>)",
+            )
+            .await;
+            write
+                .write_all(
+                    format!("* 1 FETCH (UID 1 BODY[]<0> {{0}}\r\n)\r\n{tag} OK snippet\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\" (CONDSTORE)")
+                    .await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert!(!transcript
+            .iter()
+            .any(|command| command.contains("CHANGEDSINCE")));
+        assert!(transcript
+            .iter()
+            .any(|command| command.starts_with("UID FETCH 1 (FLAGS INTERNALDATE ")));
+        assert!(store
+            .mailbox_sync_failure_uids(account.id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_parse_gap_blocks_watermark_until_retry_succeeds() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        store
+            .save_synced_messages_through(account.id, "INBOX", &[], Some(99))
+            .await
+            .unwrap();
+
+        let (mut first_client, first_server) = duplex_imap_client_and_server();
+        let first_server = tokio::spawn(scripted_realtime_gap_server(first_server, true));
+        let error = service
+            .fetch_new_inbox_headers(&mut first_client, &account, 50)
+            .await
+            .unwrap_err();
+        assert!(
+            error.to_string().contains("metadata remained incomplete"),
+            "{error:#}"
+        );
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(99),
+            "UID 101 success must not move the watermark past failed UID 100"
+        );
+        assert_eq!(
+            store
+                .mailbox_sync_failure_uids(account.id, "INBOX")
+                .await
+                .unwrap(),
+            vec![100]
+        );
+        assert!(store
+            .message_by_locator(account.id, "INBOX", 100)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .message_by_locator(account.id, "INBOX", 101)
+            .await
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            first_server.await.unwrap(),
+            vec![
+                "SELECT INBOX",
+                "FETCH 1:2 (UID FLAGS)",
+                "UID FETCH 100 (FLAGS INTERNALDATE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)])",
+                "UID FETCH 101 (FLAGS INTERNALDATE BODY.PEEK[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)])",
+            ]
+        );
+
+        let (mut retry_client, retry_server) = duplex_imap_client_and_server();
+        let retry_server = tokio::spawn(scripted_realtime_gap_server(retry_server, false));
+        service
+            .fetch_new_inbox_headers(&mut retry_client, &account, 50)
+            .await
+            .unwrap();
+        retry_server.await.unwrap();
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(101)
+        );
+        assert!(store
+            .mailbox_sync_failure_uids(account.id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [100, 101].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_failure_does_not_starve_new_mail_beyond_cycle_limit() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        store
+            .save_synced_messages_through(account.id, "INBOX", &[], Some(99))
+            .await
+            .unwrap();
+
+        let first_window = (100..=124).collect::<Vec<_>>();
+        let (mut first_client, first_server) = duplex_imap_client_and_server();
+        let first_server = tokio::spawn(scripted_realtime_starvation_server(
+            first_server,
+            first_window,
+            true,
+            false,
+        ));
+        service
+            .fetch_new_inbox_headers(&mut first_client, &account, 25)
+            .await
+            .unwrap_err();
+        first_server.await.unwrap();
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(99)
+        );
+        assert_eq!(
+            store
+                .mailbox_sync_failure_uids(account.id, "INBOX")
+                .await
+                .unwrap(),
+            vec![100]
+        );
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap().len(),
+            24
+        );
+
+        let (mut retry_client, retry_server) = duplex_imap_client_and_server();
+        let retry_server = tokio::spawn(scripted_realtime_starvation_server(
+            retry_server,
+            vec![125, 100],
+            false,
+            false,
+        ));
+        service
+            .fetch_new_inbox_headers(&mut retry_client, &account, 25)
+            .await
+            .unwrap();
+        let retry_transcript = retry_server.await.unwrap();
+        let metadata_commands = retry_transcript
+            .iter()
+            .filter(|command| command.starts_with("UID FETCH"))
+            .collect::<Vec<_>>();
+        assert_eq!(metadata_commands.len(), 2);
+        assert!(metadata_commands[0].starts_with("UID FETCH 125 "));
+        assert!(metadata_commands[1].starts_with("UID FETCH 100 "));
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(125),
+            "repairing UID 100 must advance through already-persisted UIDs 101-124 and new UID 125"
+        );
+        assert!(store
+            .mailbox_sync_failure_uids(account.id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap().len(),
+            26
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_resource_error_persists_earlier_success_before_reconnect() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        store
+            .save_synced_messages_through(account.id, "INBOX", &[], Some(99))
+            .await
+            .unwrap();
+
+        let (mut first_client, first_server) = duplex_imap_client_and_server();
+        let first_server = tokio::spawn(scripted_realtime_starvation_server(
+            first_server,
+            (100..=124).collect(),
+            true,
+            false,
+        ));
+        service
+            .fetch_new_inbox_headers(&mut first_client, &account, 25)
+            .await
+            .unwrap_err();
+        first_server.await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(scripted_realtime_starvation_server(
+            server,
+            vec![125, 100],
+            false,
+            true,
+        ));
+        let error = service
+            .fetch_new_inbox_headers(&mut client, &account, 25)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("UID 100"), "{error:#}");
+        server.await.unwrap();
+        assert!(store
+            .message_by_locator(account.id, "INBOX", 125)
+            .await
+            .unwrap()
+            .is_some());
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(99),
+            "the durable UID 100 gap must still block the contiguous watermark"
+        );
+        assert_eq!(
+            store
+                .mailbox_sync_failure_uids(account.id, "INBOX")
+                .await
+                .unwrap(),
+            vec![100]
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_finalization_keeps_explicit_bounded_watermark() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        store
+            .save_synced_messages_through(account.id, "INBOX", &[], Some(99))
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let identity =
+                "* 5 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 105] next\r\n";
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:5 (UID FLAGS)").await;
+            for (sequence, uid) in (100..=104).enumerate() {
+                write
+                    .write_all(
+                        format!("* {} FETCH (UID {uid} FLAGS ())\r\n", sequence + 1).as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+            write
+                .write_all(format!("{tag} OK snapshot\r\n").as_bytes())
+                .await
+                .unwrap();
+            for uid in [100, 101] {
+                let (tag, command) = scripted_command(&mut read).await;
+                transcript.push(command.clone());
+                assert!(command.starts_with(&format!("UID FETCH {uid} (FLAGS INTERNALDATE ")));
+                let headers = format!("Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Bounded {uid}\r\nMessage-ID: <{uid}@bounded.example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n");
+                write.write_all(format!("* 1 FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes()).await.unwrap();
+                write.write_all(headers.as_bytes()).await.unwrap();
+                write
+                    .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+        });
+        service
+            .fetch_new_inbox_headers(&mut client, &account, 2)
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(101),
+            "staged but unfetched UIDs 102-104 must not advance the durable watermark"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_bounds_oldest_failure_retries_without_reducing_new_mail_window() {
+        const FAILURE_COUNT: u32 = 30;
+        const NEW_MAIL_LIMIT: u32 = 2;
+
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        store
+            .save_synced_messages_through(account.id, "INBOX", &[], Some(FAILURE_COUNT))
+            .await
+            .unwrap();
+        for uid in 1..=FAILURE_COUNT {
+            store
+                .record_mailbox_sync_failure(account.id, "INBOX", uid, "metadata", "retry")
+                .await
+                .unwrap();
+        }
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let remote_count = FAILURE_COUNT + NEW_MAIL_LIMIT;
+            let identity = format!(
+                "* {remote_count} EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT {}] next\r\n",
+                remote_count + 1
+            );
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                &format!("FETCH 1:{remote_count} (UID FLAGS)"),
+            )
+            .await;
+            for uid in 1..=remote_count {
+                write
+                    .write_all(format!("* {uid} FETCH (UID {uid} FLAGS ())\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            write
+                .write_all(format!("{tag} OK snapshot\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            let expected = (FAILURE_COUNT + 1..=remote_count)
+                .chain(1..=u32::try_from(REALTIME_FAILED_UID_RETRY_LIMIT).unwrap())
+                .collect::<Vec<_>>();
+            for uid in expected {
+                let (tag, command) = scripted_command(&mut read).await;
+                transcript.push(command.clone());
+                assert!(command.starts_with(&format!("UID FETCH {uid} (FLAGS INTERNALDATE ")));
+                let headers = format!(
+                    "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Retry {uid}\r\nMessage-ID: <{uid}@retry.example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
+                );
+                write
+                    .write_all(
+                        format!(
+                            "* 1 FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER] {{{}}}\r\n",
+                            headers.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                write.write_all(headers.as_bytes()).await.unwrap();
+                write
+                    .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .fetch_new_inbox_headers(&mut client, &account, NEW_MAIL_LIMIT)
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        let metadata_uids = transcript
+            .iter()
+            .filter(|command| command.starts_with("UID FETCH"))
+            .map(|command| {
+                command
+                    .split_whitespace()
+                    .nth(2)
+                    .unwrap()
+                    .parse::<u32>()
+                    .unwrap()
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(
+            &metadata_uids[..NEW_MAIL_LIMIT as usize],
+            &[FAILURE_COUNT + 1, FAILURE_COUNT + 2],
+            "durable repairs must not consume new-mail capacity"
+        );
+        assert_eq!(
+            metadata_uids.len(),
+            NEW_MAIL_LIMIT as usize + REALTIME_FAILED_UID_RETRY_LIMIT
+        );
+        assert_eq!(
+            &metadata_uids[NEW_MAIL_LIMIT as usize..],
+            &(1..=u32::try_from(REALTIME_FAILED_UID_RETRY_LIMIT).unwrap()).collect::<Vec<_>>(),
+            "only the oldest bounded retry subset should run this cycle"
+        );
+        assert_eq!(
+            store
+                .mailbox_sync_failure_uids(account.id, "INBOX")
+                .await
+                .unwrap(),
+            (REALTIME_FAILED_UID_RETRY_LIMIT as u32 + 1..=FAILURE_COUNT).collect::<Vec<_>>()
+        );
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(FAILURE_COUNT + NEW_MAIL_LIMIT)
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_uidvalidity_rollover_replaces_recycled_uid_only_after_metadata() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        let mut old = snapshot_test_message(&account, 1);
+        old.subject = "Old namespace subject".into();
+        store.upsert_catalog_messages(&[old]).await.unwrap();
+        let old_generation = store
+            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 10, 1, Some(2), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account.id, "INBOX", &old_generation, &[(1, false, false)])
+            .await
+            .unwrap();
+        store
+            .finalize_mailbox_snapshot(account.id, "INBOX", &old_generation)
+            .await
+            .unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let identity = "* 1 EXISTS\r\n* OK [UIDVALIDITY 11] valid\r\n* OK [UIDNEXT 2] next\r\n";
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:1 (UID FLAGS)").await;
+            write
+                .write_all(
+                    format!("* 1 FETCH (UID 1 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(command.starts_with("UID FETCH 1 (FLAGS INTERNALDATE "));
+            let headers = "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: New <new@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: New namespace subject\r\nMessage-ID: <new-1@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n";
+            write
+                .write_all(
+                    format!(
+                        "* 1 FETCH (UID 1 FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER.FIELDS (DATE FROM TO CC BCC REPLY-TO SUBJECT MESSAGE-ID IN-REPLY-TO REFERENCES CONTENT-TYPE LIST-ID PRECEDENCE AUTO-SUBMITTED)] {{{}}}\r\n",
+                        headers.len()
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            write.write_all(headers.as_bytes()).await.unwrap();
+            write
+                .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .fetch_new_inbox_headers(&mut client, &account, 25)
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert!(transcript
+            .iter()
+            .any(|command| command.starts_with("UID FETCH 1 ")));
+        let message = store
+            .message_by_locator(account.id, "INBOX", 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(message.subject, "New namespace subject");
+        let state = store
+            .mailbox_catalog_state(account.id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.uid_validity, 11);
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_rollover_replaces_every_uid_beyond_normal_cycle_limit() {
+        const REMOTE_COUNT: u32 = 7;
+        const CYCLE_LIMIT: u32 = 3;
+
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        let old_messages = (1..=REMOTE_COUNT)
+            .map(|uid| {
+                let mut message = snapshot_test_message(&account, uid);
+                message.subject = format!("Old namespace {uid}");
+                message
+            })
+            .collect::<Vec<_>>();
+        store.upsert_catalog_messages(&old_messages).await.unwrap();
+        let old_generation = store
+            .begin_mailbox_snapshot(
+                account.id,
+                "INBOX",
+                "INBOX",
+                10,
+                REMOTE_COUNT,
+                Some(REMOTE_COUNT + 1),
+                None,
+            )
+            .await
+            .unwrap();
+        let old_flags = (1..=REMOTE_COUNT)
+            .map(|uid| (uid, false, false))
+            .collect::<Vec<_>>();
+        store
+            .stage_mailbox_snapshot_page(account.id, "INBOX", &old_generation, &old_flags)
+            .await
+            .unwrap();
+        store
+            .finalize_mailbox_snapshot(account.id, "INBOX", &old_generation)
+            .await
+            .unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let identity = format!(
+                "* {REMOTE_COUNT} EXISTS\r\n* OK [UIDVALIDITY 11] valid\r\n* OK [UIDNEXT {}] next\r\n",
+                REMOTE_COUNT + 1
+            );
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                &format!("FETCH 1:{REMOTE_COUNT} (UID FLAGS)"),
+            )
+            .await;
+            for uid in 1..=REMOTE_COUNT {
+                write
+                    .write_all(format!("* {uid} FETCH (UID {uid} FLAGS ())\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            write
+                .write_all(format!("{tag} OK snapshot\r\n").as_bytes())
+                .await
+                .unwrap();
+            let uid_set = (1..=REMOTE_COUNT)
+                .rev()
+                .map(|uid| uid.to_string())
+                .collect::<Vec<_>>()
+                .join(",");
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(command.starts_with(&format!("UID FETCH {uid_set} (FLAGS INTERNALDATE ")));
+            for uid in 1..=REMOTE_COUNT {
+                let headers = format!(
+                    "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: New <new@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: New namespace {uid}\r\nMessage-ID: <new-{uid}@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n"
+                );
+                write
+                    .write_all(
+                        format!(
+                            "* {uid} FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER] {{{}}}\r\n",
+                            headers.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                write.write_all(headers.as_bytes()).await.unwrap();
+                write.write_all(b")\r\n").await.unwrap();
+            }
+            write
+                .write_all(format!("{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .fetch_new_inbox_headers(&mut client, &account, CYCLE_LIMIT)
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert_eq!(
+            transcript
+                .iter()
+                .filter(|command| command.starts_with("UID FETCH"))
+                .count(),
+            1,
+            "replacement metadata should remain batched"
+        );
+        for uid in 1..=REMOTE_COUNT {
+            assert_eq!(
+                store
+                    .message_by_locator(account.id, "INBOX", uid)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .subject,
+                format!("New namespace {uid}")
+            );
+        }
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(REMOTE_COUNT)
+        );
+        assert_eq!(
+            store
+                .mailbox_catalog_state(account.id, "INBOX")
+                .await
+                .unwrap()
+                .unwrap()
+                .uid_validity,
+            11
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_rollover_resumes_only_uids_without_staged_outcomes() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        let old_messages = (1..=3)
+            .map(|uid| snapshot_test_message(&account, uid))
+            .collect::<Vec<_>>();
+        store.upsert_catalog_messages(&old_messages).await.unwrap();
+        let old_generation = store
+            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 10, 3, Some(4), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account.id,
+                "INBOX",
+                &old_generation,
+                &[(1, false, false), (2, false, false), (3, false, false)],
+            )
+            .await
+            .unwrap();
+        store
+            .finalize_mailbox_snapshot(account.id, "INBOX", &old_generation)
+            .await
+            .unwrap();
+
+        let spawn_server = |server: DuplexStream, retry: bool| {
+            tokio::spawn(async move {
+                let (read, mut write) = split(server);
+                let mut read = BufReader::new(read);
+                let mut transcript = Vec::new();
+                let identity =
+                    "* 3 EXISTS\r\n* OK [UIDVALIDITY 11] valid\r\n* OK [UIDNEXT 4] next\r\n";
+                let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+                write
+                    .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                    .await
+                    .unwrap();
+                let tag =
+                    scripted_expect_command(&mut read, &mut transcript, "FETCH 1:3 (UID FLAGS)")
+                        .await;
+                write.write_all(format!("* 1 FETCH (UID 1 FLAGS ())\r\n* 2 FETCH (UID 2 FLAGS ())\r\n* 3 FETCH (UID 3 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes()).await.unwrap();
+                let expected = if retry { "1" } else { "3,2,1" };
+                let (tag, command) = scripted_command(&mut read).await;
+                transcript.push(command.clone());
+                assert!(
+                    command.starts_with(&format!("UID FETCH {expected} (FLAGS INTERNALDATE ")),
+                    "unexpected metadata command: {command}"
+                );
+                let returned: &[u32] = if retry { &[1] } else { &[3, 2] };
+                for uid in returned {
+                    let headers = format!("Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: New <new@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Resumed {uid}\r\nMessage-ID: <resumed-{uid}@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n");
+                    write.write_all(format!("* {uid} FETCH (UID {uid} FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes()).await.unwrap();
+                    write.write_all(headers.as_bytes()).await.unwrap();
+                    write.write_all(b")\r\n").await.unwrap();
+                }
+                write
+                    .write_all(format!("{tag} OK metadata\r\n").as_bytes())
+                    .await
+                    .unwrap();
+                if retry {
+                    let tag =
+                        scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+                    write
+                        .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                        .await
+                        .unwrap();
+                }
+                transcript
+            })
+        };
+
+        let (mut first_client, first_server) = duplex_imap_client_and_server();
+        let first_server = spawn_server(first_server, false);
+        service
+            .fetch_new_inbox_headers(&mut first_client, &account, 1)
+            .await
+            .unwrap_err();
+        first_server.await.unwrap();
+        let resumed_generation = store
+            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 11, 3, Some(4), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account.id,
+                "INBOX",
+                &resumed_generation,
+                &[(1, false, false), (2, false, false), (3, false, false)],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids_without_replacement_outcome(
+                    account.id,
+                    "INBOX",
+                    &resumed_generation,
+                )
+                .await
+                .unwrap(),
+            vec![1]
+        );
+        let (mut retry_client, retry_server) = duplex_imap_client_and_server();
+        let retry_server = spawn_server(retry_server, true);
+        service
+            .fetch_new_inbox_headers(&mut retry_client, &account, 1)
+            .await
+            .unwrap();
+        let retry_transcript = retry_server.await.unwrap();
+        assert_eq!(
+            retry_transcript
+                .iter()
+                .filter(|command| command.starts_with("UID FETCH"))
+                .count(),
+            1
+        );
+        for uid in 1..=3 {
+            assert_eq!(
+                store
+                    .message_by_locator(account.id, "INBOX", uid)
+                    .await
+                    .unwrap()
+                    .unwrap()
+                    .subject,
+                format!("Resumed {uid}")
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn scripted_realtime_missing_uidnext_resume_prunes_old_inventory_and_reuses_outcomes() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        let old_messages = (1..=2)
+            .map(|uid| {
+                let mut message = snapshot_test_message(&account, uid);
+                message.subject = format!("Old namespace {uid}");
+                message
+            })
+            .collect::<Vec<_>>();
+        store.upsert_catalog_messages(&old_messages).await.unwrap();
+        let old_generation = store
+            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 10, 2, Some(3), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account.id,
+                "INBOX",
+                &old_generation,
+                &[(1, false, false), (2, false, false)],
+            )
+            .await
+            .unwrap();
+        store
+            .finalize_mailbox_snapshot(account.id, "INBOX", &old_generation)
+            .await
+            .unwrap();
+
+        let identity = "* 2 EXISTS\r\n* OK [UIDVALIDITY 11] valid\r\n";
+        let (mut first_client, first_server) = duplex_imap_client_and_server();
+        let first_server = tokio::spawn(async move {
+            let (read, mut write) = split(first_server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            write.write_all(format!("* 1 FETCH (UID 1 FLAGS ())\r\n* 2 FETCH (UID 2 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes()).await.unwrap();
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(
+                command.starts_with("UID FETCH 2,1 (FLAGS INTERNALDATE "),
+                "unexpected metadata command: {command}"
+            );
+            let headers = "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: New <new@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Retained 2\r\nMessage-ID: <retained-2@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n";
+            write.write_all(format!("* 2 FETCH (UID 2 FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes()).await.unwrap();
+            write.write_all(headers.as_bytes()).await.unwrap();
+            write
+                .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+        service
+            .fetch_new_inbox_headers(&mut first_client, &account, 1)
+            .await
+            .unwrap_err();
+        first_server.await.unwrap();
+
+        let (mut retry_client, retry_server) = duplex_imap_client_and_server();
+        let retry_server = tokio::spawn(async move {
+            let (read, mut write) = split(retry_server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            write.write_all(format!("* 1 FETCH (UID 2 FLAGS ())\r\n* 2 FETCH (UID 3 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes()).await.unwrap();
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(
+                command.starts_with("UID FETCH 3 (FLAGS INTERNALDATE "),
+                "the retained UID 2 outcome must not be fetched again: {command}"
+            );
+            let headers = "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: New <new@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: New 3\r\nMessage-ID: <new-3@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n";
+            write.write_all(format!("* 2 FETCH (UID 3 FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes()).await.unwrap();
+            write.write_all(headers.as_bytes()).await.unwrap();
+            write
+                .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT INBOX").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            write.write_all(format!("* 1 FETCH (UID 2 FLAGS ())\r\n* 2 FETCH (UID 3 FLAGS ())\r\n{tag} OK verification snapshot\r\n").as_bytes()).await.unwrap();
+            transcript
+        });
+        service
+            .fetch_new_inbox_headers(&mut retry_client, &account, 1)
+            .await
+            .unwrap();
+        let retry_transcript = retry_server.await.unwrap();
+        assert_eq!(
+            retry_transcript
+                .iter()
+                .filter(|command| command.starts_with("UID FETCH"))
+                .count(),
+            1
+        );
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [2, 3].into()
+        );
+        assert_eq!(
+            store
+                .message_by_locator(account.id, "INBOX", 2)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Retained 2"
+        );
+        assert_eq!(
+            store
+                .message_by_locator(account.id, "INBOX", 3)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "New 3"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_full_snapshot_without_final_uidnext_preserves_absent_rows() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let initial = "* 1 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 3] next\r\n";
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{initial}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:1 (UID FLAGS)").await;
+            write
+                .write_all(
+                    format!("* 1 FETCH (UID 1 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(
+                    format!("* 1 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n{tag} OK selected\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:1 (UID FLAGS)").await;
+            write
+                .write_all(
+                    format!("* 1 FETCH (UID 3 FLAGS ())\r\n{tag} OK replacement inventory\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+            transcript
+        });
+
+        let error = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{error:#}").contains("membership changed"),
+            "{error:#}"
+        );
+        server.await.unwrap();
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1, 2].into(),
+            "missing final UIDNEXT cannot authorize deleting UID 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_stable_missing_uidnext_publishes_after_matching_second_inventory() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let identity = "* 1 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n";
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            for label in ["first", "second"] {
+                let tag =
+                    scripted_expect_command(&mut read, &mut transcript, "FETCH 1:1 (UID FLAGS)")
+                        .await;
+                write
+                    .write_all(
+                        format!("* 1 FETCH (UID 1 FLAGS ())\r\n{tag} OK {label} inventory\r\n")
+                            .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                if label == "first" {
+                    let tag =
+                        scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"")
+                            .await;
+                    write
+                        .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                        .await
+                        .unwrap();
+                }
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert_eq!(
+            transcript
+                .iter()
+                .filter(|command| command.as_str() == "FETCH 1:1 (UID FLAGS)")
+                .count(),
+            2
+        );
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_full_snapshot_allows_modseq_only_drift_and_keeps_earlier_generation() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write.write_all(format!("* 2 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 3] next\r\n* OK [HIGHESTMODSEQ 200] modseq\r\n{tag} OK selected\r\n").as_bytes()).await.unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:2 (UID FLAGS)").await;
+            write.write_all(format!("* 1 FETCH (UID 1 FLAGS ())\r\n* 2 FETCH (UID 2 FLAGS (\\Flagged))\r\n{tag} OK snapshot\r\n").as_bytes()).await.unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write.write_all(format!("* 2 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 3] next\r\n* OK [HIGHESTMODSEQ 201] modseq\r\n{tag} OK selected\r\n").as_bytes()).await.unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                false,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1, 2].into()
+        );
+        assert_eq!(
+            store
+                .mailbox_catalog_state(account.id, "INBOX")
+                .await
+                .unwrap()
+                .unwrap()
+                .highest_modseq
+                .as_deref(),
+            Some("200"),
+            "the next CHANGEDSINCE must start before the flag change observed during backfill"
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_oversized_exists_is_rejected_before_destructive_snapshot_work() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        seed_condstore_catalog(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write.write_all(format!("* {} EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 3] next\r\n{tag} OK selected\r\n", MAX_SUPPORTED_MAILBOX_MESSAGES + 1).as_bytes()).await.unwrap();
+            transcript
+        });
+        let error = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("supported 1000000"), "{error:#}");
+        let transcript = server.await.unwrap();
+        assert!(!transcript
+            .iter()
+            .any(|command| command.starts_with("FETCH ")));
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [1, 2].into()
+        );
+    }
+
+    async fn seed_optional_archive_message(store: &Store, account: &Account) {
+        let mut message = snapshot_test_message(account, 9);
+        message.mailbox = "Archive".into();
+        message.id = stable_message_id(account.id, "Archive", 9);
+        message.thread_id = message.id.clone();
+        store.upsert_catalog_messages(&[message]).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_clears_optional_namespace_only_after_nonexistent_response_code() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        seed_optional_archive_message(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                ("LIST \"\" \"*\"", ""),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"Archive\"").await;
+            write
+                .write_all(format!("{tag} NO [NONEXISTENT] mailbox is gone\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("Archive", "Archive")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(store
+            .mailbox_uids(account.id, "Archive")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_transient_optional_select_failure_preserves_namespace() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        seed_optional_archive_message(&store, &account).await;
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for expected in [
+                "LOGIN \"reader@example.test\" \"sync secret\"",
+                "CAPABILITY",
+                "LIST \"\" \"*\"",
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                let untagged = if expected == "CAPABILITY" {
+                    "* CAPABILITY IMAP4rev1\r\n"
+                } else {
+                    ""
+                };
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"Archive\"").await;
+            write
+                .write_all(format!("{tag} NO temporary backend failure\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        let error = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("Archive", "Archive")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+        assert!(error
+            .to_string()
+            .contains("cannot replace optional mailbox"));
+        server.await.unwrap();
+        assert_eq!(
+            store.mailbox_uids(account.id, "Archive").await.unwrap(),
+            [9].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_records_gmail_filtered_uids_as_completed_replacement_outcomes() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = AccountDraft {
+            email: "reader@example.test".into(),
+            display_name: "Reader".into(),
+            provider_id: Some("gmail".into()),
+            username: None,
+            imap_host: None,
+            imap_port: None,
+            imap_security: None,
+            smtp_host: None,
+            smtp_port: None,
+            smtp_security: None,
+            archive_mailbox: None,
+            spam_mailbox: None,
+        }
+        .into_account(provider::by_id("gmail").unwrap());
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        seed_optional_archive_message(&store, &account).await;
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                ("LIST \"\" \"*\"", ""),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let identity = "* 1 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 2] next\r\n";
+            let select = "SELECT \"[Gmail]/All Mail\"";
+            let tag = scripted_expect_command(&mut read, &mut transcript, select).await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:1 (UID FLAGS)").await;
+            write
+                .write_all(
+                    format!("* 1 FETCH (UID 1 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, select).await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let (tag, command) = scripted_command(&mut read).await;
+            transcript.push(command.clone());
+            assert!(command.starts_with(
+                "UID FETCH 1 (FLAGS INTERNALDATE RFC822.SIZE BODYSTRUCTURE X-GM-LABELS "
+            ));
+            let headers = "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: Sender <sender@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Inbox copy\r\nMessage-ID: <gmail-filtered@example.test>\r\n\r\n";
+            write.write_all(format!("* 1 FETCH (UID 1 FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" RFC822.SIZE 5 X-GM-LABELS (\\Inbox) BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes()).await.unwrap();
+            write.write_all(headers.as_bytes()).await.unwrap();
+            write
+                .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, select).await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::gmail_archive("[Gmail]/All Mail")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert!(!transcript
+            .iter()
+            .any(|command| command.contains("BODY.PEEK[]<0.8192>")));
+        assert!(store
+            .mailbox_uids(account.id, "Archive")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_prunes_stale_sent_key_after_two_discovered_siblings_finalize() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let mut stale = snapshot_test_message(&account, 9);
+        stale.mailbox = "Sent::Legacy".into();
+        stale.id = stable_message_id(account.id, "Sent::Legacy", 9);
+        stale.thread_id = stale.id.clone();
+        store.upsert_catalog_messages(&[stale]).await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* list (\\HasNoChildren \\Sent) \"/\" \"Sent Items\"\r\n* LIST (\\HasNoChildren \\Sent) \"/\" \"Sent Messages\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let identity = "* 0 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 1] next\r\n";
+            for mailbox in ["Sent Items", "Sent Messages", "Sent Items", "Sent Messages"] {
+                let tag = scripted_expect_command(
+                    &mut read,
+                    &mut transcript,
+                    &format!("SELECT {}", quote_imap(mailbox)),
+                )
+                .await;
+                write
+                    .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("Sent", "Sent")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        let transcript = server.await.unwrap();
+        assert!(transcript
+            .iter()
+            .any(|command| command == "SELECT \"Sent Items\""));
+        assert!(transcript
+            .iter()
+            .any(|command| command == "SELECT \"Sent Messages\""));
+        assert!(store
+            .mailbox_uids(account.id, "Sent::Legacy")
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .mailbox_catalog_state(account.id, "Sent::Sent Items")
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .mailbox_catalog_state(account.id, "Sent::Sent Messages")
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_nonexistent_sent_sibling_does_not_clear_current_sibling() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let mut stale = snapshot_test_message(&account, 9);
+        stale.mailbox = "Sent::Legacy".into();
+        stale.id = stable_message_id(account.id, "Sent::Legacy", 9);
+        stale.thread_id = stale.id.clone();
+        store.upsert_catalog_messages(&[stale]).await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                (
+                    "LIST \"\" \"*\"",
+                    "* LIST (\\Sent) \"/\" \"Sent Items\"\r\n* LIST (\\Sent) \"/\" \"Sent Messages\"\r\n",
+                ),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let identity = "* 0 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 1] next\r\n";
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"Sent Items\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"Sent Messages\"")
+                    .await;
+            write
+                .write_all(format!("{tag} NO [NONEXISTENT] removed\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"Sent Items\"").await;
+            write
+                .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                .await
+                .unwrap();
+        });
+
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("Sent", "Sent")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        server.await.unwrap();
+        assert!(store
+            .mailbox_catalog_state(account.id, "Sent::Sent Items")
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .mailbox_catalog_state(account.id, "Sent::Sent Messages")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .mailbox_uids(account.id, "Sent::Legacy")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_malformed_list_cannot_clear_a_special_mailbox_family() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let mut stale = snapshot_test_message(&account, 9);
+        stale.mailbox = "Sent::Legacy".into();
+        stale.id = stable_message_id(account.id, "Sent::Legacy", 9);
+        stale.thread_id = stale.id.clone();
+        store.upsert_catalog_messages(&[stale]).await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                ("LIST \"\" \"*\"", "* LIST \\Sent \"/\" \"Sent Items\"\r\n"),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            transcript
+        });
+        let error = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("Sent", "Sent")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+        server.await.unwrap();
+        assert!(format!("{error:#}").contains("LIST response is malformed"));
+        assert_eq!(
+            store
+                .mailbox_uids(account.id, "Sent::Legacy")
+                .await
+                .unwrap(),
+            [9].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_list_literal_mailbox_cannot_select_or_prune_a_family() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let mut stale = snapshot_test_message(&account, 9);
+        stale.mailbox = "Sent::Legacy".into();
+        stale.id = stable_message_id(account.id, "Sent::Legacy", 9);
+        stale.thread_id = stale.id.clone();
+        store.upsert_catalog_messages(&[stale]).await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+            write
+                .write_all(b"* LIST (\\Sent) \"/\" {10}\r\nSent Items\r\n")
+                .await
+                .unwrap();
+            write
+                .write_all(format!("{tag} OK done\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+        let error = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("Sent", "Sent")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+        let transcript = server.await.unwrap();
+        assert!(format!("{error:#}").contains("LIST response is malformed"));
+        assert!(!transcript
+            .iter()
+            .any(|command| command.starts_with("SELECT ")));
+        assert_eq!(
+            store
+                .mailbox_uids(account.id, "Sent::Legacy")
+                .await
+                .unwrap(),
+            [9].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_list_command_failure_preserves_special_mailbox_family() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let mut stale = snapshot_test_message(&account, 9);
+        stale.mailbox = "Sent::Legacy".into();
+        stale.id = stable_message_id(account.id, "Sent::Legacy", 9);
+        stale.thread_id = stale.id.clone();
+        store.upsert_catalog_messages(&[stale]).await.unwrap();
+
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            for (expected, untagged) in [
+                ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+            ] {
+                let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                write
+                    .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+            write
+                .write_all(format!("{tag} NO discovery unavailable\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+        let error = service
+            .sync_mailboxes_with_progress_on_client(
+                &mut client,
+                &account,
+                50,
+                vec![MailboxPlan::new("Sent", "Sent")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+        let transcript = server.await.unwrap();
+        assert!(format!("{error:#}").contains("LIST discovery failed"));
+        assert!(!transcript
+            .iter()
+            .any(|command| command.starts_with("SELECT ")));
+        assert_eq!(
+            store
+                .mailbox_uids(account.id, "Sent::Legacy")
+                .await
+                .unwrap(),
+            [9].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn scripted_reset_missing_snippet_remains_retryable_until_literal_completes() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store.clone());
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        service
+            .credentials()
+            .set_password(&account, "sync secret")
+            .await
+            .unwrap();
+        let mut old = snapshot_test_message(&account, 1);
+        old.subject = "Old committed subject".into();
+        store.upsert_catalog_messages(&[old]).await.unwrap();
+
+        let spawn_server = |server: DuplexStream, complete_snippet: bool| {
+            tokio::spawn(async move {
+                let (read, mut write) = split(server);
+                let mut read = BufReader::new(read);
+                let mut transcript = Vec::new();
+                for (expected, untagged) in [
+                    ("LOGIN \"reader@example.test\" \"sync secret\"", ""),
+                    ("CAPABILITY", "* CAPABILITY IMAP4rev1\r\n"),
+                    (
+                        "LIST \"\" \"*\"",
+                        "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n",
+                    ),
+                ] {
+                    let tag = scripted_expect_command(&mut read, &mut transcript, expected).await;
+                    write
+                        .write_all(format!("{untagged}{tag} OK done\r\n").as_bytes())
+                        .await
+                        .unwrap();
+                }
+                let identity =
+                    "* 1 EXISTS\r\n* OK [UIDVALIDITY 77] valid\r\n* OK [UIDNEXT 2] next\r\n";
+                let tag =
+                    scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+                write
+                    .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                    .await
+                    .unwrap();
+                let tag =
+                    scripted_expect_command(&mut read, &mut transcript, "FETCH 1:1 (UID FLAGS)")
+                        .await;
+                write
+                    .write_all(
+                        format!("* 1 FETCH (UID 1 FLAGS ())\r\n{tag} OK snapshot\r\n").as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                let tag =
+                    scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+                write
+                    .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                    .await
+                    .unwrap();
+                let (tag, command) = scripted_command(&mut read).await;
+                transcript.push(command.clone());
+                assert!(command.starts_with("UID FETCH 1 (FLAGS INTERNALDATE "));
+                let headers = "Date: Wed, 30 Jul 2026 10:00:00 +0000\r\nFrom: New <new@example.test>\r\nTo: Reader <reader@example.test>\r\nSubject: Replacement subject\r\nMessage-ID: <replacement@example.test>\r\nContent-Type: text/plain; charset=utf-8\r\n\r\n";
+                write.write_all(format!("* 1 FETCH (UID 1 FLAGS () INTERNALDATE \"30-Jul-2026 10:00:00 +0000\" RFC822.SIZE 5 BODY[HEADER] {{{}}}\r\n", headers.len()).as_bytes()).await.unwrap();
+                write.write_all(headers.as_bytes()).await.unwrap();
+                write
+                    .write_all(format!(")\r\n{tag} OK metadata\r\n").as_bytes())
+                    .await
+                    .unwrap();
+                let tag = scripted_expect_command(
+                    &mut read,
+                    &mut transcript,
+                    "UID FETCH 1 (BODY.PEEK[]<0.8192>)",
+                )
+                .await;
+                if complete_snippet {
+                    write
+                        .write_all(
+                            format!(
+                                "* 1 FETCH (UID 1 BODY[]<0> {{0}}\r\n)\r\n{tag} OK snippet\r\n"
+                            )
+                            .as_bytes(),
+                        )
+                        .await
+                        .unwrap();
+                    let tag =
+                        scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"")
+                            .await;
+                    write
+                        .write_all(format!("{identity}{tag} OK selected\r\n").as_bytes())
+                        .await
+                        .unwrap();
+                    let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+                    write
+                        .write_all(format!("{tag} OK logout\r\n").as_bytes())
+                        .await
+                        .unwrap();
+                } else {
+                    write
+                        .write_all(format!("{tag} OK snippet omitted\r\n").as_bytes())
+                        .await
+                        .unwrap();
+                }
+                transcript
+            })
+        };
+
+        let (mut first_client, first_server) = duplex_imap_client_and_server();
+        let first_server = spawn_server(first_server, false);
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut first_client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap_err();
+        first_server.await.unwrap();
+        assert_eq!(
+            store
+                .message_by_locator(account.id, "INBOX", 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Old committed subject"
+        );
+
+        let (mut retry_client, retry_server) = duplex_imap_client_and_server();
+        let retry_server = spawn_server(retry_server, true);
+        service
+            .sync_mailboxes_with_progress_on_client(
+                &mut retry_client,
+                &account,
+                50,
+                vec![MailboxPlan::new("INBOX", "INBOX")],
+                true,
+                |_| {},
+            )
+            .await
+            .unwrap();
+        let retry_transcript = retry_server.await.unwrap();
+        assert!(retry_transcript
+            .iter()
+            .any(|command| command.starts_with("UID FETCH 1 (FLAGS INTERNALDATE ")));
+        assert_eq!(
+            store
+                .message_by_locator(account.id, "INBOX", 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Replacement subject"
         );
     }
 
@@ -8900,6 +13338,8 @@ mod tests {
             mailbox: "INBOX".into(),
             remote_name: "INBOX".into(),
             uid_validity: 1,
+            uid_next: None,
+            highest_modseq: None,
             remote_total: 4,
             historical_complete: false,
         };
@@ -9874,6 +14314,76 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn scripted_imap_idle_rejects_oversized_lines_in_every_protocol_state() {
+        let oversized = vec![b'x'; MAX_IMAP_RESPONSE_TRANSCRIPT_BYTES + 1];
+
+        let (mut continuation_client, continuation_server) = plain_imap_client_and_server().await;
+        let continuation_server = tokio::spawn({
+            let oversized = oversized.clone();
+            async move {
+                let (read, mut write) = continuation_server.into_split();
+                let mut read = BufReader::new(read);
+                let (_, command) = scripted_command(&mut read).await;
+                assert_eq!(command, "IDLE");
+                write.write_all(&oversized).await.unwrap();
+                write.write_all(b"\r\n").await.unwrap();
+            }
+        });
+        let (_cancel, mut active) = watch::channel(false);
+        let error = continuation_client
+            .idle_until_change(&mut active)
+            .await
+            .unwrap_err();
+        continuation_server.await.unwrap();
+        assert!(format!("{error:#}").contains("response line exceeds MIME safety limit"));
+
+        let (mut active_client, active_server) = plain_imap_client_and_server().await;
+        let active_server = tokio::spawn({
+            let oversized = oversized.clone();
+            async move {
+                let (read, mut write) = active_server.into_split();
+                let mut read = BufReader::new(read);
+                let (_, command) = scripted_command(&mut read).await;
+                assert_eq!(command, "IDLE");
+                write.write_all(b"+ idling\r\n").await.unwrap();
+                write.write_all(&oversized).await.unwrap();
+                write.write_all(b"\r\n").await.unwrap();
+            }
+        });
+        let (_cancel, mut active) = watch::channel(false);
+        let error = active_client
+            .idle_until_change(&mut active)
+            .await
+            .unwrap_err();
+        active_server.await.unwrap();
+        assert!(format!("{error:#}").contains("response line exceeds MIME safety limit"));
+
+        let (mut termination_client, termination_server) = plain_imap_client_and_server().await;
+        let termination_server = tokio::spawn(async move {
+            let (read, mut write) = termination_server.into_split();
+            let mut read = BufReader::new(read);
+            let (_, command) = scripted_command(&mut read).await;
+            assert_eq!(command, "IDLE");
+            write
+                .write_all(b"+ idling\r\n* 1 EXISTS\r\n")
+                .await
+                .unwrap();
+            let mut done = String::new();
+            read.read_line(&mut done).await.unwrap();
+            assert_eq!(done, "DONE\r\n");
+            write.write_all(&oversized).await.unwrap();
+            write.write_all(b"\r\n").await.unwrap();
+        });
+        let (_cancel, mut active) = watch::channel(false);
+        let error = termination_client
+            .idle_until_change(&mut active)
+            .await
+            .unwrap_err();
+        termination_server.await.unwrap();
+        assert!(format!("{error:#}").contains("response line exceeds MIME safety limit"));
+    }
+
+    #[tokio::test]
     async fn authentication_distinguishes_rejection_from_retryable_bye() {
         let account = test_account();
 
@@ -10028,18 +14538,15 @@ mod tests {
     #[test]
     fn parses_search() {
         assert_eq!(
-            parse_search_uids(&["* SEARCH 4 8 15\r\n".into()]),
+            parse_search_uids(&["* SEARCH 4 8 15\r\n".into()]).unwrap(),
             vec![4, 8, 15]
         );
-    }
-
-    #[test]
-    fn realtime_snapshot_fetches_only_uids_above_the_watermark() {
-        // Realtime reconciliation searches the complete mailbox so it can
-        // remove archived UIDs. The fetch batch must still contain only new
-        // mail, even when SEARCH ALL returns older UIDs out of order.
-        assert_eq!(sync_uids(vec![12, 7, 11, 10], Some(10), 25), vec![11, 12]);
-        assert_eq!(sync_uids(vec![12, 7, 11, 10], Some(10), 1), vec![11]);
+        assert!(parse_search_uids(&["* sEaRcH\r\n".into()])
+            .unwrap()
+            .is_empty());
+        assert!(parse_search_uids(&["D0001 OK searched\r\n".into()]).is_err());
+        assert!(parse_search_uids(&["* SEARCH 4 broken 15\r\n".into()]).is_err());
+        assert!(parse_search_uids(&["* SEARCH 0\r\n".into()]).is_err());
     }
 
     #[test]
@@ -10055,6 +14562,383 @@ mod tests {
             ]),
             vec![(41, true, false), (42, false, true)]
         );
+    }
+
+    #[test]
+    fn mailbox_snapshot_ranges_are_bounded_and_descend_from_newest_sequences() {
+        assert!(mailbox_snapshot_page_ranges(0).is_empty());
+        assert_eq!(mailbox_snapshot_page_ranges(1), vec![(1, 1)]);
+        assert_eq!(mailbox_snapshot_page_ranges(500), vec![(1, 500)]);
+        assert_eq!(mailbox_snapshot_page_ranges(501), vec![(2, 501), (1, 1)]);
+        assert_eq!(
+            mailbox_snapshot_page_ranges(1_001),
+            vec![(502, 1_001), (2, 501), (1, 1)]
+        );
+        assert!(mailbox_snapshot_page_ranges(30_000)
+            .iter()
+            .all(|(start, end)| end - start + 1 <= MAILBOX_SNAPSHOT_PAGE_SIZE));
+    }
+
+    #[test]
+    fn mailbox_snapshot_page_parses_mixed_case_uid_and_flags_in_either_order() {
+        assert_eq!(
+            parse_mailbox_snapshot_page(
+                &[
+                    "* 9 fEtCh (fLaGs (\\sEeN custom) uId 401)\r\n".into(),
+                    "* 10 FeTcH (UiD 402 FlAgS (\\fLaGgEd))\r\n".into(),
+                ],
+                2,
+            )
+            .unwrap(),
+            vec![
+                MailboxSnapshotItem {
+                    uid: 401,
+                    is_read: true,
+                    is_flagged: false,
+                },
+                MailboxSnapshotItem {
+                    uid: 402,
+                    is_read: false,
+                    is_flagged: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn mailbox_snapshot_page_rejects_incomplete_and_duplicate_uid_sets() {
+        let incomplete =
+            parse_mailbox_snapshot_page(&["* 1 FETCH (UID 41 FLAGS ())\r\n".into()], 2)
+                .unwrap_err();
+        assert!(incomplete.to_string().contains("page was incomplete"));
+
+        let duplicate = parse_mailbox_snapshot_page(
+            &[
+                "* 1 FETCH (UID 41 FLAGS ())\r\n".into(),
+                "* 2 FETCH (FLAGS (\\Seen) UID 41)\r\n".into(),
+            ],
+            2,
+        )
+        .unwrap_err();
+        assert!(duplicate.to_string().contains("repeated UID 41"));
+    }
+
+    #[tokio::test]
+    async fn mailbox_snapshot_range_halves_tagged_rejections_newest_half_first() {
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "FETCH 1:4 (UID FLAGS)").await;
+            write
+                .write_all(format!("{tag} NO range too large\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            for (start, end) in [(3, 4), (1, 2)] {
+                let tag = scripted_expect_command(
+                    &mut read,
+                    &mut transcript,
+                    &format!("FETCH {start}:{end} (UID FLAGS)"),
+                )
+                .await;
+                for uid in start..=end {
+                    write
+                        .write_all(format!("* {uid} FETCH (UID {uid} FLAGS ())\r\n").as_bytes())
+                        .await
+                        .unwrap();
+                }
+                write
+                    .write_all(format!("{tag} OK smaller range\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            transcript
+        });
+
+        let items = fetch_mailbox_snapshot_range(&mut client, 1, 4, None)
+            .await
+            .unwrap();
+        assert_eq!(
+            items.iter().map(|item| item.uid).collect::<Vec<_>>(),
+            vec![3, 4, 1, 2]
+        );
+        assert_eq!(
+            items
+                .iter()
+                .map(|item| item.uid)
+                .collect::<std::collections::HashSet<_>>(),
+            [1, 2, 3, 4].into()
+        );
+        assert_eq!(
+            server.await.unwrap(),
+            vec![
+                "FETCH 1:4 (UID FLAGS)",
+                "FETCH 3:4 (UID FLAGS)",
+                "FETCH 1:2 (UID FLAGS)",
+            ]
+        );
+    }
+
+    #[test]
+    fn metadata_uid_batches_obey_count_and_encoded_command_byte_limits() {
+        let uids = (1..=100).rev().collect::<Vec<_>>();
+        let batches = uid_fetch_command_batches(&uids, "FLAGS BODY.PEEK[HEADER]");
+        assert_eq!(batches.concat(), uids);
+        assert!(batches
+            .iter()
+            .all(|batch| batch.len() <= MAX_METADATA_FETCH_UIDS));
+        for batch in batches {
+            let uid_set = batch
+                .iter()
+                .map(u32::to_string)
+                .collect::<Vec<_>>()
+                .join(",");
+            assert!(
+                format!("UID FETCH {uid_set} (FLAGS BODY.PEEK[HEADER])").len()
+                    <= MAX_IMAP_COMMAND_BYTES
+            );
+        }
+
+        let nearly_full_fields = "X".repeat(MAX_IMAP_COMMAND_BYTES - "UID FETCH  ()".len() - 6);
+        let byte_bounded = uid_fetch_command_batches(&[100_000, 99_999], &nearly_full_fields);
+        assert_eq!(byte_bounded, vec![vec![100_000], vec![99_999]]);
+    }
+
+    #[tokio::test]
+    async fn metadata_batch_rejection_halves_newest_first_and_isolates_each_uid() {
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID FETCH 4,3,2,1 (FLAGS X-GM-LABELS BODY.PEEK[HEADER])",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} NO too many UIDs\r\n").as_bytes())
+                .await
+                .unwrap();
+            for uids in [[4, 3], [2, 1]] {
+                let set = uids
+                    .iter()
+                    .map(u32::to_string)
+                    .collect::<Vec<_>>()
+                    .join(",");
+                let tag = scripted_expect_command(
+                    &mut read,
+                    &mut transcript,
+                    &format!("UID FETCH {set} (FLAGS X-GM-LABELS BODY.PEEK[HEADER])"),
+                )
+                .await;
+                for uid in uids {
+                    let header = format!("Subject: UID {uid}\r\n\r\n");
+                    let flags = if uid == 4 { "\\Seen" } else { "" };
+                    let label = if uid == 3 { "\\\\Inbox" } else { "Other" };
+                    write.write_all(format!("* {uid} FETCH (UID {uid} FLAGS ({flags}) X-GM-LABELS ({label}) BODY[HEADER] {{{}}}\r\n", header.len()).as_bytes()).await.unwrap();
+                    write.write_all(header.as_bytes()).await.unwrap();
+                    write.write_all(b")\r\n").await.unwrap();
+                }
+                write
+                    .write_all(format!("{tag} OK batch\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+            transcript
+        });
+        let mut result = fetch_uid_data_batched(
+            &mut client,
+            &[4, 3, 2, 1],
+            "FLAGS X-GM-LABELS BODY.PEEK[HEADER]",
+            4096,
+        )
+        .await;
+        assert!(result.failures.is_empty());
+        assert!(result.fatal.is_none());
+        assert_eq!(
+            result
+                .responses
+                .iter()
+                .map(|(uid, _)| *uid)
+                .collect::<Vec<_>>(),
+            vec![4, 3, 2, 1]
+        );
+        for (uid, response) in &mut result.responses {
+            assert_eq!(
+                String::from_utf8(response.take_header_literal_for(*uid).unwrap()).unwrap(),
+                format!("Subject: UID {uid}\r\n\r\n")
+            );
+            assert!(response
+                .lines
+                .iter()
+                .filter_map(|line| fetch_uid_from_line(line))
+                .all(|line_uid| line_uid == *uid));
+        }
+        assert!(result.responses[0].1.lines.join("").contains("\\Seen"));
+        assert!(!result.responses[1].1.lines.join("").contains("\\Seen"));
+        assert!(result.responses[1].1.lines.join("").contains("\\\\Inbox"));
+        assert_eq!(
+            server.await.unwrap(),
+            vec![
+                "UID FETCH 4,3,2,1 (FLAGS X-GM-LABELS BODY.PEEK[HEADER])",
+                "UID FETCH 4,3 (FLAGS X-GM-LABELS BODY.PEEK[HEADER])",
+                "UID FETCH 2,1 (FLAGS X-GM-LABELS BODY.PEEK[HEADER])",
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn metadata_batch_keeps_one_missing_uid_isolated_from_successes() {
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID FETCH 3,2,1 (BODY.PEEK[HEADER])",
+            )
+            .await;
+            for uid in [3, 1] {
+                let header = format!("Subject: {uid}\r\n\r\n");
+                write
+                    .write_all(
+                        format!(
+                            "* {uid} FETCH (UID {uid} BODY[HEADER] {{{}}}\r\n",
+                            header.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                write.write_all(header.as_bytes()).await.unwrap();
+                write.write_all(b")\r\n").await.unwrap();
+            }
+            write
+                .write_all(format!("{tag} OK partial\r\n").as_bytes())
+                .await
+                .unwrap();
+        });
+        let mut result =
+            fetch_uid_data_batched(&mut client, &[3, 2, 1], "BODY.PEEK[HEADER]", 4096).await;
+        assert!(result
+            .responses
+            .iter_mut()
+            .find(|(uid, _)| *uid == 3)
+            .unwrap()
+            .1
+            .take_header_literal_for(3)
+            .is_some());
+        assert!(result
+            .responses
+            .iter_mut()
+            .find(|(uid, _)| *uid == 2)
+            .unwrap()
+            .1
+            .take_header_literal_for(2)
+            .is_none());
+        assert!(result
+            .responses
+            .iter_mut()
+            .find(|(uid, _)| *uid == 1)
+            .unwrap()
+            .1
+            .take_header_literal_for(1)
+            .is_some());
+        server.await.unwrap();
+    }
+
+    #[test]
+    fn mailbox_identity_parses_mixed_case_response_codes() {
+        assert_eq!(
+            parse_mailbox_identity(&[
+                "* 42 eXiStS\r\n".into(),
+                "* oK [uIdVaLiDiTy 98765] UIDs valid\r\n".into(),
+                "* OK [uIdNeXt 54321] Predicted next UID\r\n".into(),
+                "* OK [hIgHeStMoDsEq 18446744073709551615] Mod-sequence\r\n".into(),
+            ])
+            .unwrap(),
+            MailboxIdentity {
+                exists: 42,
+                uid_validity: 98_765,
+                uid_next: Some(54_321),
+                highest_modseq: Some(u64::MAX),
+            }
+        );
+    }
+
+    #[test]
+    fn mailbox_identity_rejects_instability_in_each_authoritative_field() {
+        let initial = MailboxIdentity {
+            exists: 42,
+            uid_validity: 77,
+            uid_next: Some(100),
+            highest_modseq: Some(900),
+        };
+        assert!(mailbox_identity_is_stable(&initial, &initial));
+
+        for changed in [
+            MailboxIdentity {
+                exists: 43,
+                ..initial.clone()
+            },
+            MailboxIdentity {
+                uid_validity: 78,
+                ..initial.clone()
+            },
+            MailboxIdentity {
+                uid_next: Some(101),
+                ..initial.clone()
+            },
+            MailboxIdentity {
+                highest_modseq: Some(901),
+                ..initial.clone()
+            },
+        ] {
+            assert!(!mailbox_identity_is_stable(&initial, &changed));
+        }
+
+        assert!(!mailbox_membership_is_stable(
+            &initial,
+            &MailboxIdentity {
+                uid_next: None,
+                highest_modseq: Some(901),
+                ..initial.clone()
+            }
+        ));
+        assert!(mailbox_membership_is_stable(
+            &initial,
+            &MailboxIdentity {
+                highest_modseq: Some(901),
+                ..initial
+            }
+        ));
+    }
+
+    #[test]
+    fn idle_invalidates_for_arrivals_expunges_flag_fetches_and_vanished_uids() {
+        for response in [
+            "* 43 EXISTS\r\n",
+            "* 7 expunge\r\n",
+            "* 8 FeTcH (UID 42 fLaGs (\\Seen))\r\n",
+            "* VANISHED (EARLIER) 4:6\r\n",
+        ] {
+            assert!(is_idle_invalidation(response), "ignored {response:?}");
+        }
+        for response in [
+            "+ idling\r\n",
+            "* 8 FETCH (UID 42 BODY[TEXT] {5}\r\n",
+            "D0001 OK IDLE completed\r\n",
+        ] {
+            assert!(!is_idle_invalidation(response), "misread {response:?}");
+        }
     }
 
     #[test]

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -8,7 +8,10 @@ use crate::{
     },
     oauth::OAuthTokens,
     provider::Security,
-    storage::{stable_message_id, Attachment, AttachmentData, AttachmentPresentation, MailSummary},
+    storage::{
+        stable_message_id, Attachment, AttachmentData, AttachmentPresentation, MailSummary,
+        MailboxChangedSinceFlags, MailboxSnapshotIdentity,
+    },
     Account, AccountAuth, Store,
 };
 use anyhow::{bail, Context, Result};
@@ -442,11 +445,13 @@ impl MailService {
             .begin_mailbox_snapshot(
                 account.id,
                 "INBOX",
-                "INBOX",
-                snapshot_identity.uid_validity,
-                snapshot_identity.exists,
-                snapshot_identity.uid_next,
-                snapshot_identity.highest_modseq,
+                MailboxSnapshotIdentity::new(
+                    "INBOX",
+                    snapshot_identity.uid_validity,
+                    snapshot_identity.exists,
+                    snapshot_identity.uid_next,
+                    snapshot_identity.highest_modseq,
+                ),
             )
             .await?;
         for (start, end) in mailbox_snapshot_page_ranges(snapshot_identity.exists) {
@@ -1179,12 +1184,17 @@ impl MailService {
                             .apply_complete_mailbox_changed_since_flags(
                                 account.id,
                                 &plan.storage,
-                                &plan.remote,
-                                final_identity.uid_validity,
-                                usize::try_from(final_identity.exists)?,
-                                final_identity.uid_next,
-                                final_identity.highest_modseq,
-                                &flags,
+                                MailboxChangedSinceFlags {
+                                    identity: MailboxSnapshotIdentity::new(
+                                        &plan.remote,
+                                        final_identity.uid_validity,
+                                        final_identity.exists,
+                                        final_identity.uid_next,
+                                        final_identity.highest_modseq,
+                                    ),
+                                    remote_total: usize::try_from(final_identity.exists)?,
+                                    flags: &flags,
+                                },
                             )
                             .await?;
                         continue;
@@ -1200,11 +1210,13 @@ impl MailService {
                 .begin_mailbox_snapshot(
                     account.id,
                     &plan.storage,
-                    &plan.remote,
-                    snapshot_identity.uid_validity,
-                    snapshot_identity.exists,
-                    snapshot_identity.uid_next,
-                    snapshot_identity.highest_modseq,
+                    MailboxSnapshotIdentity::new(
+                        &plan.remote,
+                        snapshot_identity.uid_validity,
+                        snapshot_identity.exists,
+                        snapshot_identity.uid_next,
+                        snapshot_identity.highest_modseq,
+                    ),
                 )
                 .await?;
             for (start, end) in mailbox_snapshot_page_ranges(snapshot_identity.exists) {
@@ -5073,7 +5085,7 @@ where
             Err(error)
                 if error.to_string().starts_with("IMAP command failed:") && batch.len() > 1 =>
             {
-                let midpoint = (batch.len() + 1) / 2;
+                let midpoint = batch.len().div_ceil(2);
                 let older = batch[midpoint..].to_vec();
                 let newer = batch[..midpoint].to_vec();
                 if !older.is_empty() {
@@ -5457,10 +5469,13 @@ fn verify_mailbox_uid_validity(current: u32, catalogued: i64, action: &str) -> R
 }
 
 fn parse_uid_flags(lines: &[String]) -> Vec<(u32, bool, bool)> {
-    lines.iter().filter_map(parse_uid_flags_line).collect()
+    lines
+        .iter()
+        .filter_map(|line| parse_uid_flags_line(line))
+        .collect()
 }
 
-fn parse_uid_flags_line(line: &String) -> Option<(u32, bool, bool)> {
+fn parse_uid_flags_line(line: &str) -> Option<(u32, bool, bool)> {
     if !is_untagged_fetch_start(line) {
         return None;
     }
@@ -7486,7 +7501,11 @@ mod tests {
             .await
             .unwrap();
         let generation = store
-            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 77, 2, Some(3), Some(100))
+            .begin_mailbox_snapshot(
+                account.id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 77, 2, Some(3), Some(100)),
+            )
             .await
             .unwrap();
         store
@@ -9680,7 +9699,11 @@ mod tests {
         old.subject = "Old namespace subject".into();
         store.upsert_catalog_messages(&[old]).await.unwrap();
         let old_generation = store
-            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 10, 1, Some(2), None)
+            .begin_mailbox_snapshot(
+                account.id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 10, 1, Some(2), None),
+            )
             .await
             .unwrap();
         store
@@ -9781,11 +9804,13 @@ mod tests {
             .begin_mailbox_snapshot(
                 account.id,
                 "INBOX",
-                "INBOX",
-                10,
-                REMOTE_COUNT,
-                Some(REMOTE_COUNT + 1),
-                None,
+                MailboxSnapshotIdentity::new(
+                    "INBOX",
+                    10,
+                    REMOTE_COUNT,
+                    Some(REMOTE_COUNT + 1),
+                    None,
+                ),
             )
             .await
             .unwrap();
@@ -9921,7 +9946,11 @@ mod tests {
             .collect::<Vec<_>>();
         store.upsert_catalog_messages(&old_messages).await.unwrap();
         let old_generation = store
-            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 10, 3, Some(4), None)
+            .begin_mailbox_snapshot(
+                account.id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 10, 3, Some(4), None),
+            )
             .await
             .unwrap();
         store
@@ -9992,7 +10021,11 @@ mod tests {
             .unwrap_err();
         first_server.await.unwrap();
         let resumed_generation = store
-            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 11, 3, Some(4), None)
+            .begin_mailbox_snapshot(
+                account.id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 11, 3, Some(4), None),
+            )
             .await
             .unwrap();
         store
@@ -10057,7 +10090,11 @@ mod tests {
             .collect::<Vec<_>>();
         store.upsert_catalog_messages(&old_messages).await.unwrap();
         let old_generation = store
-            .begin_mailbox_snapshot(account.id, "INBOX", "INBOX", 10, 2, Some(3), None)
+            .begin_mailbox_snapshot(
+                account.id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 10, 2, Some(3), None),
+            )
             .await
             .unwrap();
         store
@@ -14576,7 +14613,7 @@ mod tests {
         );
         assert!(mailbox_snapshot_page_ranges(30_000)
             .iter()
-            .all(|(start, end)| end - start + 1 <= MAILBOX_SNAPSHOT_PAGE_SIZE));
+            .all(|(start, end)| end - start < MAILBOX_SNAPSHOT_PAGE_SIZE));
     }
 
     #[test]

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -85,6 +85,47 @@ enum SnapshotReplacementPublication<'a> {
     Staged,
 }
 
+/// The remote identity captured when a full mailbox inventory begins.
+///
+/// Grouping these values keeps the start and resume contract explicit: all
+/// fields must describe the same selected mailbox response.
+#[derive(Clone, Copy)]
+pub struct MailboxSnapshotIdentity<'a> {
+    pub remote_name: &'a str,
+    pub uid_validity: u32,
+    pub initial_exists: u32,
+    pub uid_next: Option<u32>,
+    pub highest_modseq: Option<u64>,
+}
+
+impl<'a> MailboxSnapshotIdentity<'a> {
+    pub const fn new(
+        remote_name: &'a str,
+        uid_validity: u32,
+        initial_exists: u32,
+        uid_next: Option<u32>,
+        highest_modseq: Option<u64>,
+    ) -> Self {
+        Self {
+            remote_name,
+            uid_validity,
+            initial_exists,
+            uid_next,
+            highest_modseq,
+        }
+    }
+}
+
+/// One complete CONDSTORE `CHANGEDSINCE` result and the mailbox state that
+/// made it valid.
+pub struct MailboxChangedSinceFlags<'a> {
+    pub identity: MailboxSnapshotIdentity<'a>,
+    pub remote_total: usize,
+    pub flags: &'a [(u32, bool, bool)],
+}
+
+type MailboxSnapshotGenerationState = (String, i64, i64, Option<i64>, Option<String>);
+
 /// Cancellation-safe ownership of one provider body fetch. Dropping the
 /// owning future schedules claim release so later readers do not wait for a
 /// process restart.
@@ -2093,8 +2134,7 @@ impl Store {
         } else {
             format!(
                 " AND mailbox NOT IN ({})",
-                std::iter::repeat("?")
-                    .take(keep_mailboxes.len())
+                std::iter::repeat_n("?", keep_mailboxes.len())
                     .collect::<Vec<_>>()
                     .join(", ")
             )
@@ -4946,6 +4986,10 @@ pub fn stable_message_id(account_id: AccountId, mailbox: &str, uid: u32) -> Stri
 }
 
 #[cfg(test)]
+// The snapshot implementation is intentionally kept beside the feature's
+// storage helpers below this long-standing test module. Keep this narrowly
+// scoped until the module is split into its own test file.
+#[allow(clippy::items_after_test_module)]
 mod tests {
     use super::*;
 
@@ -10335,7 +10379,11 @@ mod tests {
                 .uid_validity_changed
         );
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 3, Some(4), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 11, 3, Some(4), None),
+            )
             .await
             .unwrap();
         store
@@ -10466,7 +10514,11 @@ mod tests {
         let account_id = uuid::Uuid::new_v4();
         save_test_account(&store, account_id).await;
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 10, 51, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 10, 51, None, None),
+            )
             .await
             .unwrap();
         let flags: Vec<(u32, bool, bool)> = (100..=150).map(|uid| (uid, false, false)).collect();
@@ -10502,7 +10554,11 @@ mod tests {
             .unwrap();
 
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 250, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 11, 250, None, None),
+            )
             .await
             .unwrap();
         let mut replacements = Vec::new();
@@ -10542,7 +10598,11 @@ mod tests {
         );
 
         let empty_generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 12, 1, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 12, 1, None, None),
+            )
             .await
             .unwrap();
         store
@@ -10593,7 +10653,11 @@ mod tests {
             .await
             .unwrap();
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 11, 1, None, None),
+            )
             .await
             .unwrap();
         store
@@ -10650,11 +10714,7 @@ mod tests {
             .begin_mailbox_snapshot(
                 account_id,
                 "[Gmail]/All Mail",
-                "[Gmail]/All Mail",
-                7,
-                99_003,
-                Some(99_004),
-                None,
+                MailboxSnapshotIdentity::new("[Gmail]/All Mail", 7, 99_003, Some(99_004), None),
             )
             .await
             .unwrap();
@@ -10699,11 +10759,7 @@ mod tests {
             .begin_mailbox_snapshot(
                 account_id,
                 "[Gmail]/All Mail",
-                "[Gmail]/All Mail",
-                7,
-                99_003,
-                Some(99_004),
-                Some(42),
+                MailboxSnapshotIdentity::new("[Gmail]/All Mail", 7, 99_003, Some(99_004), Some(42)),
             )
             .await
             .unwrap();
@@ -10741,7 +10797,11 @@ mod tests {
         let account_id = uuid::Uuid::new_v4();
         save_test_account(&store, account_id).await;
         let first = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 2, Some(3), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 7, 2, Some(3), None),
+            )
             .await
             .unwrap();
         store
@@ -10750,7 +10810,11 @@ mod tests {
             .unwrap();
 
         let replacement = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 2, Some(4), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 7, 2, Some(4), None),
+            )
             .await
             .unwrap();
         assert_ne!(replacement, first);
@@ -10787,7 +10851,11 @@ mod tests {
             .await
             .unwrap();
         let generation = store
-            .begin_mailbox_snapshot(account_id, "Sent", "Sent", 5, 1, Some(5), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "Sent",
+                MailboxSnapshotIdentity::new("Sent", 5, 1, Some(5), None),
+            )
             .await
             .unwrap();
         store
@@ -10855,7 +10923,11 @@ mod tests {
             .await
             .unwrap();
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, Some(8), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 11, 1, Some(8), None),
+            )
             .await
             .unwrap();
         store
@@ -10920,7 +10992,11 @@ mod tests {
             .unwrap();
 
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 77, 2, Some(3), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 77, 2, Some(3), None),
+            )
             .await
             .unwrap();
         store
@@ -10967,11 +11043,7 @@ mod tests {
             .begin_mailbox_snapshot(
                 account_id,
                 "INBOX",
-                "Remote Inbox",
-                88,
-                1,
-                Some(3),
-                Some(u64::MAX),
+                MailboxSnapshotIdentity::new("Remote Inbox", 88, 1, Some(3), Some(u64::MAX)),
             )
             .await
             .unwrap();
@@ -11062,7 +11134,11 @@ mod tests {
         assert_eq!(pending_tombstones, 1);
 
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, Some(3), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 11, 1, Some(3), None),
+            )
             .await
             .unwrap();
         store
@@ -11110,12 +11186,17 @@ mod tests {
             .apply_complete_mailbox_changed_since_flags(
                 account_id,
                 "INBOX",
-                "Remote Inbox",
-                77,
-                2,
-                Some(3),
-                Some(u64::MAX),
-                &[(1, true, true)],
+                MailboxChangedSinceFlags {
+                    identity: MailboxSnapshotIdentity::new(
+                        "Remote Inbox",
+                        77,
+                        2,
+                        Some(3),
+                        Some(u64::MAX),
+                    ),
+                    remote_total: 2,
+                    flags: &[(1, true, true)],
+                },
             )
             .await
             .unwrap();
@@ -11159,12 +11240,11 @@ mod tests {
             .apply_complete_mailbox_changed_since_flags(
                 account_id,
                 "INBOX",
-                "INBOX",
-                77,
-                0,
-                None,
-                None,
-                &[],
+                MailboxChangedSinceFlags {
+                    identity: MailboxSnapshotIdentity::new("INBOX", 77, 0, None, None),
+                    remote_total: 0,
+                    flags: &[],
+                },
             )
             .await
             .unwrap();
@@ -11212,7 +11292,11 @@ mod tests {
         let account_id = uuid::Uuid::new_v4();
         save_test_account(&store, account_id).await;
         let inbox_first = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 2, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 7, 2, None, None),
+            )
             .await
             .unwrap();
         store
@@ -11220,7 +11304,11 @@ mod tests {
             .await
             .unwrap();
         let archive = store
-            .begin_mailbox_snapshot(account_id, "Archive", "Archive", 8, 1, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "Archive",
+                MailboxSnapshotIdentity::new("Archive", 8, 1, None, None),
+            )
             .await
             .unwrap();
         store
@@ -11229,7 +11317,11 @@ mod tests {
             .unwrap();
 
         let inbox_replacement = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 3, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 7, 3, None, None),
+            )
             .await
             .unwrap();
         assert!(store
@@ -11267,7 +11359,11 @@ mod tests {
             .unwrap();
 
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 99, 0, Some(1), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 99, 0, Some(1), None),
+            )
             .await
             .unwrap();
         assert_eq!(
@@ -11419,7 +11515,11 @@ mod tests {
         let account_id = uuid::Uuid::new_v4();
         save_test_account(&store, account_id).await;
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 9, 2, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 9, 2, None, None),
+            )
             .await
             .unwrap();
         store
@@ -11444,7 +11544,11 @@ mod tests {
             .unwrap();
 
         let resumed = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 9, 2, None, None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 9, 2, None, None),
+            )
             .await
             .unwrap();
         assert_eq!(resumed, generation);
@@ -11498,7 +11602,11 @@ mod tests {
             .await
             .unwrap();
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, Some(2), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 11, 1, Some(2), None),
+            )
             .await
             .unwrap();
         store
@@ -11543,7 +11651,11 @@ mod tests {
         let account_id = uuid::Uuid::new_v4();
         save_test_account(&store, account_id).await;
         let generation = store
-            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 1, 2, Some(3), None)
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                MailboxSnapshotIdentity::new("INBOX", 1, 2, Some(3), None),
+            )
             .await
             .unwrap();
         store
@@ -11604,7 +11716,11 @@ mod tests {
         }
         for (mailbox, uid) in [("Sent::A", 3), ("Sent::B", 4)] {
             let generation = store
-                .begin_mailbox_snapshot(account_id, mailbox, mailbox, 5, 1, Some(5), None)
+                .begin_mailbox_snapshot(
+                    account_id,
+                    mailbox,
+                    MailboxSnapshotIdentity::new(mailbox, 5, 1, Some(5), None),
+                )
                 .await
                 .unwrap();
             store
@@ -11959,12 +12075,15 @@ impl Store {
         &self,
         account_id: AccountId,
         mailbox: &str,
-        remote_name: &str,
-        uid_validity: u32,
-        initial_exists: u32,
-        uid_next: Option<u32>,
-        highest_modseq: Option<u64>,
+        identity: MailboxSnapshotIdentity<'_>,
     ) -> Result<String> {
+        let MailboxSnapshotIdentity {
+            remote_name,
+            uid_validity,
+            initial_exists,
+            uid_next,
+            highest_modseq,
+        } = identity;
         let account_id = account_id.to_string();
         let generation = uuid::Uuid::new_v4().to_string();
         let uid_next = uid_next.map(i64::from);
@@ -12487,7 +12606,7 @@ impl Store {
             tx.rollback().await?;
             return Err(anyhow!("account was removed"));
         }
-        let generation_state: Option<(String, i64, i64, Option<i64>, Option<String>)> = sqlx::query_as(
+        let generation_state: Option<MailboxSnapshotGenerationState> = sqlx::query_as(
             "SELECT remote_name, uid_validity, initial_exists, uid_next, highest_modseq FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?",
         )
         .bind(&account_id)
@@ -12791,13 +12910,20 @@ impl Store {
         &self,
         account_id: AccountId,
         mailbox: &str,
-        remote_name: &str,
-        uid_validity: u32,
-        remote_total: usize,
-        uid_next: Option<u32>,
-        highest_modseq: Option<u64>,
-        flags: &[(u32, bool, bool)],
+        changed_since: MailboxChangedSinceFlags<'_>,
     ) -> Result<()> {
+        let MailboxChangedSinceFlags {
+            identity:
+                MailboxSnapshotIdentity {
+                    remote_name,
+                    uid_validity,
+                    uid_next,
+                    highest_modseq,
+                    ..
+                },
+            remote_total,
+            flags,
+        } = changed_since;
         if flags.iter().any(|(uid, _, _)| *uid == 0) {
             return Err(anyhow!("CHANGEDSINCE flag delta contains UID 0"));
         }

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -54,6 +54,7 @@ const CLASSIFICATION_REVISION_ACTIVITY_SECONDS: i64 = 90;
 /// short grace period beyond that before a crashed process's lease may be
 /// replaced, while preserving fresh claims across concurrently open processes.
 const MESSAGE_CONTENT_FETCH_LEASE_SECONDS: i64 = 90;
+const MAILBOX_SNAPSHOT_REPLACEMENT_PUBLISH_BATCH_SIZE: i64 = 100;
 /// All stores opened by this process share a fetch-claim owner. This lets a
 /// second connection respect work already in flight, while a new process can
 /// discard claims left by the previous process during migration.
@@ -69,6 +70,19 @@ fn message_content_fetch_owner() -> &'static str {
 pub struct Store {
     pool: SqlitePool,
     vault_key: Arc<[u8; VAULT_KEY_LEN]>,
+}
+
+#[derive(Clone, Copy)]
+enum SnapshotFinalizeWatermark {
+    StagedMaximum,
+    Explicit(Option<u32>),
+}
+
+#[derive(Clone, Copy)]
+enum SnapshotReplacementPublication<'a> {
+    None,
+    InMemory(&'a [MailSummary]),
+    Staged,
 }
 
 /// Cancellation-safe ownership of one provider body fetch. Dropping the
@@ -130,6 +144,7 @@ pub struct MailRebuildJob {
     pub phase: String,
     pub completed: usize,
     pub total: Option<usize>,
+    pub reset_before_sync: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, FromRow)]
@@ -191,6 +206,9 @@ pub struct MailboxSyncState {
     pub initialized: bool,
     pub highest_uid: Option<u32>,
     pub uid_validity: Option<u64>,
+    /// The selected mailbox is a new UID namespace and needs a replacement
+    /// catalogue, not an incremental UID sync.
+    pub uid_validity_changed: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -261,6 +279,45 @@ pub struct MailboxCatalogState {
     pub uid_validity: i64,
     pub remote_total: i64,
     pub historical_complete: bool,
+    /// The provider's next UID at the last complete, identity-stable sync.
+    pub uid_next: Option<i64>,
+    /// Stored as decimal text because IMAP MODSEQ is an unsigned 64-bit value
+    /// while SQLite INTEGER is signed.
+    pub highest_modseq: Option<String>,
+}
+
+/// A durable, generation-scoped inventory of the UIDs and flags observed
+/// while reconciling one IMAP mailbox. A generation remains non-authoritative
+/// until [`Store::finalize_mailbox_snapshot`] succeeds.
+///
+/// The provider's message metadata is still published through the ordinary
+/// catalogue path. Keeping the inventory separate means an interrupted page
+/// fetch can never make an incomplete UID list look like an empty mailbox.
+#[derive(Debug, Clone, FromRow)]
+pub struct MailboxSnapshotGeneration {
+    pub account_id: String,
+    pub mailbox: String,
+    pub generation: String,
+    pub remote_name: String,
+    pub uid_validity: i64,
+    pub initial_exists: i64,
+    pub uid_next: Option<i64>,
+    pub highest_modseq: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// A UID whose catalogue metadata could not be fetched or parsed. These rows
+/// deliberately outlive the current IMAP session so a later high-water mark
+/// cannot silently make the message permanently invisible.
+#[derive(Debug, Clone, FromRow)]
+pub struct MailboxSyncFailure {
+    pub account_id: String,
+    pub mailbox: String,
+    pub uid: i64,
+    pub stage: String,
+    pub error: String,
+    pub updated_at: DateTime<Utc>,
 }
 
 /// Display metadata for an attachment. Bytes stay in the local store and are
@@ -584,8 +641,14 @@ impl Store {
             "CREATE INDEX IF NOT EXISTS message_content_cache_lru ON message_content_cache(last_accessed, message_id)",
             "CREATE TABLE IF NOT EXISTS message_content_fetches (message_id TEXT PRIMARY KEY REFERENCES messages(id) ON DELETE CASCADE ON UPDATE CASCADE, claimed_at TEXT NOT NULL, claim_owner TEXT NOT NULL DEFAULT '')",
             "CREATE TABLE IF NOT EXISTS app_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
-            "CREATE TABLE IF NOT EXISTS mailbox_catalog_state (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, remote_name TEXT NOT NULL, uid_validity INTEGER NOT NULL, remote_total INTEGER NOT NULL DEFAULT 0, historical_complete INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox))",
-            "CREATE TABLE IF NOT EXISTS mail_rebuild_jobs (account_id TEXT PRIMARY KEY, phase TEXT NOT NULL, completed INTEGER NOT NULL DEFAULT 0, total INTEGER, updated_at TEXT NOT NULL)",
+            "CREATE TABLE IF NOT EXISTS mailbox_catalog_state (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, remote_name TEXT NOT NULL, uid_validity INTEGER NOT NULL, remote_total INTEGER NOT NULL DEFAULT 0, historical_complete INTEGER NOT NULL DEFAULT 0, uid_next INTEGER, highest_modseq TEXT, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox))",
+            "CREATE TABLE IF NOT EXISTS mailbox_snapshot_generations (account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE, mailbox TEXT NOT NULL, generation TEXT NOT NULL, remote_name TEXT NOT NULL, uid_validity INTEGER NOT NULL, initial_exists INTEGER NOT NULL, uid_next INTEGER, highest_modseq TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox, generation))",
+            "CREATE TABLE IF NOT EXISTS mailbox_snapshot_items (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, generation TEXT NOT NULL, uid INTEGER NOT NULL, is_read INTEGER NOT NULL, is_flagged INTEGER NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox, generation, uid), FOREIGN KEY(account_id, mailbox, generation) REFERENCES mailbox_snapshot_generations(account_id, mailbox, generation) ON DELETE CASCADE)",
+            "CREATE TABLE IF NOT EXISTS mailbox_snapshot_messages (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, generation TEXT NOT NULL, uid INTEGER NOT NULL, message_json TEXT NOT NULL, created_at TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox, generation, uid), FOREIGN KEY(account_id, mailbox, generation) REFERENCES mailbox_snapshot_generations(account_id, mailbox, generation) ON DELETE CASCADE)",
+            "CREATE TABLE IF NOT EXISTS mailbox_snapshot_replacement_outcomes (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, generation TEXT NOT NULL, uid INTEGER NOT NULL, outcome TEXT NOT NULL CHECK(outcome IN ('message', 'excluded')), created_at TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox, generation, uid), FOREIGN KEY(account_id, mailbox, generation) REFERENCES mailbox_snapshot_generations(account_id, mailbox, generation) ON DELETE CASCADE)",
+            "CREATE INDEX IF NOT EXISTS mailbox_snapshot_items_generation_uid ON mailbox_snapshot_items(account_id, mailbox, generation, uid DESC)",
+            "CREATE TABLE IF NOT EXISTS mailbox_sync_failures (account_id TEXT NOT NULL REFERENCES accounts(id) ON DELETE CASCADE, mailbox TEXT NOT NULL, uid INTEGER NOT NULL, stage TEXT NOT NULL, error TEXT NOT NULL, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox, uid))",
+            "CREATE TABLE IF NOT EXISTS mail_rebuild_jobs (account_id TEXT PRIMARY KEY, phase TEXT NOT NULL, completed INTEGER NOT NULL DEFAULT 0, total INTEGER, reset_before_sync INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL)",
             "CREATE TABLE IF NOT EXISTS deleted_account_tombstones (account_id TEXT PRIMARY KEY, deleted_at TEXT NOT NULL)",
             "CREATE TABLE IF NOT EXISTS sent_correspondents (account_id TEXT NOT NULL, address TEXT NOT NULL COLLATE NOCASE, PRIMARY KEY(account_id, address))",
         ] {
@@ -608,6 +671,23 @@ impl Store {
             .execute(&self.pool)
             .await?;
         }
+        let catalog_columns: Vec<(i64, String, String, i64, Option<String>, i64)> =
+            sqlx::query_as("PRAGMA table_info(mailbox_catalog_state)")
+                .fetch_all(&self.pool)
+                .await?;
+        if !catalog_columns.iter().any(|column| column.1 == "uid_next") {
+            sqlx::query("ALTER TABLE mailbox_catalog_state ADD COLUMN uid_next INTEGER")
+                .execute(&self.pool)
+                .await?;
+        }
+        if !catalog_columns
+            .iter()
+            .any(|column| column.1 == "highest_modseq")
+        {
+            sqlx::query("ALTER TABLE mailbox_catalog_state ADD COLUMN highest_modseq TEXT")
+                .execute(&self.pool)
+                .await?;
+        }
         // A CLI and the desktop can open this database concurrently. Preserve
         // every fresh lease regardless of process owner; only work old enough
         // to have outlived the foreground wait window is safe to discard.
@@ -627,6 +707,11 @@ impl Store {
             "CREATE TRIGGER IF NOT EXISTS mailbox_sync_state_require_account BEFORE INSERT ON mailbox_sync_state WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
             "CREATE TRIGGER IF NOT EXISTS mailbox_action_tombstones_require_account BEFORE INSERT ON mailbox_action_tombstones WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
             "CREATE TRIGGER IF NOT EXISTS mailbox_catalog_state_require_account BEFORE INSERT ON mailbox_catalog_state WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
+            "CREATE TRIGGER IF NOT EXISTS mailbox_snapshot_generations_require_account BEFORE INSERT ON mailbox_snapshot_generations WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
+            "CREATE TRIGGER IF NOT EXISTS mailbox_snapshot_items_require_account BEFORE INSERT ON mailbox_snapshot_items WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
+            "CREATE TRIGGER IF NOT EXISTS mailbox_snapshot_messages_require_account BEFORE INSERT ON mailbox_snapshot_messages WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
+            "CREATE TRIGGER IF NOT EXISTS mailbox_snapshot_replacement_outcomes_require_account BEFORE INSERT ON mailbox_snapshot_replacement_outcomes WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
+            "CREATE TRIGGER IF NOT EXISTS mailbox_sync_failures_require_account BEFORE INSERT ON mailbox_sync_failures WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
             "CREATE TRIGGER IF NOT EXISTS mail_rebuild_jobs_require_account BEFORE INSERT ON mail_rebuild_jobs WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
             "CREATE TRIGGER IF NOT EXISTS sent_correspondents_require_account BEFORE INSERT ON sent_correspondents WHEN EXISTS (SELECT 1 FROM deleted_account_tombstones WHERE account_id = NEW.account_id) BEGIN SELECT RAISE(ABORT, 'account was removed'); END",
         ] {
@@ -651,6 +736,20 @@ impl Store {
         if !columns.iter().any(|column| column.1 == "content_state") {
             sqlx::query(
                 "ALTER TABLE messages ADD COLUMN content_state TEXT NOT NULL DEFAULT 'complete'",
+            )
+            .execute(&self.pool)
+            .await?;
+        }
+        let rebuild_job_columns: Vec<(i64, String, String, i64, Option<String>, i64)> =
+            sqlx::query_as("PRAGMA table_info(mail_rebuild_jobs)")
+                .fetch_all(&self.pool)
+                .await?;
+        if !rebuild_job_columns
+            .iter()
+            .any(|column| column.1 == "reset_before_sync")
+        {
+            sqlx::query(
+                "ALTER TABLE mail_rebuild_jobs ADD COLUMN reset_before_sync INTEGER NOT NULL DEFAULT 0",
             )
             .execute(&self.pool)
             .await?;
@@ -1026,6 +1125,8 @@ impl Store {
                  SELECT account_id FROM messages \
                  UNION SELECT account_id FROM mailbox_sync_state \
                  UNION SELECT account_id FROM mailbox_catalog_state \
+                 UNION SELECT account_id FROM mailbox_snapshot_generations \
+                 UNION SELECT account_id FROM mailbox_sync_failures \
                  UNION SELECT account_id FROM mailbox_action_tombstones \
                  UNION SELECT account_id FROM mail_rebuild_jobs \
                  UNION SELECT account_id FROM sent_correspondents \
@@ -1045,6 +1146,8 @@ impl Store {
             "DELETE FROM messages WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = messages.account_id)",
             "DELETE FROM mailbox_sync_state WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mailbox_sync_state.account_id)",
             "DELETE FROM mailbox_catalog_state WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mailbox_catalog_state.account_id)",
+            "DELETE FROM mailbox_snapshot_generations WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mailbox_snapshot_generations.account_id)",
+            "DELETE FROM mailbox_sync_failures WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mailbox_sync_failures.account_id)",
             "DELETE FROM mailbox_action_tombstones WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mailbox_action_tombstones.account_id)",
             "DELETE FROM mail_rebuild_jobs WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = mail_rebuild_jobs.account_id)",
             "DELETE FROM sent_correspondents WHERE NOT EXISTS (SELECT 1 FROM accounts WHERE accounts.id = sent_correspondents.account_id)",
@@ -1329,23 +1432,68 @@ impl Store {
 
     pub async fn save_account(&self, account: &Account) -> Result<()> {
         let mut tx = self.pool.begin().await?;
-        let deleted: bool = sqlx::query_scalar(
-            "SELECT EXISTS(SELECT 1 FROM deleted_account_tombstones WHERE account_id = ?)",
-        )
-        .bind(account.id.to_string())
-        .fetch_one(&mut *tx)
-        .await?;
-        if deleted {
-            tx.rollback().await?;
-            return Err(anyhow!("account was removed"));
+        save_account_in_transaction(&mut tx, account).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Persists an account and its reset-required rebuild job as one commit.
+    /// This is used when a provider identity changes: callers cannot publish
+    /// the new account data before durable replacement intent exists.
+    pub async fn save_account_with_reset_mail_rebuild_job(
+        &self,
+        account: &Account,
+        job: &MailRebuildJob,
+    ) -> Result<()> {
+        if job.account_id != account.id {
+            return Err(anyhow!("mail rebuild job belongs to a different account"));
         }
-        sqlx::query("INSERT INTO accounts(id, email, data, created_at) VALUES (?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET email=excluded.email, data=excluded.data")
-            .bind(account.id.to_string())
-            .bind(&account.email)
-            .bind(serde_json::to_string(account)?)
-            .bind(account.created_at)
-            .execute(&mut *tx)
-            .await?;
+        if !job.reset_before_sync {
+            return Err(anyhow!(
+                "identity replacement requires a reset-before-sync rebuild job"
+            ));
+        }
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        save_account_in_transaction(&mut tx, account).await?;
+        save_mail_rebuild_job_in_transaction(&mut tx, job).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Commits a changed account identity, durable reset intent, and removal
+    /// of its superseded credential key together. The replacement credential
+    /// is deliberately written before this boundary, under
+    /// `current_secret_name`; rejecting equal names makes it impossible for
+    /// this cleanup to erase that newly written key.
+    pub async fn save_account_with_reset_mail_rebuild_job_and_delete_previous_secret(
+        &self,
+        account: &Account,
+        job: &MailRebuildJob,
+        previous_secret_name: Option<&str>,
+        current_secret_name: &str,
+    ) -> Result<()> {
+        if job.account_id != account.id {
+            return Err(anyhow!("mail rebuild job belongs to a different account"));
+        }
+        if !job.reset_before_sync {
+            return Err(anyhow!(
+                "identity replacement requires a reset-before-sync rebuild job"
+            ));
+        }
+        if previous_secret_name.is_some_and(|name| name == current_secret_name) {
+            return Err(anyhow!(
+                "previous credential key must differ from the current credential key"
+            ));
+        }
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        save_account_in_transaction(&mut tx, account).await?;
+        save_mail_rebuild_job_in_transaction(&mut tx, job).await?;
+        if let Some(previous_secret_name) = previous_secret_name {
+            sqlx::query("DELETE FROM credentials WHERE name = ?")
+                .bind(previous_secret_name)
+                .execute(&mut *tx)
+                .await?;
+        }
         tx.commit().await?;
         Ok(())
     }
@@ -1368,34 +1516,28 @@ impl Store {
     }
 
     pub async fn mail_rebuild_jobs(&self) -> Result<Vec<MailRebuildJob>> {
-        let rows: Vec<(String, String, i64, Option<i64>)> = sqlx::query_as(
-            "SELECT account_id, phase, completed, total FROM mail_rebuild_jobs ORDER BY updated_at",
+        let rows: Vec<(String, String, i64, Option<i64>, bool)> = sqlx::query_as(
+            "SELECT account_id, phase, completed, total, reset_before_sync FROM mail_rebuild_jobs ORDER BY updated_at",
         )
         .fetch_all(&self.pool)
         .await?;
         rows.into_iter()
-            .map(|(account_id, phase, completed, total)| {
+            .map(|(account_id, phase, completed, total, reset_before_sync)| {
                 Ok(MailRebuildJob {
                     account_id: AccountId::parse_str(&account_id)?,
                     phase,
                     completed: usize::try_from(completed)?,
                     total: total.map(usize::try_from).transpose()?,
+                    reset_before_sync,
                 })
             })
             .collect()
     }
 
     pub async fn save_mail_rebuild_job(&self, job: &MailRebuildJob) -> Result<()> {
-        sqlx::query(
-            "INSERT INTO mail_rebuild_jobs(account_id, phase, completed, total, updated_at) VALUES (?, ?, ?, ?, ?) ON CONFLICT(account_id) DO UPDATE SET phase=excluded.phase, completed=excluded.completed, total=excluded.total, updated_at=excluded.updated_at",
-        )
-        .bind(job.account_id.to_string())
-        .bind(&job.phase)
-        .bind(i64::try_from(job.completed)?)
-        .bind(job.total.map(i64::try_from).transpose()?)
-        .bind(Utc::now())
-        .execute(&self.pool)
-        .await?;
+        let mut tx = self.pool.begin().await?;
+        save_mail_rebuild_job_in_transaction(&mut tx, job).await?;
+        tx.commit().await?;
         Ok(())
     }
 
@@ -1419,6 +1561,14 @@ impl Store {
             .execute(&mut *tx)
             .await?;
         sqlx::query("DELETE FROM mailbox_catalog_state WHERE account_id = ?")
+            .bind(id.to_string())
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM mailbox_snapshot_generations WHERE account_id = ?")
+            .bind(id.to_string())
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM mailbox_sync_failures WHERE account_id = ?")
             .bind(id.to_string())
             .execute(&mut *tx)
             .await?;
@@ -1457,6 +1607,8 @@ impl Store {
             "DELETE FROM starred_message_bodies WHERE message_id IN (SELECT id FROM messages WHERE account_id = ?)",
             "DELETE FROM attachments WHERE message_id IN (SELECT id FROM messages WHERE account_id = ?)",
             "DELETE FROM mailbox_catalog_state WHERE account_id = ?",
+            "DELETE FROM mailbox_snapshot_generations WHERE account_id = ?",
+            "DELETE FROM mailbox_sync_failures WHERE account_id = ?",
             "DELETE FROM mailbox_sync_state WHERE account_id = ?",
             "DELETE FROM mailbox_action_tombstones WHERE account_id = ?",
             "DELETE FROM sent_correspondents WHERE account_id = ?",
@@ -1490,6 +1642,25 @@ impl Store {
         for message in messages {
             persist_message(&mut tx, message).await?;
         }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Publishes catalogue metadata from a replacement UIDVALIDITY namespace.
+    ///
+    /// A UID is only unique within one UIDVALIDITY value. Generic catalogue
+    /// writes intentionally preserve complete local content when a headers-
+    /// only refresh collides with an existing UID, but that policy would leak
+    /// the old namespace's snippet, body, classification, and attachment
+    /// state into a recycled UID. Replacement publication therefore removes
+    /// the exact old locator and all of its dependents before inserting the
+    /// new provider row.
+    pub async fn replace_uidvalidity_catalog_messages(
+        &self,
+        messages: &[MailSummary],
+    ) -> Result<()> {
+        let mut tx = self.pool.begin().await?;
+        replace_uidvalidity_catalog_messages_in_transaction(&mut tx, messages).await?;
         tx.commit().await?;
         Ok(())
     }
@@ -1569,6 +1740,27 @@ impl Store {
         mailbox: &str,
         messages: &[MailSummary],
     ) -> Result<Vec<MailSummary>> {
+        let watermark = messages
+            .iter()
+            .map(|message| u32::try_from(message.uid).context("message UID is invalid"))
+            .collect::<Result<Vec<_>>>()?
+            .into_iter()
+            .max();
+        self.save_synced_messages_through(account_id, mailbox, messages, watermark)
+            .await
+    }
+
+    /// Stores a realtime batch while advancing only through the caller's
+    /// highest contiguous successful UID. A higher message may be committed
+    /// for immediate display without making an earlier failed UID invisible
+    /// to the next retry.
+    pub async fn save_synced_messages_through(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        messages: &[MailSummary],
+        watermark: Option<u32>,
+    ) -> Result<Vec<MailSummary>> {
         let account_id = account_id.to_string();
         if messages
             .iter()
@@ -1624,12 +1816,11 @@ impl Store {
         for message in messages {
             persist_message(&mut tx, message).await?;
         }
-        let highest_uid = messages.iter().map(|message| message.uid).max();
         sqlx::query("INSERT INTO mailbox_sync_state(account_id, mailbox, initialized_at, highest_uid) VALUES (?, ?, ?, ?) ON CONFLICT(account_id, mailbox) DO UPDATE SET initialized_at=excluded.initialized_at, highest_uid=MAX(COALESCE(mailbox_sync_state.highest_uid, 0), COALESCE(excluded.highest_uid, 0))")
             .bind(&account_id)
             .bind(mailbox)
             .bind(Utc::now())
-            .bind(highest_uid)
+            .bind(watermark.map(i64::from))
             .execute(&mut *tx)
             .await?;
         tx.commit().await?;
@@ -1677,22 +1868,6 @@ impl Store {
                 .await?;
         uid.map(|uid| u32::try_from(uid).context("stored message UID is invalid"))
             .transpose()
-    }
-
-    pub(crate) async fn advance_mailbox_sync_watermark(
-        &self,
-        account_id: AccountId,
-        mailbox: &str,
-        uid: u32,
-    ) -> Result<()> {
-        sqlx::query("INSERT INTO mailbox_sync_state(account_id, mailbox, initialized_at, highest_uid) VALUES (?, ?, ?, ?) ON CONFLICT(account_id, mailbox) DO UPDATE SET initialized_at=excluded.initialized_at, highest_uid=MAX(COALESCE(mailbox_sync_state.highest_uid, 0), excluded.highest_uid)")
-            .bind(account_id.to_string())
-            .bind(mailbox)
-            .bind(Utc::now())
-            .bind(i64::from(uid))
-            .execute(&self.pool)
-            .await?;
-        Ok(())
     }
 
     pub async fn mailbox_uids(&self, account_id: AccountId, mailbox: &str) -> Result<HashSet<u32>> {
@@ -1788,7 +1963,7 @@ impl Store {
         mailbox: &str,
     ) -> Result<Option<MailboxCatalogState>> {
         Ok(sqlx::query_as::<_, MailboxCatalogState>(
-            "SELECT account_id, mailbox, remote_name, uid_validity, remote_total, historical_complete FROM mailbox_catalog_state WHERE account_id = ? AND mailbox = ?",
+            "SELECT account_id, mailbox, remote_name, uid_validity, remote_total, historical_complete, uid_next, highest_modseq FROM mailbox_catalog_state WHERE account_id = ? AND mailbox = ?",
         )
         .bind(account_id.to_string())
         .bind(mailbox)
@@ -1805,7 +1980,7 @@ impl Store {
         remote_total: usize,
         historical_complete: bool,
     ) -> Result<()> {
-        sqlx::query("INSERT INTO mailbox_catalog_state(account_id, mailbox, remote_name, uid_validity, remote_total, historical_complete, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox) DO UPDATE SET remote_name=excluded.remote_name, uid_validity=excluded.uid_validity, remote_total=excluded.remote_total, historical_complete=excluded.historical_complete, updated_at=excluded.updated_at")
+        sqlx::query("INSERT INTO mailbox_catalog_state(account_id, mailbox, remote_name, uid_validity, remote_total, historical_complete, uid_next, highest_modseq, updated_at) VALUES (?, ?, ?, ?, ?, ?, NULL, NULL, ?) ON CONFLICT(account_id, mailbox) DO UPDATE SET remote_name=excluded.remote_name, uid_validity=excluded.uid_validity, remote_total=excluded.remote_total, historical_complete=excluded.historical_complete, updated_at=excluded.updated_at")
             .bind(account_id.to_string())
             .bind(mailbox)
             .bind(remote_name)
@@ -1830,6 +2005,13 @@ impl Store {
             .bind(mailbox)
             .execute(&mut *tx)
             .await?;
+        sqlx::query(
+            "DELETE FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ?",
+        )
+        .bind(account_id.to_string())
+        .bind(mailbox)
+        .execute(&mut *tx)
+        .await?;
         sqlx::query("DELETE FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = ?")
             .bind(account_id.to_string())
             .bind(mailbox)
@@ -1841,9 +2023,130 @@ impl Store {
         Ok(())
     }
 
+    /// Removes a mailbox namespace only after the provider has authoritatively
+    /// reported it nonexistent. This is transactional so a provider mapping
+    /// reset cannot leave old Sent, Archive, Spam, or cache rows visible.
+    pub async fn clear_nonexistent_mailbox_namespace(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+    ) -> Result<()> {
+        let account_id = account_id.to_string();
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        for table in [
+            "message_content_fetches",
+            "message_content_cache",
+            "starred_attachment_metadata",
+            "starred_message_bodies",
+            "attachments",
+        ] {
+            let statement = format!("DELETE FROM {table} WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ?)");
+            sqlx::query(&statement)
+                .bind(&account_id)
+                .bind(mailbox)
+                .execute(&mut *tx)
+                .await?;
+        }
+        for statement in [
+            "DELETE FROM messages WHERE account_id = ? AND mailbox = ?",
+            "DELETE FROM mailbox_catalog_state WHERE account_id = ? AND mailbox = ?",
+            "DELETE FROM mailbox_sync_state WHERE account_id = ? AND mailbox = ?",
+            "DELETE FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ?",
+            "DELETE FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ?",
+            "DELETE FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = ?",
+        ] {
+            sqlx::query(statement)
+                .bind(&account_id)
+                .bind(mailbox)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+        self.rebuild_threads_for_account(&account_id).await?;
+        Ok(())
+    }
+
+    /// After every authoritative plan for one special-use family has
+    /// completed, removes family keys which are absent from that plan's keep
+    /// set. A single mailbox finalization deliberately never calls this: a
+    /// provider can expose several valid Sent or Trash siblings at once.
+    /// An empty keep set is an authoritative empty family.
+    pub async fn prune_obsolete_mailbox_family_namespaces(
+        &self,
+        account_id: AccountId,
+        family: &str,
+        keep_mailboxes: &[String],
+    ) -> Result<()> {
+        if family.is_empty() || mailbox_family(family) != family {
+            return Err(anyhow!("mailbox family must be a non-empty root key"));
+        }
+        if keep_mailboxes
+            .iter()
+            .any(|mailbox| mailbox_family(mailbox) != family)
+        {
+            return Err(anyhow!("mailbox keep set contains another family"));
+        }
+        let account_id = account_id.to_string();
+        let descendants = format!("{family}::%");
+        let keep_clause = if keep_mailboxes.is_empty() {
+            String::new()
+        } else {
+            format!(
+                " AND mailbox NOT IN ({})",
+                std::iter::repeat("?")
+                    .take(keep_mailboxes.len())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
+        };
+        let predicate = format!("account_id = ? AND (mailbox = ? OR mailbox LIKE ?){keep_clause}");
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        for table in [
+            "message_content_fetches",
+            "message_content_cache",
+            "starred_attachment_metadata",
+            "starred_message_bodies",
+            "attachments",
+        ] {
+            let statement = format!(
+                "DELETE FROM {table} WHERE message_id IN (SELECT id FROM messages WHERE {predicate})"
+            );
+            let mut query = sqlx::query(&statement)
+                .bind(&account_id)
+                .bind(family)
+                .bind(&descendants);
+            for mailbox in keep_mailboxes {
+                query = query.bind(mailbox);
+            }
+            query.execute(&mut *tx).await?;
+        }
+        for table in [
+            "messages",
+            "mailbox_catalog_state",
+            "mailbox_sync_state",
+            "mailbox_snapshot_generations",
+            "mailbox_sync_failures",
+            "mailbox_action_tombstones",
+        ] {
+            let statement = format!("DELETE FROM {table} WHERE {predicate}");
+            let mut query = sqlx::query(&statement)
+                .bind(&account_id)
+                .bind(family)
+                .bind(&descendants);
+            for mailbox in keep_mailboxes {
+                query = query.bind(mailbox);
+            }
+            query.execute(&mut *tx).await?;
+        }
+        tx.commit().await?;
+        self.rebuild_threads_for_account(&account_id).await?;
+        Ok(())
+    }
+
     /// Reconciles the durable UIDVALIDITY/watermark before incremental sync.
-    /// A changed UIDVALIDITY invalidates only this local mailbox and resets its
-    /// notification baseline so historical mail is never reported as new.
+    /// A changed UIDVALIDITY invalidates only pending incremental work. The
+    /// previous committed sync/catalogue identity survives until replacement
+    /// finalization, so retries and restarts still require a full replacement.
     pub async fn prepare_mailbox_sync(
         &self,
         account_id: AccountId,
@@ -1858,35 +2161,79 @@ impl Store {
         .bind(mailbox)
         .fetch_optional(&self.pool)
         .await?;
-        let changed = row
+        let catalog_uid_validity: Option<i64> = sqlx::query_scalar(
+            "SELECT uid_validity FROM mailbox_catalog_state WHERE account_id = ? AND mailbox = ?",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .fetch_optional(&self.pool)
+        .await?
+        .flatten();
+        let stored_uid_validity = row
             .as_ref()
             .and_then(|(_, _, stored)| *stored)
+            .or(catalog_uid_validity);
+        let changed = stored_uid_validity
             .zip(uid_validity.and_then(|value| i64::try_from(value).ok()))
             .is_some_and(|(stored, current)| stored != current);
         if changed {
             let mut tx = self.pool.begin().await?;
-            sqlx::query("DELETE FROM messages WHERE account_id = ? AND mailbox = ?")
+            // Locators are scoped by UIDVALIDITY. Keep committed metadata
+            // visible until the replacement generation succeeds, but never
+            // let cached bodies or attachment bytes from the old namespace be
+            // served for a recycled UID.
+            for statement in [
+                "DELETE FROM message_content_cache WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ?)",
+                "DELETE FROM starred_message_bodies WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ?)",
+                "DELETE FROM starred_attachment_metadata WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ?)",
+                "DELETE FROM attachments WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ?)",
+            ] {
+                sqlx::query(statement)
+                    .bind(&account_id)
+                    .bind(mailbox)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+            let current_uid_validity = uid_validity.and_then(|value| i64::try_from(value).ok());
+            let replacement_generation_matches = match current_uid_validity {
+                Some(current_uid_validity) => sqlx::query_scalar::<_, bool>(
+                    "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND uid_validity = ?)",
+                )
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(current_uid_validity)
+                .fetch_one(&mut *tx)
+                .await?,
+                None => false,
+            };
+            if !replacement_generation_matches {
+                if let Some(current_uid_validity) = current_uid_validity {
+                    // A snapshot for another namespace is proven stale. Keep a
+                    // matching replacement generation across reconnects.
+                    sqlx::query("DELETE FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND uid_validity != ?")
+                        .bind(&account_id)
+                        .bind(mailbox)
+                        .bind(current_uid_validity)
+                        .execute(&mut *tx)
+                        .await?;
+                }
+                // Failures belong to the previous namespace only until a
+                // replacement generation is active; later retries preserve
+                // its retry queue alongside its staged outcomes.
+                sqlx::query(
+                    "DELETE FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ?",
+                )
                 .bind(&account_id)
                 .bind(mailbox)
                 .execute(&mut *tx)
                 .await?;
-            sqlx::query("DELETE FROM mailbox_sync_state WHERE account_id = ? AND mailbox = ?")
-                .bind(&account_id)
-                .bind(mailbox)
-                .execute(&mut *tx)
-                .await?;
-            sqlx::query(
-                "DELETE FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = ?",
-            )
-            .bind(&account_id)
-            .bind(mailbox)
-            .execute(&mut *tx)
-            .await?;
+            }
             tx.commit().await?;
             return Ok(MailboxSyncState {
                 initialized: false,
                 highest_uid: None,
                 uid_validity,
+                uid_validity_changed: true,
             });
         }
         if let Some(uid_validity) = uid_validity.and_then(|value| i64::try_from(value).ok()) {
@@ -1904,6 +2251,7 @@ impl Store {
                 .and_then(|(_, uid, _)| *uid)
                 .and_then(|uid| u32::try_from(uid).ok()),
             uid_validity,
+            uid_validity_changed: false,
         })
     }
 
@@ -3859,6 +4207,146 @@ async fn persist_message(
     persist_message_with_flag_policy(tx, message, FlagUpdatePolicy::ProviderAuthoritative).await
 }
 
+async fn replace_uidvalidity_catalog_messages_in_transaction(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    messages: &[MailSummary],
+) -> Result<()> {
+    let mut scopes = HashSet::new();
+    for message in messages {
+        scopes.insert((message.account_id.as_str(), message.mailbox.as_str()));
+    }
+    for (account_id, mailbox) in scopes {
+        // A successful UIDVALIDITY replacement starts a new namespace;
+        // tombstones from the old one must not suppress replacement rows.
+        sqlx::query("DELETE FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = ?")
+            .bind(account_id)
+            .bind(mailbox)
+            .execute(&mut **tx)
+            .await?;
+    }
+    for message in messages {
+        for table in [
+            "message_content_fetches",
+            "message_content_cache",
+            "starred_attachment_metadata",
+            "starred_message_bodies",
+            "attachments",
+        ] {
+            let statement = format!("DELETE FROM {table} WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)");
+            sqlx::query(&statement)
+                .bind(&message.account_id)
+                .bind(&message.mailbox)
+                .bind(message.uid)
+                .execute(&mut **tx)
+                .await?;
+        }
+        sqlx::query("DELETE FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?")
+            .bind(&message.account_id)
+            .bind(&message.mailbox)
+            .bind(message.uid)
+            .execute(&mut **tx)
+            .await?;
+        persist_message(tx, message).await?;
+    }
+    Ok(())
+}
+
+async fn clear_uidvalidity_replacement_namespace_in_transaction(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    account_id: &str,
+    mailbox: &str,
+) -> Result<()> {
+    for table in [
+        "message_content_fetches",
+        "message_content_cache",
+        "starred_attachment_metadata",
+        "starred_message_bodies",
+        "attachments",
+    ] {
+        let statement = format!("DELETE FROM {table} WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ?)");
+        sqlx::query(&statement)
+            .bind(account_id)
+            .bind(mailbox)
+            .execute(&mut **tx)
+            .await?;
+    }
+    sqlx::query("DELETE FROM messages WHERE account_id = ? AND mailbox = ?")
+        .bind(account_id)
+        .bind(mailbox)
+        .execute(&mut **tx)
+        .await?;
+    sqlx::query("DELETE FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = ?")
+        .bind(account_id)
+        .bind(mailbox)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+/// Streams one replacement namespace from generation staging. Each query is
+/// keyset-bounded so finalization does not turn a large mailbox rebuild into a
+/// second in-memory catalogue.
+async fn persist_staged_uidvalidity_replacement_messages_in_transaction(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    account_id: &str,
+    mailbox: &str,
+    generation: &str,
+) -> Result<()> {
+    let mut after_uid: Option<i64> = None;
+    loop {
+        let rows: Vec<(i64, String)> = match after_uid {
+            Some(after_uid) => sqlx::query_as(
+                "SELECT message.uid, message.message_json FROM mailbox_snapshot_messages AS message JOIN mailbox_snapshot_items AS item ON item.account_id = message.account_id AND item.mailbox = message.mailbox AND item.generation = message.generation AND item.uid = message.uid WHERE message.account_id = ? AND message.mailbox = ? AND message.generation = ? AND message.uid > ? ORDER BY message.uid ASC LIMIT ?",
+            )
+            .bind(account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .bind(after_uid)
+            .bind(MAILBOX_SNAPSHOT_REPLACEMENT_PUBLISH_BATCH_SIZE)
+            .fetch_all(&mut **tx)
+            .await?,
+            None => sqlx::query_as(
+                "SELECT message.uid, message.message_json FROM mailbox_snapshot_messages AS message JOIN mailbox_snapshot_items AS item ON item.account_id = message.account_id AND item.mailbox = message.mailbox AND item.generation = message.generation AND item.uid = message.uid WHERE message.account_id = ? AND message.mailbox = ? AND message.generation = ? ORDER BY message.uid ASC LIMIT ?",
+            )
+            .bind(account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .bind(MAILBOX_SNAPSHOT_REPLACEMENT_PUBLISH_BATCH_SIZE)
+            .fetch_all(&mut **tx)
+            .await?,
+        };
+        if rows.is_empty() {
+            return Ok(());
+        }
+        for (uid, message_json) in &rows {
+            let message: MailSummary = serde_json::from_str(message_json)
+                .context("decode staged snapshot replacement message")?;
+            if message.account_id != account_id || message.mailbox != mailbox || message.uid != *uid
+            {
+                return Err(anyhow!(
+                    "staged replacement message does not match its snapshot UID namespace"
+                ));
+            }
+            let staged: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_items WHERE account_id = ? AND mailbox = ? AND generation = ? AND uid = ?)",
+            )
+            .bind(account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .bind(uid)
+            .fetch_one(&mut **tx)
+            .await?;
+            if !staged {
+                return Err(anyhow!(
+                    "staged replacement message UID is absent from the finalized snapshot"
+                ));
+            }
+            persist_message(tx, &message).await?;
+        }
+        after_uid = rows.last().map(|(uid, _)| *uid);
+    }
+}
+
 async fn persist_message_with_flag_policy(
     tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
     message: &MailSummary,
@@ -4411,6 +4899,47 @@ fn is_sqlite_migration_race(error: &anyhow::Error) -> bool {
         .any(|cause| cause.to_string().contains("duplicate column name"))
 }
 
+async fn save_account_in_transaction(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    account: &Account,
+) -> Result<()> {
+    let deleted: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM deleted_account_tombstones WHERE account_id = ?)",
+    )
+    .bind(account.id.to_string())
+    .fetch_one(&mut **tx)
+    .await?;
+    if deleted {
+        return Err(anyhow!("account was removed"));
+    }
+    sqlx::query("INSERT INTO accounts(id, email, data, created_at) VALUES (?, ?, ?, ?) ON CONFLICT(id) DO UPDATE SET email=excluded.email, data=excluded.data")
+        .bind(account.id.to_string())
+        .bind(&account.email)
+        .bind(serde_json::to_string(account)?)
+        .bind(account.created_at)
+        .execute(&mut **tx)
+        .await?;
+    Ok(())
+}
+
+async fn save_mail_rebuild_job_in_transaction(
+    tx: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+    job: &MailRebuildJob,
+) -> Result<()> {
+    sqlx::query(
+        "INSERT INTO mail_rebuild_jobs(account_id, phase, completed, total, reset_before_sync, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(account_id) DO UPDATE SET phase=excluded.phase, completed=excluded.completed, total=excluded.total, reset_before_sync=excluded.reset_before_sync, updated_at=excluded.updated_at",
+    )
+    .bind(job.account_id.to_string())
+    .bind(&job.phase)
+    .bind(i64::try_from(job.completed)?)
+    .bind(job.total.map(i64::try_from).transpose()?)
+    .bind(job.reset_before_sync)
+    .bind(Utc::now())
+    .execute(&mut **tx)
+    .await?;
+    Ok(())
+}
+
 pub fn stable_message_id(account_id: AccountId, mailbox: &str, uid: u32) -> String {
     // UUID v4 is used for accounts; deriving a stable ID avoids duplicates during resync.
     format!("{}:{}:{}", account_id, mailbox.replace(':', "_"), uid)
@@ -4448,49 +4977,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejected_message_watermark_advances_without_a_message_row() {
-        let store = Store::in_memory().await.unwrap();
-        let account = AccountDraft {
-            email: "budget@example.test".into(),
-            display_name: "Budget".into(),
-            provider_id: Some("fastmail".into()),
-            username: None,
-            imap_host: None,
-            imap_port: None,
-            imap_security: None,
-            smtp_host: None,
-            smtp_port: None,
-            smtp_security: None,
-            archive_mailbox: None,
-            spam_mailbox: None,
-        }
-        .into_account(provider::by_id("fastmail").unwrap());
-        store.save_account(&account).await.unwrap();
-
-        store
-            .advance_mailbox_sync_watermark(account.id, "INBOX", 42)
-            .await
-            .unwrap();
-        store
-            .advance_mailbox_sync_watermark(account.id, "INBOX", 41)
-            .await
-            .unwrap();
-
-        assert_eq!(
-            store
-                .highest_mailbox_uid(account.id, "INBOX")
-                .await
-                .unwrap(),
-            Some(42)
-        );
-        assert!(store
-            .mailbox_uids(account.id, "INBOX")
-            .await
-            .unwrap()
-            .is_empty());
-    }
-
-    #[tokio::test]
     async fn mail_rebuild_job_survives_until_explicitly_completed() {
         let store = Store::in_memory().await.unwrap();
         let account = AccountDraft {
@@ -4515,6 +5001,7 @@ mod tests {
             phase: "downloading".into(),
             completed: 150,
             total: Some(1_200),
+            reset_before_sync: true,
         };
 
         store.save_mail_rebuild_job(&job).await.unwrap();
@@ -4524,6 +5011,7 @@ mod tests {
         assert_eq!(restored[0].phase, "downloading");
         assert_eq!(restored[0].completed, 150);
         assert_eq!(restored[0].total, Some(1_200));
+        assert!(restored[0].reset_before_sync);
 
         store.delete_mail_rebuild_job(account_id).await.unwrap();
         assert!(store.mail_rebuild_jobs().await.unwrap().is_empty());
@@ -8833,38 +9321,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn uidvalidity_change_resets_mailbox_and_notification_baseline() {
-        let store = Store::in_memory().await.unwrap();
-        let account_id = uuid::Uuid::new_v4();
-        save_test_account(&store, account_id).await;
-        let mut old = message("Old UID namespace", "old");
-        old.account_id = account_id.to_string();
-        store
-            .save_synced_messages(account_id, "INBOX", &[old])
-            .await
-            .unwrap();
-        store
-            .set_mailbox_uid_validity(account_id, "INBOX", Some(10))
-            .await
-            .unwrap();
-
-        let reset = store
-            .prepare_mailbox_sync(account_id, "INBOX", Some(11))
-            .await
-            .unwrap();
-        assert!(!reset.initialized);
-        assert_eq!(reset.highest_uid, None);
-
-        let mut replacement = message("New UID namespace", "new");
-        replacement.account_id = account_id.to_string();
-        assert!(store
-            .save_synced_messages(account_id, "INBOX", &[replacement])
-            .await
-            .unwrap()
-            .is_empty());
-    }
-
-    #[tokio::test]
     async fn returns_the_highest_uid_for_a_mailbox() {
         let store = Store::in_memory().await.unwrap();
         let account_id = uuid::Uuid::new_v4();
@@ -9335,6 +9791,7 @@ mod tests {
                     phase: "downloading".into(),
                     completed: 1,
                     total: Some(2),
+                    reset_before_sync: false,
                 })
                 .await
                 .err(),
@@ -9433,6 +9890,7 @@ mod tests {
                 phase: "downloading".into(),
                 completed: 1,
                 total: Some(3),
+                reset_before_sync: false,
             })
             .await
             .unwrap();
@@ -9515,6 +9973,7 @@ mod tests {
                 phase: "late".into(),
                 completed: 0,
                 total: None,
+                reset_before_sync: false,
             })
             .await
             .is_err());
@@ -9731,5 +10190,2680 @@ mod tests {
 
         let restored = store.account(account.id).await.unwrap().unwrap();
         assert_eq!(restored.account_name, restored.email);
+    }
+    #[tokio::test]
+    async fn synced_message_above_a_gap_does_not_advance_the_contiguous_watermark() {
+        let store = Store::in_memory().await.unwrap();
+        let account = AccountDraft {
+            email: "budget@example.test".into(),
+            display_name: "Budget".into(),
+            provider_id: Some("fastmail".into()),
+            username: None,
+            imap_host: None,
+            imap_port: None,
+            imap_security: None,
+            smtp_host: None,
+            smtp_port: None,
+            smtp_security: None,
+            archive_mailbox: None,
+            spam_mailbox: None,
+        }
+        .into_account(provider::by_id("fastmail").unwrap());
+        store.save_account(&account).await.unwrap();
+
+        let mut higher = message("Higher UID", "available before the gap is repaired");
+        higher.account_id = account.id.to_string();
+        higher.uid = 42;
+        higher.id = stable_message_id(account.id, "INBOX", 42);
+        store
+            .save_synced_messages_through(account.id, "INBOX", &[higher], Some(41))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .highest_mailbox_uid(account.id, "INBOX")
+                .await
+                .unwrap(),
+            Some(41)
+        );
+        assert_eq!(
+            store.mailbox_uids(account.id, "INBOX").await.unwrap(),
+            [42].into()
+        );
+    }
+
+    #[tokio::test]
+    async fn uidvalidity_change_preserves_identity_and_rows_until_replacement_finalizes() {
+        let directory = tempfile::tempdir().unwrap();
+        let database = directory.path().join("uidvalidity-retry.db");
+        let store = Store::open(&database).await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old UID namespace", "old");
+        old.account_id = account_id.to_string();
+        let old_id = old.id.clone();
+        store
+            .save_synced_messages(account_id, "INBOX", &[old])
+            .await
+            .unwrap();
+        store
+            .set_mailbox_uid_validity(account_id, "INBOX", Some(10))
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "INBOX", 10, 1, true)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE mailbox_sync_state SET initialized_at = ?, highest_uid = 2, uid_validity = 10 WHERE account_id = ? AND mailbox = 'INBOX'")
+            .bind(Utc::now())
+            .bind(account_id.to_string())
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let reset = store
+            .prepare_mailbox_sync(account_id, "INBOX", Some(11))
+            .await
+            .unwrap();
+        assert!(!reset.initialized);
+        assert_eq!(reset.highest_uid, None);
+        assert_eq!(reset.uid_validity, Some(11));
+        assert!(reset.uid_validity_changed);
+        let old_catalogue = store
+            .mailbox_catalog_state(account_id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(old_catalogue.uid_validity, 10);
+        assert_eq!(
+            store
+                .message_by_locator(account_id, "INBOX", 1)
+                .await
+                .unwrap()
+                .as_ref()
+                .map(|message| &message.id),
+            Some(&old_id),
+            "UIDVALIDITY rollover must not delete committed mail before a replacement snapshot finalizes"
+        );
+        drop(store);
+
+        let reopened = Store::open(&database).await.unwrap();
+        let retry = reopened
+            .prepare_mailbox_sync(account_id, "INBOX", Some(11))
+            .await
+            .unwrap();
+        assert!(!retry.initialized);
+        assert_eq!(retry.highest_uid, None);
+        assert!(retry.uid_validity_changed);
+        assert_eq!(
+            reopened
+                .mailbox_catalog_state(account_id, "INBOX")
+                .await
+                .unwrap()
+                .unwrap()
+                .uid_validity,
+            10
+        );
+    }
+
+    #[tokio::test]
+    async fn rollover_prepare_retry_preserves_matching_replacement_outcomes() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old namespace", "old");
+        old.account_id = account_id.to_string();
+        store
+            .save_synced_messages(account_id, "INBOX", &[old])
+            .await
+            .unwrap();
+        store
+            .set_mailbox_uid_validity(account_id, "INBOX", Some(10))
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "INBOX", 10, 1, true)
+            .await
+            .unwrap();
+
+        assert!(
+            store
+                .prepare_mailbox_sync(account_id, "INBOX", Some(11))
+                .await
+                .unwrap()
+                .uid_validity_changed
+        );
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 3, Some(4), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account_id,
+                "INBOX",
+                &generation,
+                &[(1, false, false), (2, false, false), (3, false, false)],
+            )
+            .await
+            .unwrap();
+        let mut parsed = message("Replacement", "headers only");
+        parsed.account_id = account_id.to_string();
+        parsed.uid = 3;
+        store
+            .stage_mailbox_snapshot_message_page(account_id, "INBOX", &generation, &[parsed])
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_excluded_uids(account_id, "INBOX", &generation, &[2])
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids_without_replacement_outcome(
+                    account_id,
+                    "INBOX",
+                    &generation,
+                )
+                .await
+                .unwrap(),
+            vec![1]
+        );
+
+        assert!(
+            store
+                .prepare_mailbox_sync(account_id, "INBOX", Some(11))
+                .await
+                .unwrap()
+                .uid_validity_changed
+        );
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids_without_replacement_outcome(
+                    account_id,
+                    "INBOX",
+                    &generation,
+                )
+                .await
+                .unwrap(),
+            vec![1],
+            "a retry must retain parsed and provider-excluded outcomes"
+        );
+    }
+
+    #[tokio::test]
+    async fn uidvalidity_replacement_catalogue_rows_cannot_retain_old_namespace_content() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old namespace", "old snippet");
+        old.id = stable_message_id(account_id, "INBOX", 7);
+        old.account_id = account_id.to_string();
+        old.uid = 7;
+        old.content_state = "complete".into();
+        old.is_flagged = true;
+        old.has_attachments = true;
+        old.category = Some("travel".into());
+        old.classification_confidence = Some(0.99);
+        old.classification_source = Some("model".into());
+        store
+            .upsert_messages(std::slice::from_ref(&old))
+            .await
+            .unwrap();
+        // Recreate fields a generic headers-only conflict intentionally keeps
+        // for ordinary incremental refreshes, then prove replacement deletes
+        // all of them before the new UID namespace is inserted.
+        sqlx::query("UPDATE messages SET snippet = 'old snippet', body_text = 'old body', body_html = '<p>old</p>', content_state = 'complete', has_attachments = 1, category = 'travel', classification_confidence = 0.99, classification_source = 'model' WHERE id = ?")
+            .bind(&old.id)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        store
+            .cache_message_content(&old.id, false, cached_content("old body"))
+            .await
+            .unwrap();
+
+        let mut replacement = message("Replacement namespace", "new snippet");
+        replacement.id = stable_message_id(account_id, "INBOX", 7);
+        replacement.account_id = account_id.to_string();
+        replacement.uid = 7;
+        replacement.content_state = "headers_only".into();
+        replacement.is_read = true;
+        replacement.is_flagged = false;
+        replacement.has_attachments = false;
+        replacement.category = None;
+        replacement.classification_confidence = None;
+        replacement.classification_source = None;
+        store
+            .replace_uidvalidity_catalog_messages(std::slice::from_ref(&replacement))
+            .await
+            .unwrap();
+
+        let stored = store
+            .message_by_locator(account_id, "INBOX", 7)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(stored.subject, "Replacement namespace");
+        assert_eq!(stored.snippet, "new snippet");
+        assert!(stored.body_text.is_empty());
+        assert_eq!(stored.body_html, None);
+        assert_eq!(stored.content_state, "headers_only");
+        assert!(!stored.has_attachments);
+        assert_eq!(stored.category, None);
+        assert_eq!(stored.classification_confidence, None);
+        assert_eq!(stored.classification_source, None);
+        assert!(store
+            .cached_message_content(&old.id)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn explicit_snapshot_watermark_does_not_assume_the_staged_maximum() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 10, 51, None, None)
+            .await
+            .unwrap();
+        let flags: Vec<(u32, bool, bool)> = (100..=150).map(|uid| (uid, false, false)).collect();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &flags)
+            .await
+            .unwrap();
+
+        store
+            .finalize_mailbox_snapshot_with_watermark(account_id, "INBOX", &generation, Some(124))
+            .await
+            .unwrap();
+        let state = store
+            .prepare_mailbox_sync(account_id, "INBOX", Some(10))
+            .await
+            .unwrap();
+        assert!(state.initialized);
+        assert_eq!(state.highest_uid, Some(124));
+        assert!(!state.uid_validity_changed);
+    }
+
+    #[tokio::test]
+    async fn staged_replacement_finalization_streams_metadata_and_purges_an_empty_namespace() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old namespace", "old");
+        old.account_id = account_id.to_string();
+        old.uid = 7;
+        store
+            .upsert_catalog_messages(std::slice::from_ref(&old))
+            .await
+            .unwrap();
+
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 250, None, None)
+            .await
+            .unwrap();
+        let mut replacements = Vec::new();
+        let mut flags = Vec::new();
+        for uid in 1..=250_i64 {
+            let mut replacement = message(&format!("Replacement {uid}"), "headers only");
+            replacement.id = stable_message_id(account_id, "INBOX", uid as u32);
+            replacement.account_id = account_id.to_string();
+            replacement.uid = uid;
+            replacements.push(replacement);
+            flags.push((uid as u32, uid % 2 == 0, uid % 3 == 0));
+        }
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &flags)
+            .await
+            .unwrap();
+        for page in replacements.chunks(37) {
+            store
+                .stage_mailbox_snapshot_message_page(account_id, "INBOX", &generation, page)
+                .await
+                .unwrap();
+        }
+        store
+            .finalize_mailbox_snapshot_with_staged_replacements(account_id, "INBOX", &generation)
+            .await
+            .unwrap();
+        let uids = store.mailbox_uids(account_id, "INBOX").await.unwrap();
+        assert_eq!(uids.len(), 250);
+        assert!(uids.contains(&250));
+        assert!(
+            store
+                .message_by_locator(account_id, "INBOX", 7)
+                .await
+                .unwrap()
+                .is_some(),
+            "UID 7 is the new staged replacement, not the old row"
+        );
+
+        let empty_generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 12, 1, None, None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account_id,
+                "INBOX",
+                &empty_generation,
+                &[(7, false, false)],
+            )
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_excluded_uids(account_id, "INBOX", &empty_generation, &[7])
+            .await
+            .unwrap();
+        store
+            .finalize_mailbox_snapshot_with_staged_replacements(
+                account_id,
+                "INBOX",
+                &empty_generation,
+            )
+            .await
+            .unwrap();
+        assert!(
+            store
+                .message_by_locator(account_id, "INBOX", 7)
+                .await
+                .unwrap()
+                .is_none(),
+            "replacement mode clears old rows even if this UID was filtered from metadata"
+        );
+    }
+
+    #[tokio::test]
+    async fn malformed_staged_replacement_rolls_back_the_namespace_publish() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old namespace", "old");
+        old.account_id = account_id.to_string();
+        old.uid = 7;
+        store
+            .upsert_catalog_messages(std::slice::from_ref(&old))
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "INBOX", 10, 1, true)
+            .await
+            .unwrap();
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, None, None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &[(7, false, false)])
+            .await
+            .unwrap();
+        let now = Utc::now();
+        sqlx::query("INSERT INTO mailbox_snapshot_messages(account_id, mailbox, generation, uid, message_json, created_at, updated_at) VALUES (?, 'INBOX', ?, 7, '{bad json', ?, ?)")
+            .bind(account_id.to_string())
+            .bind(&generation)
+            .bind(now)
+            .bind(now)
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        assert!(store
+            .finalize_mailbox_snapshot_with_staged_replacements(account_id, "INBOX", &generation)
+            .await
+            .is_err());
+        assert_eq!(
+            store
+                .message_by_locator(account_id, "INBOX", 7)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Old namespace"
+        );
+        assert_eq!(
+            store
+                .mailbox_catalog_state(account_id, "INBOX")
+                .await
+                .unwrap()
+                .unwrap()
+                .uid_validity,
+            10
+        );
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids(account_id, "INBOX", &generation)
+                .await
+                .unwrap(),
+            vec![7]
+        );
+    }
+
+    #[tokio::test]
+    async fn matching_snapshot_identity_resumes_large_partial_replacement_outcomes() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let generation = store
+            .begin_mailbox_snapshot(
+                account_id,
+                "[Gmail]/All Mail",
+                "[Gmail]/All Mail",
+                7,
+                99_003,
+                Some(99_004),
+                None,
+            )
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account_id,
+                "[Gmail]/All Mail",
+                &generation,
+                &[
+                    (99_003, false, false),
+                    (99_002, true, false),
+                    (99_001, false, false),
+                ],
+            )
+            .await
+            .unwrap();
+        let mut parsed = message("Retained staged metadata", "headers only");
+        parsed.id = stable_message_id(account_id, "[Gmail]/All Mail", 99_003);
+        parsed.account_id = account_id.to_string();
+        parsed.mailbox = "[Gmail]/All Mail".into();
+        parsed.uid = 99_003;
+        store
+            .stage_mailbox_snapshot_message_page(
+                account_id,
+                "[Gmail]/All Mail",
+                &generation,
+                &[parsed],
+            )
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_excluded_uids(
+                account_id,
+                "[Gmail]/All Mail",
+                &generation,
+                &[99_002],
+            )
+            .await
+            .unwrap();
+
+        let resumed = store
+            .begin_mailbox_snapshot(
+                account_id,
+                "[Gmail]/All Mail",
+                "[Gmail]/All Mail",
+                7,
+                99_003,
+                Some(99_004),
+                Some(42),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resumed, generation);
+        store
+            .stage_mailbox_snapshot_page(
+                account_id,
+                "[Gmail]/All Mail",
+                &resumed,
+                &[
+                    (99_003, false, false),
+                    (99_002, true, false),
+                    (99_001, false, false),
+                ],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids_without_replacement_outcome(
+                    account_id,
+                    "[Gmail]/All Mail",
+                    &resumed,
+                )
+                .await
+                .unwrap(),
+            vec![99_001],
+            "already parsed and durably filtered UIDs are never fetched again"
+        );
+    }
+
+    #[tokio::test]
+    async fn mismatched_snapshot_identity_replaces_old_staging() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let first = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 2, Some(3), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &first, &[(2, false, false)])
+            .await
+            .unwrap();
+
+        let replacement = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 2, Some(4), None)
+            .await
+            .unwrap();
+        assert_ne!(replacement, first);
+        assert!(store
+            .staged_mailbox_snapshot_uids(account_id, "INBOX", &first)
+            .await
+            .is_err());
+        assert!(store
+            .staged_mailbox_snapshot_uids(account_id, "INBOX", &replacement)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn authoritative_nonexistent_mailbox_clear_removes_the_entire_namespace() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old Sent", "old");
+        old.account_id = account_id.to_string();
+        old.mailbox = "Sent".into();
+        old.uid = 4;
+        store
+            .upsert_catalog_messages(std::slice::from_ref(&old))
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "Sent", "Sent", 5, 1, true)
+            .await
+            .unwrap();
+        store
+            .set_mailbox_uid_validity(account_id, "Sent", Some(5))
+            .await
+            .unwrap();
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "Sent", "Sent", 5, 1, Some(5), None)
+            .await
+            .unwrap();
+        store
+            .record_mailbox_sync_failure(account_id, "Sent", 4, "parse", "old namespace")
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO mailbox_action_tombstones(account_id, mailbox, uid, created_at) VALUES (?, 'Sent', 4, ?)")
+            .bind(account_id.to_string())
+            .bind(Utc::now())
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        store
+            .clear_nonexistent_mailbox_namespace(account_id, "Sent")
+            .await
+            .unwrap();
+        assert!(store
+            .message_by_locator(account_id, "Sent", 4)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .mailbox_catalog_state(account_id, "Sent")
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .prepare_mailbox_sync(account_id, "Sent", Some(5))
+            .await
+            .unwrap()
+            .highest_uid
+            .is_none());
+        assert!(store
+            .staged_mailbox_snapshot_uids(account_id, "Sent", &generation)
+            .await
+            .is_err());
+        assert!(store
+            .mailbox_sync_failure_uids(account_id, "Sent")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn replacement_snapshot_finalization_rolls_back_replacements_when_publish_fails() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old namespace", "old");
+        old.id = stable_message_id(account_id, "INBOX", 7);
+        old.account_id = account_id.to_string();
+        old.uid = 7;
+        let mut collision = message("Unrelated row", "keep");
+        collision.id = "replacement-id-collision".into();
+        collision.account_id = account_id.to_string();
+        collision.mailbox = "Archive".into();
+        collision.uid = 9;
+        store
+            .upsert_catalog_messages(&[old.clone(), collision])
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "INBOX", 10, 1, true)
+            .await
+            .unwrap();
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, Some(8), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &[(7, true, false)])
+            .await
+            .unwrap();
+        let mut replacement = message("Replacement namespace", "new");
+        replacement.id = "replacement-id-collision".into();
+        replacement.account_id = account_id.to_string();
+        replacement.uid = 7;
+
+        assert!(store
+            .finalize_mailbox_snapshot_with_replacements(
+                account_id,
+                "INBOX",
+                &generation,
+                &[replacement],
+            )
+            .await
+            .is_err());
+        assert_eq!(
+            store
+                .message_by_locator(account_id, "INBOX", 7)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Old namespace"
+        );
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids(account_id, "INBOX", &generation)
+                .await
+                .unwrap(),
+            vec![7]
+        );
+        assert_eq!(
+            store
+                .mailbox_catalog_state(account_id, "INBOX")
+                .await
+                .unwrap()
+                .unwrap()
+                .uid_validity,
+            10
+        );
+    }
+
+    #[tokio::test]
+    async fn partial_mailbox_snapshot_never_deletes_committed_messages() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut first = message("First", "one");
+        first.account_id = account_id.to_string();
+        first.uid = 1;
+        let mut second = message("Second", "two");
+        second.account_id = account_id.to_string();
+        second.uid = 2;
+        store
+            .upsert_catalog_messages(&[first, second])
+            .await
+            .unwrap();
+
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 77, 2, Some(3), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &[(2, true, false)])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids(account_id, "INBOX", &generation)
+                .await
+                .unwrap(),
+            vec![2]
+        );
+        assert!(store
+            .message_by_locator(account_id, "INBOX", 1)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .message_by_locator(account_id, "INBOX", 2)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
+    async fn finalized_mailbox_snapshot_applies_flags_deletes_absent_rows_and_clears_staging() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut stale = message("Stale", "remove me");
+        stale.account_id = account_id.to_string();
+        stale.uid = 1;
+        let mut retained = message("Retained", "keep me");
+        retained.account_id = account_id.to_string();
+        retained.uid = 2;
+        store
+            .upsert_catalog_messages(&[stale, retained])
+            .await
+            .unwrap();
+
+        let generation = store
+            .begin_mailbox_snapshot(
+                account_id,
+                "INBOX",
+                "Remote Inbox",
+                88,
+                1,
+                Some(3),
+                Some(u64::MAX),
+            )
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &[(2, true, true)])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store
+                .finalize_mailbox_snapshot(account_id, "INBOX", &generation)
+                .await
+                .unwrap(),
+            1
+        );
+        assert!(store
+            .message_by_locator(account_id, "INBOX", 1)
+            .await
+            .unwrap()
+            .is_none());
+        let retained = store
+            .message_by_locator(account_id, "INBOX", 2)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(retained.is_read);
+        assert!(retained.is_flagged);
+        let state = store
+            .mailbox_catalog_state(account_id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.remote_name, "Remote Inbox");
+        assert_eq!(state.uid_validity, 88);
+        assert_eq!(state.remote_total, 1);
+        assert!(state.historical_complete);
+        assert_eq!(state.uid_next, Some(3));
+        assert_eq!(
+            state.highest_modseq.as_deref(),
+            Some("18446744073709551615")
+        );
+        let sync_state = store
+            .prepare_mailbox_sync(account_id, "INBOX", Some(88))
+            .await
+            .unwrap();
+        assert!(sync_state.initialized);
+        assert_eq!(sync_state.highest_uid, Some(2));
+        assert!(store
+            .message_by_locator(account_id, "INBOX", 2)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .staged_mailbox_snapshot_uids(account_id, "INBOX", &generation)
+            .await
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn finalized_uidvalidity_rollover_clears_old_namespace_tombstones() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "INBOX", 10, 1, true)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO mailbox_action_tombstones(account_id, mailbox, uid, created_at) VALUES (?, 'INBOX', 2, ?)")
+            .bind(account_id.to_string())
+            .bind(Utc::now())
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        assert!(
+            store
+                .prepare_mailbox_sync(account_id, "INBOX", Some(11))
+                .await
+                .unwrap()
+                .uid_validity_changed
+        );
+        let pending_tombstones: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = 'INBOX'",
+        )
+        .bind(account_id.to_string())
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+        assert_eq!(pending_tombstones, 1);
+
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, Some(3), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &[(2, false, false)])
+            .await
+            .unwrap();
+        store
+            .finalize_mailbox_snapshot(account_id, "INBOX", &generation)
+            .await
+            .unwrap();
+
+        let tombstones: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = 'INBOX'",
+        )
+        .bind(account_id.to_string())
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+        assert_eq!(tombstones, 0);
+    }
+
+    #[tokio::test]
+    async fn changed_since_delta_updates_only_observed_flags_and_persists_condstore_state() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut changed = message("Changed", "one");
+        changed.account_id = account_id.to_string();
+        changed.uid = 1;
+        let mut omitted = message("Omitted", "two");
+        omitted.account_id = account_id.to_string();
+        omitted.uid = 2;
+        omitted.is_read = true;
+        omitted.is_flagged = true;
+        store
+            .upsert_catalog_messages(&[changed, omitted])
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "Remote Inbox", 77, 2, true)
+            .await
+            .unwrap();
+
+        store
+            .apply_complete_mailbox_changed_since_flags(
+                account_id,
+                "INBOX",
+                "Remote Inbox",
+                77,
+                2,
+                Some(3),
+                Some(u64::MAX),
+                &[(1, true, true)],
+            )
+            .await
+            .unwrap();
+
+        let changed = store
+            .message_by_locator(account_id, "INBOX", 1)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(changed.is_read && changed.is_flagged);
+        let omitted = store
+            .message_by_locator(account_id, "INBOX", 2)
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(omitted.is_read && omitted.is_flagged);
+        let state = store
+            .mailbox_catalog_state(account_id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.remote_total, 2);
+        assert_eq!(state.uid_next, Some(3));
+        assert_eq!(
+            state.highest_modseq.as_deref(),
+            Some("18446744073709551615")
+        );
+    }
+
+    #[tokio::test]
+    async fn changed_since_delta_supports_nomodseq_by_persisting_null_condstore_state() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "INBOX", 77, 0, true)
+            .await
+            .unwrap();
+
+        store
+            .apply_complete_mailbox_changed_since_flags(
+                account_id,
+                "INBOX",
+                "INBOX",
+                77,
+                0,
+                None,
+                None,
+                &[],
+            )
+            .await
+            .unwrap();
+        let state = store
+            .mailbox_catalog_state(account_id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.uid_next, None);
+        assert_eq!(state.highest_modseq, None);
+    }
+
+    #[tokio::test]
+    async fn migration_adds_nullable_condstore_columns_to_existing_catalogue_state() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("legacy-catalogue.db");
+        let options = SqliteConnectOptions::from_str(path.to_str().unwrap())
+            .unwrap()
+            .create_if_missing(true);
+        let pool = SqlitePool::connect_with(options).await.unwrap();
+        sqlx::query("CREATE TABLE accounts (id TEXT PRIMARY KEY, email TEXT NOT NULL UNIQUE, data TEXT NOT NULL, created_at TEXT NOT NULL)")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE mailbox_catalog_state (account_id TEXT NOT NULL, mailbox TEXT NOT NULL, remote_name TEXT NOT NULL, uid_validity INTEGER NOT NULL, remote_total INTEGER NOT NULL DEFAULT 0, historical_complete INTEGER NOT NULL DEFAULT 0, updated_at TEXT NOT NULL, PRIMARY KEY(account_id, mailbox))")
+            .execute(&pool)
+            .await
+            .unwrap();
+        drop(pool);
+
+        let store = Store::open(&path).await.unwrap();
+        let columns: Vec<(i64, String, String, i64, Option<String>, i64)> =
+            sqlx::query_as("PRAGMA table_info(mailbox_catalog_state)")
+                .fetch_all(&store.pool)
+                .await
+                .unwrap();
+        assert!(columns.iter().any(|column| column.1 == "uid_next"));
+        assert!(columns.iter().any(|column| column.1 == "highest_modseq"));
+    }
+
+    #[tokio::test]
+    async fn mailbox_snapshot_generations_are_replaced_per_mailbox_and_isolated_between_mailboxes()
+    {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let inbox_first = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 2, None, None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &inbox_first, &[(2, false, false)])
+            .await
+            .unwrap();
+        let archive = store
+            .begin_mailbox_snapshot(account_id, "Archive", "Archive", 8, 1, None, None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "Archive", &archive, &[(9, true, true)])
+            .await
+            .unwrap();
+
+        let inbox_replacement = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 7, 3, None, None)
+            .await
+            .unwrap();
+        assert!(store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &inbox_first, &[(1, false, false)])
+            .await
+            .is_err());
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids(account_id, "Archive", &archive)
+                .await
+                .unwrap(),
+            vec![9]
+        );
+        assert!(store
+            .staged_mailbox_snapshot_uids(account_id, "INBOX", &inbox_replacement)
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn finalized_empty_mailbox_snapshot_authoritatively_clears_a_mailbox() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut first = message("Old one", "old");
+        first.account_id = account_id.to_string();
+        first.uid = 1;
+        let mut second = message("Old two", "old");
+        second.account_id = account_id.to_string();
+        second.uid = 2;
+        store
+            .upsert_catalog_messages(&[first, second])
+            .await
+            .unwrap();
+
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 99, 0, Some(1), None)
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .finalize_mailbox_snapshot(account_id, "INBOX", &generation)
+                .await
+                .unwrap(),
+            2
+        );
+        assert!(store
+            .mailbox_uids(account_id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+        let state = store
+            .mailbox_catalog_state(account_id, "INBOX")
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(state.remote_total, 0);
+        assert!(state.historical_complete);
+    }
+
+    #[tokio::test]
+    async fn mailbox_sync_failures_remain_retryable_until_their_uids_are_cleared() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 100, "parse", "bad header")
+            .await
+            .unwrap();
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 101, "fetch", "timed out")
+            .await
+            .unwrap();
+        // A retry updates the diagnostic but does not create a second UID.
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 100, "fetch", "literal too large")
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .mailbox_sync_failure_uids(account_id, "INBOX")
+                .await
+                .unwrap(),
+            vec![101, 100]
+        );
+
+        store
+            .clear_mailbox_sync_failure(account_id, "INBOX", 100)
+            .await
+            .unwrap();
+        store
+            .clear_mailbox_sync_failures(account_id, "INBOX", &[101])
+            .await
+            .unwrap();
+        assert!(store
+            .mailbox_sync_failure_uids(account_id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn retried_mailbox_sync_failure_yields_to_untouched_failures_in_oldest_first_order() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        for uid in 1..=50 {
+            store
+                .record_mailbox_sync_failure(account_id, "INBOX", uid, "fetch", "timed out")
+                .await
+                .unwrap();
+        }
+        let tie_time = Utc::now();
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 25, "fetch", "still timed out")
+            .await
+            .unwrap();
+        sqlx::query("UPDATE mailbox_sync_failures SET updated_at = ? WHERE account_id = ? AND mailbox = 'INBOX' AND uid IN (49, 50)")
+            .bind(tie_time)
+            .bind(account_id.to_string())
+            .execute(&store.pool)
+            .await
+            .unwrap();
+
+        let ordered = store
+            .mailbox_sync_failure_uids(account_id, "INBOX")
+            .await
+            .unwrap();
+        let retried = ordered.iter().position(|uid| *uid == 25).unwrap();
+        for uid in 26..=50 {
+            assert!(
+                ordered
+                    .iter()
+                    .position(|candidate| *candidate == uid)
+                    .unwrap()
+                    < retried,
+                "untouched UID {uid} must precede the retried UID"
+            );
+        }
+        let forty_nine = ordered.iter().position(|uid| *uid == 49).unwrap();
+        let fifty = ordered.iter().position(|uid| *uid == 50).unwrap();
+        assert!(
+            forty_nine < fifty,
+            "equal timestamps use UID as a stable tie-breaker"
+        );
+    }
+
+    #[tokio::test]
+    async fn mailbox_sync_failures_are_cleared_by_index_reset_and_fenced_after_account_deletion() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 10, "parse", "bad header")
+            .await
+            .unwrap();
+        store.reset_account_mail_index(account_id).await.unwrap();
+        assert!(store
+            .mailbox_sync_failure_uids(account_id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 11, "fetch", "timed out")
+            .await
+            .unwrap();
+        store.delete_account(account_id).await.unwrap();
+        assert!(store
+            .mailbox_sync_failure_uids(account_id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+        assert!(store
+            .record_mailbox_sync_failure(account_id, "INBOX", 12, "fetch", "late writer")
+            .await
+            .unwrap_err()
+            .to_string()
+            .contains("account was removed"));
+    }
+
+    #[tokio::test]
+    async fn uidnext_absent_resume_rebuilds_inventory_and_keeps_current_outcomes() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 9, 2, None, None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account_id,
+                "INBOX",
+                &generation,
+                &[(1, false, false), (2, false, false)],
+            )
+            .await
+            .unwrap();
+        let mut retained = message("Still present", "headers only");
+        retained.account_id = account_id.to_string();
+        retained.uid = 2;
+        store
+            .stage_mailbox_snapshot_message_page(account_id, "INBOX", &generation, &[retained])
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_excluded_uids(account_id, "INBOX", &generation, &[1])
+            .await
+            .unwrap();
+
+        let resumed = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 9, 2, None, None)
+            .await
+            .unwrap();
+        assert_eq!(resumed, generation);
+        assert!(store
+            .staged_mailbox_snapshot_uids(account_id, "INBOX", &resumed)
+            .await
+            .unwrap()
+            .is_empty());
+        store
+            .stage_mailbox_snapshot_page(
+                account_id,
+                "INBOX",
+                &resumed,
+                &[(2, false, false), (3, false, false)],
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids(account_id, "INBOX", &resumed)
+                .await
+                .unwrap(),
+            vec![3, 2]
+        );
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids_without_replacement_outcome(
+                    account_id, "INBOX", &resumed,
+                )
+                .await
+                .unwrap(),
+            vec![3],
+            "the still-present UID retains its prior staged metadata outcome"
+        );
+    }
+
+    #[tokio::test]
+    async fn incomplete_staged_replacement_does_not_publish_or_delete_old_namespace() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut old = message("Old namespace", "old");
+        old.account_id = account_id.to_string();
+        old.uid = 1;
+        store
+            .upsert_catalog_messages(std::slice::from_ref(&old))
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "INBOX", 10, 1, true)
+            .await
+            .unwrap();
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 11, 1, Some(2), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(account_id, "INBOX", &generation, &[(1, false, false)])
+            .await
+            .unwrap();
+
+        assert!(store
+            .finalize_mailbox_snapshot_with_staged_replacements(account_id, "INBOX", &generation)
+            .await
+            .is_err());
+        assert_eq!(
+            store
+                .message_by_locator(account_id, "INBOX", 1)
+                .await
+                .unwrap()
+                .unwrap()
+                .subject,
+            "Old namespace"
+        );
+        assert_eq!(
+            store
+                .mailbox_catalog_state(account_id, "INBOX")
+                .await
+                .unwrap()
+                .unwrap()
+                .uid_validity,
+            10
+        );
+        assert_eq!(
+            store
+                .staged_mailbox_snapshot_uids(account_id, "INBOX", &generation)
+                .await
+                .unwrap(),
+            vec![1]
+        );
+    }
+
+    #[tokio::test]
+    async fn staging_replacement_outcomes_clears_their_durable_failures_atomically() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let generation = store
+            .begin_mailbox_snapshot(account_id, "INBOX", "INBOX", 1, 2, Some(3), None)
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_page(
+                account_id,
+                "INBOX",
+                &generation,
+                &[(1, false, false), (2, false, false)],
+            )
+            .await
+            .unwrap();
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 1, "parse", "filtered later")
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_excluded_uids(account_id, "INBOX", &generation, &[1])
+            .await
+            .unwrap();
+        let mut parsed = message("Parsed", "headers only");
+        parsed.account_id = account_id.to_string();
+        parsed.uid = 2;
+        store
+            .record_mailbox_sync_failure(account_id, "INBOX", 2, "parse", "fixed later")
+            .await
+            .unwrap();
+        store
+            .stage_mailbox_snapshot_message_page(account_id, "INBOX", &generation, &[parsed])
+            .await
+            .unwrap();
+        assert!(store
+            .mailbox_sync_failure_uids(account_id, "INBOX")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn complete_family_keep_set_prunes_only_obsolete_provider_keys() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        for (mailbox, uid) in [
+            ("Sent", 1),
+            ("Sent::Legacy", 2),
+            ("Sent::A", 3),
+            ("Sent::B", 4),
+        ] {
+            let mut message = message(mailbox, "old provider spelling");
+            message.account_id = account_id.to_string();
+            message.mailbox = mailbox.into();
+            message.uid = uid;
+            store.upsert_catalog_messages(&[message]).await.unwrap();
+            store
+                .save_mailbox_catalog_state(account_id, mailbox, mailbox, 5, 1, true)
+                .await
+                .unwrap();
+        }
+        for (mailbox, uid) in [("Sent::A", 3), ("Sent::B", 4)] {
+            let generation = store
+                .begin_mailbox_snapshot(account_id, mailbox, mailbox, 5, 1, Some(5), None)
+                .await
+                .unwrap();
+            store
+                .stage_mailbox_snapshot_page(
+                    account_id,
+                    mailbox,
+                    &generation,
+                    &[(uid, true, false)],
+                )
+                .await
+                .unwrap();
+            store
+                .finalize_mailbox_snapshot(account_id, mailbox, &generation)
+                .await
+                .unwrap();
+        }
+
+        // One sibling's completed plan must not erase another or a legacy
+        // key before the caller has a complete family keep-set.
+        assert!(store
+            .message_by_locator(account_id, "Sent::Legacy", 2)
+            .await
+            .unwrap()
+            .is_some());
+        store
+            .prune_obsolete_mailbox_family_namespaces(
+                account_id,
+                "Sent",
+                &["Sent::A".into(), "Sent::B".into()],
+            )
+            .await
+            .unwrap();
+        assert!(store
+            .message_by_locator(account_id, "Sent", 1)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .message_by_locator(account_id, "Sent::Legacy", 2)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .message_by_locator(account_id, "Sent::A", 3)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(store
+            .message_by_locator(account_id, "Sent::B", 4)
+            .await
+            .unwrap()
+            .is_some());
+        let old_state_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM mailbox_catalog_state WHERE account_id = ? AND mailbox IN ('Sent', 'Sent::Legacy')",
+        )
+        .bind(account_id.to_string())
+        .fetch_one(&store.pool)
+        .await
+        .unwrap();
+        assert_eq!(old_state_count, 0);
+
+        store
+            .prune_obsolete_mailbox_family_namespaces(account_id, "Sent", &[])
+            .await
+            .unwrap();
+        assert!(store
+            .message_by_locator(account_id, "Sent::A", 3)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .message_by_locator(account_id, "Sent::B", 4)
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn nonexistent_mailbox_clear_isolated_to_the_confirmed_key() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        for (mailbox, uid) in [
+            ("Archive::Missing", 1),
+            ("Archive::Current", 2),
+            ("Spam::Missing", 3),
+            ("Spam::Current", 4),
+            ("Trash::Missing", 5),
+            ("Trash::Current", 6),
+            ("Sent::Missing", 7),
+            ("Sent::Current", 8),
+            ("INBOX", 9),
+            ("INBOX::Current", 10),
+        ] {
+            let mut message = message(mailbox, "gone");
+            message.account_id = account_id.to_string();
+            message.mailbox = mailbox.into();
+            message.uid = uid;
+            store.upsert_catalog_messages(&[message]).await.unwrap();
+        }
+        for (missing, current) in [
+            ("Archive::Missing", "Archive::Current"),
+            ("Spam::Missing", "Spam::Current"),
+            ("Trash::Missing", "Trash::Current"),
+            ("Sent::Missing", "Sent::Current"),
+            ("INBOX", "INBOX::Current"),
+        ] {
+            store
+                .clear_nonexistent_mailbox_namespace(account_id, missing)
+                .await
+                .unwrap();
+            let removed: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM messages WHERE account_id = ? AND mailbox = ?",
+            )
+            .bind(account_id.to_string())
+            .bind(missing)
+            .fetch_one(&store.pool)
+            .await
+            .unwrap();
+            assert_eq!(removed, 0);
+            assert!(store
+                .message_by_locator(
+                    account_id,
+                    current,
+                    match current {
+                        "Archive::Current" => 2,
+                        "Spam::Current" => 4,
+                        "Trash::Current" => 6,
+                        "Sent::Current" => 8,
+                        _ => 10,
+                    },
+                )
+                .await
+                .unwrap()
+                .is_some());
+        }
+    }
+
+    #[tokio::test]
+    async fn account_and_reset_rebuild_job_commit_together() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let account = account_with_id(account_id, "atomic-reset@example.test");
+        let job = MailRebuildJob {
+            account_id,
+            phase: "queued".into(),
+            completed: 0,
+            total: None,
+            reset_before_sync: true,
+        };
+        store
+            .save_account_with_reset_mail_rebuild_job(&account, &job)
+            .await
+            .unwrap();
+        assert!(store.account(account_id).await.unwrap().is_some());
+        let saved_jobs = store.mail_rebuild_jobs().await.unwrap();
+        assert_eq!(saved_jobs.len(), 1);
+        assert_eq!(saved_jobs[0].account_id, job.account_id);
+        assert!(saved_jobs[0].reset_before_sync);
+
+        let uncommitted_id = uuid::Uuid::new_v4();
+        let uncommitted = account_with_id(uncommitted_id, "must-not-save@example.test");
+        let wrong_job = MailRebuildJob {
+            account_id: uuid::Uuid::new_v4(),
+            phase: "queued".into(),
+            completed: 0,
+            total: None,
+            reset_before_sync: true,
+        };
+        assert!(store
+            .save_account_with_reset_mail_rebuild_job(&uncommitted, &wrong_job)
+            .await
+            .is_err());
+        assert!(store.account(uncommitted_id).await.unwrap().is_none());
+        let mut changed_existing = account.clone();
+        changed_existing.email = "must-not-update@example.test".into();
+        assert!(store
+            .save_account_with_reset_mail_rebuild_job(&changed_existing, &wrong_job)
+            .await
+            .is_err());
+        assert_eq!(
+            store.account(account_id).await.unwrap().unwrap().email,
+            "atomic-reset@example.test"
+        );
+        assert!(store
+            .save_account_with_reset_mail_rebuild_job(
+                &uncommitted,
+                &MailRebuildJob {
+                    account_id: uncommitted_id,
+                    phase: "queued".into(),
+                    completed: 0,
+                    total: None,
+                    reset_before_sync: false,
+                },
+            )
+            .await
+            .is_err());
+        assert!(store.account(uncommitted_id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn account_reset_and_previous_secret_rotation_are_atomic() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        let initial = account_with_id(account_id, "before-rotation@example.test");
+        store.save_account(&initial).await.unwrap();
+        store
+            .save_mail_rebuild_job(&MailRebuildJob {
+                account_id,
+                phase: "old-job".into(),
+                completed: 1,
+                total: Some(2),
+                reset_before_sync: false,
+            })
+            .await
+            .unwrap();
+        store
+            .set_secret("rotation-old", "old-secret")
+            .await
+            .unwrap();
+        store
+            .set_secret("rotation-new", "new-secret")
+            .await
+            .unwrap();
+        let mut rotated = initial.clone();
+        rotated.email = "after-rotation@example.test".into();
+        let reset_job = MailRebuildJob {
+            account_id,
+            phase: "new-job".into(),
+            completed: 0,
+            total: None,
+            reset_before_sync: true,
+        };
+        store
+            .save_account_with_reset_mail_rebuild_job_and_delete_previous_secret(
+                &rotated,
+                &reset_job,
+                Some("rotation-old"),
+                "rotation-new",
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            store.account(account_id).await.unwrap().unwrap().email,
+            "after-rotation@example.test"
+        );
+        assert_eq!(store.mail_rebuild_jobs().await.unwrap()[0].phase, "new-job");
+        assert!(store.secret("rotation-old").await.unwrap().is_none());
+        assert_eq!(
+            store.secret("rotation-new").await.unwrap().as_deref(),
+            Some("new-secret")
+        );
+
+        let rollback_id = uuid::Uuid::new_v4();
+        let rollback_initial = account_with_id(rollback_id, "before-rollback@example.test");
+        store.save_account(&rollback_initial).await.unwrap();
+        store
+            .save_mail_rebuild_job(&MailRebuildJob {
+                account_id: rollback_id,
+                phase: "old-job".into(),
+                completed: 1,
+                total: Some(2),
+                reset_before_sync: false,
+            })
+            .await
+            .unwrap();
+        store
+            .set_secret("rollback-old", "old-secret")
+            .await
+            .unwrap();
+        store
+            .set_secret("rollback-new", "new-secret")
+            .await
+            .unwrap();
+        sqlx::query("CREATE TRIGGER reject_rotation_secret_delete BEFORE DELETE ON credentials WHEN OLD.name = 'rollback-old' BEGIN SELECT RAISE(ABORT, 'forced credential cleanup failure'); END")
+            .execute(&store.pool)
+            .await
+            .unwrap();
+        let mut rollback_rotated = rollback_initial.clone();
+        rollback_rotated.email = "must-not-commit@example.test".into();
+        assert!(store
+            .save_account_with_reset_mail_rebuild_job_and_delete_previous_secret(
+                &rollback_rotated,
+                &MailRebuildJob {
+                    account_id: rollback_id,
+                    phase: "must-not-commit".into(),
+                    completed: 0,
+                    total: None,
+                    reset_before_sync: true,
+                },
+                Some("rollback-old"),
+                "rollback-new",
+            )
+            .await
+            .is_err());
+        assert_eq!(
+            store.account(rollback_id).await.unwrap().unwrap().email,
+            "before-rollback@example.test"
+        );
+        assert_eq!(
+            store
+                .mail_rebuild_jobs()
+                .await
+                .unwrap()
+                .into_iter()
+                .find(|job| job.account_id == rollback_id)
+                .unwrap()
+                .phase,
+            "old-job"
+        );
+        assert_eq!(
+            store.secret("rollback-old").await.unwrap().as_deref(),
+            Some("old-secret")
+        );
+        assert_eq!(
+            store.secret("rollback-new").await.unwrap().as_deref(),
+            Some("new-secret")
+        );
+
+        let deleted_id = uuid::Uuid::new_v4();
+        let deleted_account = account_with_id(deleted_id, "deleted@example.test");
+        store.save_account(&deleted_account).await.unwrap();
+        store.set_secret("deleted-old", "old-secret").await.unwrap();
+        store.set_secret("deleted-new", "new-secret").await.unwrap();
+        store.delete_account(deleted_id).await.unwrap();
+        assert!(store
+            .save_account_with_reset_mail_rebuild_job_and_delete_previous_secret(
+                &deleted_account,
+                &MailRebuildJob {
+                    account_id: deleted_id,
+                    phase: "must-not-revive".into(),
+                    completed: 0,
+                    total: None,
+                    reset_before_sync: true,
+                },
+                Some("deleted-old"),
+                "deleted-new",
+            )
+            .await
+            .is_err());
+        assert_eq!(
+            store.secret("deleted-old").await.unwrap().as_deref(),
+            Some("old-secret")
+        );
+    }
+}
+impl Store {
+    /// Starts or resumes an incomplete mailbox inventory. Matching mailbox
+    /// identity retains its staged flags and replacement outcomes across a
+    /// cancelled connection; a changed identity replaces only staging.
+    pub async fn begin_mailbox_snapshot(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        remote_name: &str,
+        uid_validity: u32,
+        initial_exists: u32,
+        uid_next: Option<u32>,
+        highest_modseq: Option<u64>,
+    ) -> Result<String> {
+        let account_id = account_id.to_string();
+        let generation = uuid::Uuid::new_v4().to_string();
+        let uid_next = uid_next.map(i64::from);
+        let highest_modseq = highest_modseq.map(|value| value.to_string());
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        let account_removed: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM deleted_account_tombstones WHERE account_id = ?)",
+        )
+        .bind(&account_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        let account_exists: bool =
+            sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM accounts WHERE id = ?)")
+                .bind(&account_id)
+                .fetch_one(&mut *tx)
+                .await?;
+        if account_removed || !account_exists {
+            tx.rollback().await?;
+            return Err(anyhow!(if account_removed {
+                "account was removed"
+            } else {
+                "account does not exist"
+            }));
+        }
+        let existing: Option<(String, String, i64, i64, Option<i64>)> = sqlx::query_as(
+            "SELECT generation, remote_name, uid_validity, initial_exists, uid_next FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ?",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if let Some((
+            existing_generation,
+            existing_remote_name,
+            existing_uid_validity,
+            existing_exists,
+            existing_uid_next,
+        )) = existing
+        {
+            if existing_remote_name == remote_name
+                && existing_uid_validity == i64::from(uid_validity)
+                && existing_exists == i64::from(initial_exists)
+                && existing_uid_next == uid_next
+            {
+                sqlx::query("UPDATE mailbox_snapshot_generations SET highest_modseq = ?, updated_at = ? WHERE account_id = ? AND mailbox = ? AND generation = ?")
+                    .bind(highest_modseq)
+                    .bind(Utc::now())
+                    .bind(&account_id)
+                    .bind(mailbox)
+                    .bind(&existing_generation)
+                    .execute(&mut *tx)
+                    .await?;
+                // A resumed full inventory must replace its old UID list.
+                // Metadata and outcomes survive, then reattach only when the
+                // current bounded inventory restages their UID.
+                sqlx::query("DELETE FROM mailbox_snapshot_items WHERE account_id = ? AND mailbox = ? AND generation = ?")
+                    .bind(&account_id)
+                    .bind(mailbox)
+                    .bind(&existing_generation)
+                    .execute(&mut *tx)
+                    .await?;
+                tx.commit().await?;
+                return Ok(existing_generation);
+            }
+        }
+        sqlx::query(
+            "DELETE FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ?",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .execute(&mut *tx)
+        .await?;
+        let now = Utc::now();
+        sqlx::query("INSERT INTO mailbox_snapshot_generations(account_id, mailbox, generation, remote_name, uid_validity, initial_exists, uid_next, highest_modseq, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(&generation)
+            .bind(remote_name)
+            .bind(i64::from(uid_validity))
+            .bind(i64::from(initial_exists))
+            .bind(uid_next)
+            // SQLite integers are signed, while IMAP mod-sequences are
+            // unsigned 64-bit values. Text preserves every valid value.
+            .bind(highest_modseq)
+            .bind(now)
+            .bind(now)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(generation)
+    }
+
+    /// Writes one completed IMAP response page into a snapshot generation.
+    /// Repeating a UID is safe: the most recently observed flag tuple wins.
+    pub async fn stage_mailbox_snapshot_page(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        flags: &[(u32, bool, bool)],
+    ) -> Result<()> {
+        if flags.iter().any(|(uid, _, _)| *uid == 0) {
+            return Err(anyhow!("mailbox snapshot contains UID 0"));
+        }
+        let account_id = account_id.to_string();
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        let active: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?)",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .bind(generation)
+        .fetch_one(&mut *tx)
+        .await?;
+        if !active {
+            tx.rollback().await?;
+            return Err(anyhow!("mailbox snapshot generation is not active"));
+        }
+        let now = Utc::now();
+        for (uid, is_read, is_flagged) in flags {
+            sqlx::query("INSERT INTO mailbox_snapshot_items(account_id, mailbox, generation, uid, is_read, is_flagged, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox, generation, uid) DO UPDATE SET is_read=excluded.is_read, is_flagged=excluded.is_flagged, updated_at=excluded.updated_at")
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .bind(i64::from(*uid))
+                .bind(*is_read)
+                .bind(*is_flagged)
+                .bind(now)
+                .bind(now)
+                .execute(&mut *tx)
+                .await?;
+        }
+        sqlx::query("UPDATE mailbox_snapshot_generations SET updated_at = ? WHERE account_id = ? AND mailbox = ? AND generation = ?")
+            .bind(now)
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Durably stages one bounded page of parsed replacement metadata. JSON is
+    /// intentionally stored per UID so a 100k-message replacement never needs
+    /// an in-memory `Vec<MailSummary>` at finalization time.
+    pub async fn stage_mailbox_snapshot_message_page(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        messages: &[MailSummary],
+    ) -> Result<()> {
+        let account_id = account_id.to_string();
+        if messages
+            .iter()
+            .any(|message| message.account_id != account_id || message.mailbox != mailbox)
+        {
+            return Err(anyhow!(
+                "snapshot replacement message does not match the requested account or mailbox"
+            ));
+        }
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        let active: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?)",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .bind(generation)
+        .fetch_one(&mut *tx)
+        .await?;
+        if !active {
+            tx.rollback().await?;
+            return Err(anyhow!("mailbox snapshot generation is not active"));
+        }
+        let now = Utc::now();
+        for message in messages {
+            let staged: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_items WHERE account_id = ? AND mailbox = ? AND generation = ? AND uid = ?)",
+            )
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .bind(message.uid)
+            .fetch_one(&mut *tx)
+            .await?;
+            if !staged {
+                tx.rollback().await?;
+                return Err(anyhow!(
+                    "replacement message UID is absent from the snapshot"
+                ));
+            }
+            sqlx::query("INSERT INTO mailbox_snapshot_messages(account_id, mailbox, generation, uid, message_json, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox, generation, uid) DO UPDATE SET message_json=excluded.message_json, updated_at=excluded.updated_at")
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .bind(message.uid)
+                .bind(serde_json::to_string(message).context("serialize snapshot replacement message")?)
+                .bind(now)
+                .bind(now)
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("INSERT INTO mailbox_snapshot_replacement_outcomes(account_id, mailbox, generation, uid, outcome, created_at, updated_at) VALUES (?, ?, ?, ?, 'message', ?, ?) ON CONFLICT(account_id, mailbox, generation, uid) DO UPDATE SET outcome=excluded.outcome, updated_at=excluded.updated_at")
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .bind(message.uid)
+                .bind(now)
+                .bind(now)
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ? AND uid = ?")
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(message.uid)
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Returns every staged UID newest first. This is only an inventory view,
+    /// never proof that the generation can delete absent local messages.
+    pub async fn staged_mailbox_snapshot_uids(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+    ) -> Result<Vec<u32>> {
+        let account_id = account_id.to_string();
+        let active: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?)",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .bind(generation)
+        .fetch_one(&self.pool)
+        .await?;
+        if !active {
+            return Err(anyhow!("mailbox snapshot generation is not active"));
+        }
+        let uids: Vec<i64> = sqlx::query_scalar("SELECT uid FROM mailbox_snapshot_items WHERE account_id = ? AND mailbox = ? AND generation = ? ORDER BY uid DESC")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .fetch_all(&self.pool)
+            .await?;
+        uids.into_iter()
+            .map(|uid| u32::try_from(uid).context("staged mailbox UID is invalid"))
+            .collect()
+    }
+
+    /// Returns staged UIDs that have no local message metadata yet, newest
+    /// first. Callers can fetch these headers without re-fetching rows that
+    /// were already committed by a prior incremental sync.
+    pub async fn staged_mailbox_snapshot_uids_needing_messages(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+    ) -> Result<Vec<u32>> {
+        let account_id = account_id.to_string();
+        let active: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?)",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .bind(generation)
+        .fetch_one(&self.pool)
+        .await?;
+        if !active {
+            return Err(anyhow!("mailbox snapshot generation is not active"));
+        }
+        let uids: Vec<i64> = sqlx::query_scalar("SELECT staged.uid FROM mailbox_snapshot_items AS staged LEFT JOIN messages AS message ON message.account_id = staged.account_id AND message.mailbox = staged.mailbox AND message.uid = staged.uid WHERE staged.account_id = ? AND staged.mailbox = ? AND staged.generation = ? AND message.id IS NULL ORDER BY staged.uid DESC")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .fetch_all(&self.pool)
+            .await?;
+        uids.into_iter()
+            .map(|uid| u32::try_from(uid).context("staged mailbox UID is invalid"))
+            .collect()
+    }
+
+    /// Persists provider-filtered UIDs as deliberate replacement outcomes.
+    /// They remain part of the authoritative flag inventory but must not be
+    /// repeatedly fetched as missing metadata on each resumed connection.
+    pub async fn stage_mailbox_snapshot_excluded_uids(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        uids: &[u32],
+    ) -> Result<()> {
+        if uids.contains(&0) {
+            return Err(anyhow!("snapshot excluded outcome contains UID 0"));
+        }
+        let account_id = account_id.to_string();
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        for uid in uids {
+            let staged: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_items WHERE account_id = ? AND mailbox = ? AND generation = ? AND uid = ?)",
+            )
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .bind(i64::from(*uid))
+            .fetch_one(&mut *tx)
+            .await?;
+            if !staged {
+                tx.rollback().await?;
+                return Err(anyhow!(
+                    "excluded replacement UID is absent from the snapshot"
+                ));
+            }
+            let now = Utc::now();
+            sqlx::query("INSERT INTO mailbox_snapshot_replacement_outcomes(account_id, mailbox, generation, uid, outcome, created_at, updated_at) VALUES (?, ?, ?, ?, 'excluded', ?, ?) ON CONFLICT(account_id, mailbox, generation, uid) DO UPDATE SET outcome=excluded.outcome, updated_at=excluded.updated_at")
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .bind(i64::from(*uid))
+                .bind(now)
+                .bind(now)
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM mailbox_snapshot_messages WHERE account_id = ? AND mailbox = ? AND generation = ? AND uid = ?")
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .bind(i64::from(*uid))
+                .execute(&mut *tx)
+                .await?;
+            sqlx::query("DELETE FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ? AND uid = ?")
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(i64::from(*uid))
+                .execute(&mut *tx)
+                .await?;
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Returns replacement UIDs that have not yet received either staged
+    /// metadata or a durable provider-excluded outcome, newest first.
+    pub async fn staged_mailbox_snapshot_uids_without_replacement_outcome(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+    ) -> Result<Vec<u32>> {
+        let account_id = account_id.to_string();
+        let active: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?)",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .bind(generation)
+        .fetch_one(&self.pool)
+        .await?;
+        if !active {
+            return Err(anyhow!("mailbox snapshot generation is not active"));
+        }
+        let uids: Vec<i64> = sqlx::query_scalar("SELECT item.uid FROM mailbox_snapshot_items AS item LEFT JOIN mailbox_snapshot_replacement_outcomes AS outcome ON outcome.account_id = item.account_id AND outcome.mailbox = item.mailbox AND outcome.generation = item.generation AND outcome.uid = item.uid WHERE item.account_id = ? AND item.mailbox = ? AND item.generation = ? AND outcome.uid IS NULL ORDER BY item.uid DESC")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .fetch_all(&self.pool)
+            .await?;
+        uids.into_iter()
+            .map(|uid| u32::try_from(uid).context("staged mailbox UID is invalid"))
+            .collect()
+    }
+
+    /// Makes a fully observed snapshot authoritative. Flags, absence-based
+    /// deletions, catalogue state, and staging cleanup commit together. The
+    /// caller must invoke this only after every page has received tagged OK
+    /// and mailbox identity remained stable.
+    pub async fn finalize_mailbox_snapshot(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+    ) -> Result<u64> {
+        self.finalize_mailbox_snapshot_inner(
+            account_id,
+            mailbox,
+            generation,
+            SnapshotReplacementPublication::None,
+            SnapshotFinalizeWatermark::StagedMaximum,
+        )
+        .await
+    }
+
+    /// Atomically publishes a completed snapshot and any metadata decoded in
+    /// its replacement UIDVALIDITY namespace. This is the only safe publish
+    /// path when numerical UIDs can overlap the prior namespace.
+    pub async fn finalize_mailbox_snapshot_with_replacements(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        replacements: &[MailSummary],
+    ) -> Result<u64> {
+        self.finalize_mailbox_snapshot_inner(
+            account_id,
+            mailbox,
+            generation,
+            SnapshotReplacementPublication::InMemory(replacements),
+            SnapshotFinalizeWatermark::StagedMaximum,
+        )
+        .await
+    }
+
+    /// Finalizes a snapshot using the caller-proven contiguous realtime
+    /// watermark. `None` explicitly records that this snapshot established no
+    /// safe incremental watermark, even if staged UIDs are present.
+    pub async fn finalize_mailbox_snapshot_with_replacements_and_watermark(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        replacements: &[MailSummary],
+        watermark: Option<u32>,
+    ) -> Result<u64> {
+        self.finalize_mailbox_snapshot_inner(
+            account_id,
+            mailbox,
+            generation,
+            SnapshotReplacementPublication::InMemory(replacements),
+            SnapshotFinalizeWatermark::Explicit(watermark),
+        )
+        .await
+    }
+
+    /// Atomically publishes a replacement namespace from durable, paged
+    /// generation staging rather than retaining all decoded messages in RAM.
+    pub async fn finalize_mailbox_snapshot_with_staged_replacements(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+    ) -> Result<u64> {
+        self.finalize_mailbox_snapshot_inner(
+            account_id,
+            mailbox,
+            generation,
+            SnapshotReplacementPublication::Staged,
+            SnapshotFinalizeWatermark::StagedMaximum,
+        )
+        .await
+    }
+
+    /// Realtime replacement finalization with a caller-proven contiguous
+    /// watermark. `None` is preserved as an explicit no-watermark outcome.
+    pub async fn finalize_mailbox_snapshot_with_staged_replacements_and_watermark(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        watermark: Option<u32>,
+    ) -> Result<u64> {
+        self.finalize_mailbox_snapshot_inner(
+            account_id,
+            mailbox,
+            generation,
+            SnapshotReplacementPublication::Staged,
+            SnapshotFinalizeWatermark::Explicit(watermark),
+        )
+        .await
+    }
+
+    /// Realtime callers without replacement metadata can use an explicit
+    /// contiguous watermark without constructing an empty replacement slice.
+    pub async fn finalize_mailbox_snapshot_with_watermark(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        watermark: Option<u32>,
+    ) -> Result<u64> {
+        self.finalize_mailbox_snapshot_inner(
+            account_id,
+            mailbox,
+            generation,
+            SnapshotReplacementPublication::None,
+            SnapshotFinalizeWatermark::Explicit(watermark),
+        )
+        .await
+    }
+
+    async fn finalize_mailbox_snapshot_inner(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+        replacement_publication: SnapshotReplacementPublication<'_>,
+        watermark: SnapshotFinalizeWatermark,
+    ) -> Result<u64> {
+        let account_id = account_id.to_string();
+        if let SnapshotReplacementPublication::InMemory(replacements) = replacement_publication {
+            if replacements
+                .iter()
+                .any(|message| message.account_id != account_id || message.mailbox != mailbox)
+            {
+                return Err(anyhow!(
+                    "replacement message does not match the finalized account or mailbox"
+                ));
+            }
+        }
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        let account_removed: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM deleted_account_tombstones WHERE account_id = ?)",
+        )
+        .bind(&account_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        if account_removed {
+            tx.rollback().await?;
+            return Err(anyhow!("account was removed"));
+        }
+        let generation_state: Option<(String, i64, i64, Option<i64>, Option<String>)> = sqlx::query_as(
+            "SELECT remote_name, uid_validity, initial_exists, uid_next, highest_modseq FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .bind(generation)
+        .fetch_optional(&mut *tx)
+        .await?;
+        let Some((remote_name, uid_validity, initial_exists, uid_next, highest_modseq)) =
+            generation_state
+        else {
+            tx.rollback().await?;
+            return Err(anyhow!("mailbox snapshot generation is not active"));
+        };
+        let prior_uid_validities: Vec<i64> = sqlx::query_scalar(
+            "SELECT uid_validity FROM mailbox_catalog_state WHERE account_id = ? AND mailbox = ? UNION SELECT uid_validity FROM mailbox_sync_state WHERE account_id = ? AND mailbox = ? AND uid_validity IS NOT NULL",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .bind(&account_id)
+        .bind(mailbox)
+        .fetch_all(&mut *tx)
+        .await?;
+        let replacement_namespace = !matches!(
+            replacement_publication,
+            SnapshotReplacementPublication::None
+        );
+        if let SnapshotReplacementPublication::InMemory(replacements) = replacement_publication {
+            for replacement in replacements {
+                let staged: bool = sqlx::query_scalar(
+                    "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_items WHERE account_id = ? AND mailbox = ? AND generation = ? AND uid = ?)",
+                )
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .bind(replacement.uid)
+                .fetch_one(&mut *tx)
+                .await?;
+                if !staged {
+                    tx.rollback().await?;
+                    return Err(anyhow!(
+                        "replacement message UID is absent from the finalized snapshot"
+                    ));
+                }
+            }
+        }
+        if matches!(
+            replacement_publication,
+            SnapshotReplacementPublication::Staged
+        ) {
+            let missing_outcome: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_items AS item LEFT JOIN mailbox_snapshot_replacement_outcomes AS outcome ON outcome.account_id = item.account_id AND outcome.mailbox = item.mailbox AND outcome.generation = item.generation AND outcome.uid = item.uid WHERE item.account_id = ? AND item.mailbox = ? AND item.generation = ? AND outcome.uid IS NULL)",
+            )
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .fetch_one(&mut *tx)
+            .await?;
+            let message_outcome_without_json: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM mailbox_snapshot_items AS item JOIN mailbox_snapshot_replacement_outcomes AS outcome ON outcome.account_id = item.account_id AND outcome.mailbox = item.mailbox AND outcome.generation = item.generation AND outcome.uid = item.uid AND outcome.outcome = 'message' LEFT JOIN mailbox_snapshot_messages AS message ON message.account_id = item.account_id AND message.mailbox = item.mailbox AND message.generation = item.generation AND message.uid = item.uid WHERE item.account_id = ? AND item.mailbox = ? AND item.generation = ? AND message.uid IS NULL)",
+            )
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .fetch_one(&mut *tx)
+            .await?;
+            if missing_outcome || message_outcome_without_json {
+                tx.rollback().await?;
+                return Err(anyhow!(
+                    "staged replacement snapshot is incomplete and cannot be published"
+                ));
+            }
+        }
+        if replacement_namespace {
+            clear_uidvalidity_replacement_namespace_in_transaction(&mut tx, &account_id, mailbox)
+                .await?;
+        }
+        match replacement_publication {
+            SnapshotReplacementPublication::None => {}
+            SnapshotReplacementPublication::InMemory(replacements) => {
+                for replacement in replacements {
+                    persist_message(&mut tx, replacement).await?;
+                }
+            }
+            SnapshotReplacementPublication::Staged => {
+                persist_staged_uidvalidity_replacement_messages_in_transaction(
+                    &mut tx,
+                    &account_id,
+                    mailbox,
+                    generation,
+                )
+                .await?;
+            }
+        }
+        sqlx::query("DELETE FROM message_content_cache WHERE message_id IN (SELECT message.id FROM messages AS message JOIN mailbox_snapshot_items AS staged ON staged.account_id = message.account_id AND staged.mailbox = message.mailbox AND staged.uid = message.uid WHERE staged.account_id = ? AND staged.mailbox = ? AND staged.generation = ? AND staged.is_flagged = 1)")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .execute(&mut *tx)
+            .await?;
+        for table in ["starred_message_bodies", "starred_attachment_metadata"] {
+            let statement = format!("DELETE FROM {table} WHERE message_id IN (SELECT message.id FROM messages AS message JOIN mailbox_snapshot_items AS staged ON staged.account_id = message.account_id AND staged.mailbox = message.mailbox AND staged.uid = message.uid WHERE staged.account_id = ? AND staged.mailbox = ? AND staged.generation = ? AND staged.is_flagged = 0)");
+            sqlx::query(&statement)
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .execute(&mut *tx)
+                .await?;
+        }
+        sqlx::query("UPDATE messages SET is_read = (SELECT staged.is_read FROM mailbox_snapshot_items AS staged WHERE staged.account_id = messages.account_id AND staged.mailbox = messages.mailbox AND staged.uid = messages.uid AND staged.generation = ?), is_flagged = (SELECT staged.is_flagged FROM mailbox_snapshot_items AS staged WHERE staged.account_id = messages.account_id AND staged.mailbox = messages.mailbox AND staged.uid = messages.uid AND staged.generation = ?) WHERE account_id = ? AND mailbox = ? AND EXISTS (SELECT 1 FROM mailbox_snapshot_items AS staged WHERE staged.account_id = messages.account_id AND staged.mailbox = messages.mailbox AND staged.uid = messages.uid AND staged.generation = ?)")
+            .bind(generation)
+            .bind(generation)
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .execute(&mut *tx)
+            .await?;
+        let deleted = sqlx::query("DELETE FROM messages WHERE account_id = ? AND mailbox = ? AND NOT EXISTS (SELECT 1 FROM mailbox_snapshot_items AS staged WHERE staged.account_id = messages.account_id AND staged.mailbox = messages.mailbox AND staged.generation = ? AND staged.uid = messages.uid)")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .execute(&mut *tx)
+            .await?
+            .rows_affected();
+        // A complete authoritative snapshot also proves that failures for
+        // UIDs no longer present remotely are obsolete. Failures for staged
+        // UIDs remain until their metadata fetch succeeds explicitly.
+        sqlx::query("DELETE FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ? AND NOT EXISTS (SELECT 1 FROM mailbox_snapshot_items AS staged WHERE staged.account_id = mailbox_sync_failures.account_id AND staged.mailbox = mailbox_sync_failures.mailbox AND staged.generation = ? AND staged.uid = mailbox_sync_failures.uid)")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("INSERT INTO mailbox_catalog_state(account_id, mailbox, remote_name, uid_validity, remote_total, historical_complete, uid_next, highest_modseq, updated_at) VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?) ON CONFLICT(account_id, mailbox) DO UPDATE SET remote_name=excluded.remote_name, uid_validity=excluded.uid_validity, remote_total=excluded.remote_total, historical_complete=excluded.historical_complete, uid_next=excluded.uid_next, highest_modseq=excluded.highest_modseq, updated_at=excluded.updated_at")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(remote_name)
+            .bind(uid_validity)
+            .bind(initial_exists)
+            .bind(uid_next)
+            .bind(highest_modseq)
+            .bind(Utc::now())
+            .execute(&mut *tx)
+            .await?;
+        if prior_uid_validities
+            .iter()
+            .any(|previous| *previous != uid_validity)
+        {
+            sqlx::query(
+                "DELETE FROM mailbox_action_tombstones WHERE account_id = ? AND mailbox = ?",
+            )
+            .bind(&account_id)
+            .bind(mailbox)
+            .execute(&mut *tx)
+            .await?;
+        }
+        let highest_uid = match watermark {
+            SnapshotFinalizeWatermark::StagedMaximum => {
+                sqlx::query_scalar(
+                    "SELECT MAX(uid) FROM mailbox_snapshot_items WHERE account_id = ? AND mailbox = ? AND generation = ?",
+                )
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(generation)
+                .fetch_one(&mut *tx)
+                .await?
+            }
+            SnapshotFinalizeWatermark::Explicit(watermark) => watermark.map(i64::from),
+        };
+        sqlx::query("INSERT INTO mailbox_sync_state(account_id, mailbox, initialized_at, highest_uid, uid_validity) VALUES (?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox) DO UPDATE SET initialized_at=excluded.initialized_at, highest_uid=excluded.highest_uid, uid_validity=excluded.uid_validity")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(Utc::now())
+            .bind(highest_uid)
+            .bind(uid_validity)
+            .execute(&mut *tx)
+            .await?;
+        sqlx::query("DELETE FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?")
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(generation)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        if deleted > 0 || replacement_namespace {
+            self.rebuild_threads_for_account(&account_id).await?;
+        }
+        Ok(deleted)
+    }
+
+    /// Discards an incomplete or invalidated snapshot without touching the
+    /// committed mailbox. This is the cancellation and identity-change path.
+    pub async fn discard_mailbox_snapshot(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        generation: &str,
+    ) -> Result<()> {
+        sqlx::query("DELETE FROM mailbox_snapshot_generations WHERE account_id = ? AND mailbox = ? AND generation = ?")
+            .bind(account_id.to_string())
+            .bind(mailbox)
+            .bind(generation)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Records a retryable per-UID failure. A later failure for the same UID
+    /// replaces its diagnostic while preserving the fact that it still needs
+    /// a fetch, even if newer UIDs were successfully committed.
+    pub async fn record_mailbox_sync_failure(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        uid: u32,
+        stage: &str,
+        error: &str,
+    ) -> Result<()> {
+        if uid == 0 {
+            return Err(anyhow!("mailbox sync failure contains UID 0"));
+        }
+        sqlx::query("INSERT INTO mailbox_sync_failures(account_id, mailbox, uid, stage, error, updated_at) VALUES (?, ?, ?, ?, ?, ?) ON CONFLICT(account_id, mailbox, uid) DO UPDATE SET stage=excluded.stage, error=excluded.error, updated_at=excluded.updated_at")
+            .bind(account_id.to_string())
+            .bind(mailbox)
+            .bind(i64::from(uid))
+            .bind(stage)
+            .bind(error)
+            .bind(Utc::now())
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    /// Returns outstanding failures oldest first. Retrying a permanent
+    /// failure refreshes its timestamp, allowing untouched failures to make
+    /// progress on later reconnects instead of starving behind one UID.
+    pub async fn mailbox_sync_failure_uids(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+    ) -> Result<Vec<u32>> {
+        let uids: Vec<i64> = sqlx::query_scalar(
+            "SELECT uid FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ? ORDER BY updated_at ASC, uid ASC",
+        )
+        .bind(account_id.to_string())
+        .bind(mailbox)
+        .fetch_all(&self.pool)
+        .await?;
+        uids.into_iter()
+            .map(|uid| u32::try_from(uid).context("stored failed mailbox UID is invalid"))
+            .collect()
+    }
+
+    /// Marks one previously failed UID as successfully published.
+    pub async fn clear_mailbox_sync_failure(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        uid: u32,
+    ) -> Result<()> {
+        sqlx::query(
+            "DELETE FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ? AND uid = ?",
+        )
+        .bind(account_id.to_string())
+        .bind(mailbox)
+        .bind(i64::from(uid))
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Clears a page of successfully published UIDs. An empty page is a
+    /// no-op, which makes callers safe to invoke this after every batch.
+    pub async fn clear_mailbox_sync_failures(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        uids: &[u32],
+    ) -> Result<()> {
+        if uids.is_empty() {
+            return Ok(());
+        }
+        let placeholders = vec!["?"; uids.len()].join(",");
+        let statement = format!(
+            "DELETE FROM mailbox_sync_failures WHERE account_id = ? AND mailbox = ? AND uid IN ({placeholders})"
+        );
+        let mut query = sqlx::query(&statement)
+            .bind(account_id.to_string())
+            .bind(mailbox);
+        for uid in uids {
+            query = query.bind(i64::from(*uid));
+        }
+        query.execute(&self.pool).await?;
+        Ok(())
+    }
+
+    /// Commits a complete CONDSTORE `CHANGEDSINCE` flag result. Unlike a full
+    /// snapshot, omitted UIDs are not evidence of deletion and are left
+    /// untouched. Call this only after the IMAP command received tagged OK
+    /// and the caller has confirmed the selected mailbox identity is stable.
+    pub async fn apply_complete_mailbox_changed_since_flags(
+        &self,
+        account_id: AccountId,
+        mailbox: &str,
+        remote_name: &str,
+        uid_validity: u32,
+        remote_total: usize,
+        uid_next: Option<u32>,
+        highest_modseq: Option<u64>,
+        flags: &[(u32, bool, bool)],
+    ) -> Result<()> {
+        if flags.iter().any(|(uid, _, _)| *uid == 0) {
+            return Err(anyhow!("CHANGEDSINCE flag delta contains UID 0"));
+        }
+        let remote_total =
+            i64::try_from(remote_total).context("remote mailbox total is invalid")?;
+        let account_id = account_id.to_string();
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
+        let current: Option<(String, i64, bool)> = sqlx::query_as(
+            "SELECT remote_name, uid_validity, historical_complete FROM mailbox_catalog_state WHERE account_id = ? AND mailbox = ?",
+        )
+        .bind(&account_id)
+        .bind(mailbox)
+        .fetch_optional(&mut *tx)
+        .await?;
+        if current.as_ref() != Some(&(remote_name.to_owned(), i64::from(uid_validity), true)) {
+            tx.rollback().await?;
+            return Err(anyhow!(
+                "cannot apply CHANGEDSINCE delta without a stable mailbox catalogue"
+            ));
+        }
+        for (uid, is_read, is_flagged) in flags {
+            sqlx::query("UPDATE messages SET is_read = ?, is_flagged = ? WHERE account_id = ? AND mailbox = ? AND uid = ?")
+                .bind(is_read)
+                .bind(is_flagged)
+                .bind(&account_id)
+                .bind(mailbox)
+                .bind(i64::from(*uid))
+                .execute(&mut *tx)
+                .await?;
+            if *is_flagged {
+                sqlx::query("DELETE FROM message_content_cache WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)")
+                    .bind(&account_id)
+                    .bind(mailbox)
+                    .bind(i64::from(*uid))
+                    .execute(&mut *tx)
+                    .await?;
+            } else {
+                for table in ["starred_message_bodies", "starred_attachment_metadata"] {
+                    let statement = format!("DELETE FROM {table} WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)");
+                    sqlx::query(&statement)
+                        .bind(&account_id)
+                        .bind(mailbox)
+                        .bind(i64::from(*uid))
+                        .execute(&mut *tx)
+                        .await?;
+                }
+            }
+        }
+        let updated = sqlx::query("UPDATE mailbox_catalog_state SET remote_total = ?, uid_next = ?, highest_modseq = ?, updated_at = ? WHERE account_id = ? AND mailbox = ? AND remote_name = ? AND uid_validity = ?")
+            .bind(remote_total)
+            .bind(uid_next.map(i64::from))
+            .bind(highest_modseq.map(|value| value.to_string()))
+            .bind(Utc::now())
+            .bind(&account_id)
+            .bind(mailbox)
+            .bind(remote_name)
+            .bind(i64::from(uid_validity))
+            .execute(&mut *tx)
+            .await?;
+        if updated.rows_affected() != 1 {
+            tx.rollback().await?;
+            return Err(anyhow!(
+                "mailbox identity changed while applying CHANGEDSINCE delta"
+            ));
+        }
+        tx.commit().await?;
+        Ok(())
     }
 }

--- a/docs/releases/v0.4.3.md
+++ b/docs/releases/v0.4.3.md
@@ -1,11 +1,13 @@
 # Dakia v0.4.3
 
-This update makes Dakia faster to use and better at organizing the people in your mailbox, and it adds privacy-preserving usage analytics.
+This update makes Dakia faster and more reliable with large or changing mailboxes, improves attachment names and people organization, and adds privacy-preserving usage analytics.
 
 ## What changed
 
 - **Resend sent messages.** Use the new Send again action to resend a message you have already sent.
 - **Faster archiving and read updates.** Archiving a message or marking it as read now updates instantly, with no wait on the network.
+- **More reliable mailbox syncing.** Large IMAP mailboxes now sync in bounded batches, recover more safely from interrupted rebuilds, and handle mailbox resets and server changes without leaving partial local state.
+- **Correct attachment filenames.** Encoded attachment names from more email providers are now decoded before they are shown or saved.
 - **Better people categorization.** People are now grouped more consistently across the desktop app, the CLI, and the core engine.
 - **Privacy-preserving usage analytics.** Dakia now collects minimal, privacy-preserving usage analytics to help guide development.
 

--- a/scripts/production-release-workflow.node-test.mjs
+++ b/scripts/production-release-workflow.node-test.mjs
@@ -1,0 +1,20 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const workflow = readFileSync(
+  resolve(root, ".github/workflows/production-release.yml"),
+  "utf8",
+);
+
+test("release builds run after the optional preparation job is skipped", () => {
+  const buildJob = workflow.match(/\n  build:\n([\s\S]*?)\n  publish:\n/)?.[1];
+  assert.ok(buildJob, "production release build job is missing");
+  assert.match(buildJob, /if:\s*>-\s*\n\s+always\(\)/);
+  assert.match(buildJob, /needs\.decide\.result == 'success'/);
+  assert.match(buildJob, /needs\.validate\.result == 'success'/);
+  assert.match(buildJob, /needs\.decide\.outputs\.should_release == 'true'/);
+});


### PR DESCRIPTION
## Summary

- bound IMAP commands, response parsing, mailbox discovery, and metadata fetching for large accounts
- make mailbox snapshots, UIDVALIDITY resets, failed UID retries, rebuild jobs, and credential rotation durable and atomic
- add CONDSTORE and IDLE invalidation paths with safe fallback behavior
- reload desktop state after terminal rebuild outcomes and keep account connection mutations consistent
- expand v0.4.3 release notes for the IMAP reliability work and encoded attachment filenames

## Verification

- cargo test -p dakia-core --no-fail-fast
- cargo test -p dakia-desktop --lib --no-fail-fast
- npm test
- npm run typecheck
- cargo fmt --all -- --check
- npm run format:check
- git diff --check