### PR TITLE
Stabilize Reader mailto test

### DIFF
--- a/apps/desktop/src/components/Reader.test.tsx
+++ b/apps/desktop/src/components/Reader.test.tsx
@@ -172,8 +172,8 @@ describe("Reader unsubscribe action", () => {
       const surface = documentRole.shadowRoot?.firstElementChild as
         HTMLElement | undefined;
       const nextAnchor = surface?.shadowRoot?.querySelector("a");
-      expect(nextAnchor).not.toBeNull();
-      return nextAnchor!;
+      expect(nextAnchor).toBeInstanceOf(HTMLAnchorElement);
+      return nextAnchor as HTMLAnchorElement;
     });
     fireEvent.click(anchor);
 


### PR DESCRIPTION
## Summary

- wait for a real shadow-DOM anchor before clicking the email-body mailto link
- prevent `undefined` from satisfying the test readiness assertion

## Verification

- Reader test file passed 20 consecutive runs
- full frontend suite passed: 35 files, 332 tests
- formatting and diff checks passed

This fixes the only failure in production release run 34606111659. No release artifacts were published by that failed run.