### PR TITLE
Offer sender cleanup after unsubscribe

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -11,12 +11,12 @@ use base64::{
 use dakia_core::storage::{ConversationTarget, MessageContentFetchAcquire};
 use dakia_core::{
     ai::{AiConfig, AiProvider, AiService},
-    mailbox_action_destination, provider, Account, AccountAuth, AccountDraft, Attachment,
-    CachedMessageContent, ComposeMessage, EmailClassificationInput, LocalEmailClassifier,
-    MailConversation, MailConversationPage, MailRebuildJob, MailService, MailSummary,
-    MailboxAction, ModelClassificationUpdate, OAuthFlow, OAuthProviderConfig, ProviderPreset,
-    SearchQuery, SmartInboxPage, SmartInboxQuery, Store, SyncProgress, SyncResult,
-    UnsubscribeOutcome,
+    mailbox_action_destination, normalize_sender_address, provider, Account, AccountAuth,
+    AccountDraft, Attachment, CachedMessageContent, ComposeMessage, EmailClassificationInput,
+    LocalEmailClassifier, MailConversation, MailConversationPage, MailRebuildJob, MailService,
+    MailSummary, MailboxAction, ModelClassificationUpdate, OAuthFlow, OAuthProviderConfig,
+    ProviderPreset, SearchQuery, SenderTrashResult, SmartInboxPage, SmartInboxQuery, Store,
+    SyncProgress, SyncResult, UnsubscribeOutcome,
 };
 use secrecy::SecretString;
 use serde::Deserialize;
@@ -1510,12 +1510,47 @@ struct AiInput {
 #[derive(Serialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 enum UnsubscribeResult {
-    Completed,
-    OpenedWeb,
+    Completed {
+        #[serde(rename = "cleanupTarget")]
+        cleanup_target: Option<SenderCleanupTarget>,
+    },
+    OpenedWeb {
+        #[serde(rename = "cleanupTarget")]
+        cleanup_target: Option<SenderCleanupTarget>,
+    },
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SenderCleanupTarget {
+    account_id: Uuid,
+    sender_name: Option<String>,
+    sender_address: String,
 }
 
 fn error(error: impl std::fmt::Display) -> String {
     error.to_string()
+}
+
+fn sender_cleanup_target(message: &MailSummary, account_id: Uuid) -> Option<SenderCleanupTarget> {
+    let sender_address = normalize_sender_address(&message.from_address)?;
+    let sender_name = message
+        .from_name
+        .as_deref()
+        .map(|name| {
+            name.chars()
+                .filter(|character| !character.is_control())
+                .take(256)
+                .collect::<String>()
+                .trim()
+                .to_owned()
+        })
+        .filter(|name| !name.is_empty());
+    Some(SenderCleanupTarget {
+        account_id,
+        sender_name,
+        sender_address,
+    })
 }
 
 fn unsubscribe_email(
@@ -1598,6 +1633,40 @@ mod unsubscribe_email_tests {
             "x".repeat(64 * 1024 + 1),
         )
         .is_err());
+    }
+
+    #[test]
+    fn unsubscribe_result_exposes_an_immutable_sender_cleanup_target() {
+        let result = UnsubscribeResult::OpenedWeb {
+            cleanup_target: Some(SenderCleanupTarget {
+                account_id: Uuid::nil(),
+                sender_name: Some("Newsletter".into()),
+                sender_address: "news@example.test".into(),
+            }),
+        };
+        assert_eq!(
+            serde_json::to_value(result).unwrap(),
+            serde_json::json!({
+                "kind": "opened_web",
+                "cleanupTarget": {
+                    "accountId": Uuid::nil(),
+                    "senderName": "Newsletter",
+                    "senderAddress": "news@example.test"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn malformed_sender_does_not_block_the_unsubscribe_result() {
+        assert!(normalize_sender_address("not a mailbox").is_none());
+        assert_eq!(
+            serde_json::to_value(UnsubscribeResult::Completed {
+                cleanup_target: None,
+            })
+            .unwrap(),
+            serde_json::json!({ "kind": "completed", "cleanupTarget": null })
+        );
     }
 }
 
@@ -4956,6 +5025,7 @@ async fn unsubscribe_message(
         .map_err(error)?
         .ok_or_else(|| "Message not found".to_owned())?;
     let account_id = Uuid::parse_str(&message.account_id).map_err(error)?;
+    let mut cleanup_target = sender_cleanup_target(&message, account_id);
     let _operation = state.account_operations.acquire(account_id).await;
     let account = enabled_account_for_operation(state.inner(), account_id).await?;
     let service = MailService::new(state.store.clone());
@@ -4967,15 +5037,16 @@ async fn unsubscribe_message(
         // Never retry a one-click POST: its failure may be ambiguous.
         Err(_) if message.unsubscribe_kind.as_deref() != Some("one_click") => {
             let refreshed = fetch_remote_message(state.inner(), &message_id).await?;
+            cleanup_target = sender_cleanup_target(&refreshed, account_id);
             service.unsubscribe(&refreshed).await.map_err(error)?
         }
         Err(failure) => return Err(error(failure)),
     };
     match outcome {
-        UnsubscribeOutcome::Completed => Ok(UnsubscribeResult::Completed),
+        UnsubscribeOutcome::Completed => Ok(UnsubscribeResult::Completed { cleanup_target }),
         UnsubscribeOutcome::Web(url) => {
             open_external_url(app, url)?;
-            Ok(UnsubscribeResult::OpenedWeb)
+            Ok(UnsubscribeResult::OpenedWeb { cleanup_target })
         }
         UnsubscribeOutcome::Mailto { to, subject, body } => {
             let draft = unsubscribe_email(account_id, to, subject, body)?;
@@ -4983,9 +5054,23 @@ async fn unsubscribe_message(
                 .send(&account, &draft)
                 .await
                 .map_err(error)?;
-            Ok(UnsubscribeResult::Completed)
+            Ok(UnsubscribeResult::Completed { cleanup_target })
         }
     }
+}
+
+#[tauri::command]
+async fn trash_messages_from_sender(
+    state: State<'_, Arc<AppState>>,
+    account_id: Uuid,
+    sender_address: String,
+) -> Result<SenderTrashResult, String> {
+    let _operation = state.account_operations.acquire(account_id).await;
+    let account = enabled_account_for_operation(state.inner(), account_id).await?;
+    MailService::new(state.store.clone())
+        .trash_messages_from_sender(&account, &sender_address)
+        .await
+        .map_err(error)
 }
 
 #[tauri::command]
@@ -5473,6 +5558,7 @@ pub fn run() {
             send_message,
             apply_mailbox_action,
             unsubscribe_message,
+            trash_messages_from_sender,
             ai_summarize,
             ai_draft,
             ai_available,

--- a/apps/desktop/src/App.test.tsx
+++ b/apps/desktop/src/App.test.tsx
@@ -117,7 +117,21 @@ const mocks = vi.hoisted(() => {
       starredCount: vi.fn(async () => 0),
       startRealtimeSync: vi.fn(async () => undefined),
       sync: vi.fn(async () => ({ syncedCount: 0, newMessages: [] })),
-      unsubscribe: vi.fn(async () => ({ kind: "completed" as const })),
+      unsubscribe: vi.fn(
+        async (): Promise<import("./api").UnsubscribeResult> => ({
+          kind: "completed",
+          cleanupTarget: {
+            accountId: "account-1",
+            senderName: "Sender",
+            senderAddress: "sender@example.com",
+          },
+        }),
+      ),
+      trashMessagesFromSender: vi.fn(async () => ({
+        matched: 0,
+        moved: 0,
+        failed: 0,
+      })),
     },
     windowApi: {
       show: vi.fn(async () => undefined),
@@ -2277,6 +2291,253 @@ describe("App read state", () => {
     expect(
       await screen.findByText("invalid unsubscribe email address"),
     ).toBeVisible();
+  });
+
+  it("offers sender cleanup after opening an unsubscribe page", async () => {
+    const cleanupTarget = {
+      accountId: "account-1",
+      senderName: "Sender",
+      senderAddress: "sender@example.com",
+    };
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages([
+        { ...mocks.message, unsubscribe_kind: "web" },
+        {
+          ...mocks.message,
+          id: "message-2",
+          uid: 2,
+          from_address: "not-sender@example.com",
+          subject: "Mixed sender thread",
+        },
+      ]),
+      nextCursor: null,
+    });
+    mocks.api.content.mockResolvedValue({
+      body_text: "Message body",
+      unsubscribe_kind: "web",
+      attachments: [],
+    });
+    mocks.api.unsubscribe.mockResolvedValueOnce({
+      kind: "opened_web",
+      cleanupTarget,
+    });
+    mocks.api.trashMessagesFromSender.mockResolvedValueOnce({
+      matched: 1,
+      moved: 1,
+      failed: 0,
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(
+      (await screen.findByText("Mixed sender thread")).closest("button")!,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    expect(await screen.findByText("Unsubscribe page opened.")).toBeVisible();
+
+    const cleanupButton = screen.getByRole("button", {
+      name: "Move to Trash",
+    });
+    fireEvent.click(cleanupButton);
+    fireEvent.click(cleanupButton);
+    await waitFor(() =>
+      expect(mocks.api.trashMessagesFromSender).toHaveBeenCalledWith(
+        "account-1",
+        "sender@example.com",
+      ),
+    );
+    expect(mocks.api.trashMessagesFromSender).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText("Moved 1 email to Trash")).toBeVisible();
+  });
+
+  it("keeps sender mail hidden through a stale reload while cleanup is pending", async () => {
+    let resolveCleanup: (
+      result: import("./api").TrashMessagesFromSenderResult,
+    ) => void = () => undefined;
+    let cleanupResolved = false;
+    mocks.api.search.mockImplementation(async () => ({
+      conversations: cleanupResolved ? [] : groupMessages([mocks.message]),
+      nextCursor: null,
+    }));
+    mocks.api.trashMessagesFromSender.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+    mocks.api.content.mockResolvedValue({
+      body_text: "Message body",
+      unsubscribe_kind: "one_click",
+      attachments: [],
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const list = document.querySelector<HTMLElement>(".mail-list-panel")!;
+    fireEvent.click(
+      await within(list).findByRole("checkbox", { name: "Select" }),
+    );
+    expect(within(list).getByText("1 selected")).toBeVisible();
+    fireEvent.click(
+      (await within(list).findByText("Unread thread")).closest("button")!,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Move to Trash" }),
+    );
+
+    await waitFor(() =>
+      expect(within(list).queryByText("Unread thread")).not.toBeInTheDocument(),
+    );
+    expect(within(list).queryByText("0 selected")).not.toBeInTheDocument();
+    expect(within(list).queryByText("1 selected")).not.toBeInTheDocument();
+    const searchesBeforeReload = mocks.api.search.mock.calls.length;
+    act(() => mocks.mailChangedHandlers.at(-1)!());
+    await waitFor(() =>
+      expect(mocks.api.search.mock.calls.length).toBeGreaterThan(
+        searchesBeforeReload,
+      ),
+    );
+    expect(within(list).queryByText("Unread thread")).not.toBeInTheDocument();
+
+    cleanupResolved = true;
+    await act(async () => resolveCleanup({ matched: 1, moved: 1, failed: 0 }));
+    expect(await screen.findByText("Moved 1 email to Trash")).toBeVisible();
+  });
+
+  it("restores sender mail when cleanup and reconciliation both fail", async () => {
+    let searchCount = 0;
+    mocks.api.search.mockImplementation(async () => {
+      searchCount += 1;
+      if (searchCount === 1) {
+        return {
+          conversations: groupMessages([mocks.message]),
+          nextCursor: null,
+        };
+      }
+      throw new Error("catalogue unavailable");
+    });
+    mocks.api.trashMessagesFromSender.mockRejectedValueOnce(
+      new Error("provider unavailable"),
+    );
+    mocks.api.content.mockResolvedValue({
+      body_text: "Message body",
+      unsubscribe_kind: "one_click",
+      attachments: [],
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const list = document.querySelector<HTMLElement>(".mail-list-panel")!;
+    fireEvent.click(
+      (await within(list).findByText("Unread thread")).closest("button")!,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Move to Trash" }),
+    );
+
+    expect(await within(list).findByText("Unread thread")).toBeVisible();
+    expect(
+      await screen.findByText(
+        "Could not move emails from this sender to Trash",
+      ),
+    ).toBeVisible();
+    expect(searchCount).toBeGreaterThan(1);
+  });
+
+  it("restores provider failures after a partial sender cleanup", async () => {
+    let resolveCleanup: (
+      result: import("./api").TrashMessagesFromSenderResult,
+    ) => void = () => undefined;
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages([mocks.message]),
+      nextCursor: null,
+    });
+    mocks.api.trashMessagesFromSender.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+    mocks.api.content.mockResolvedValue({
+      body_text: "Message body",
+      unsubscribe_kind: "one_click",
+      attachments: [],
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    const list = document.querySelector<HTMLElement>(".mail-list-panel")!;
+    fireEvent.click(
+      (await within(list).findByText("Unread thread")).closest("button")!,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    fireEvent.click(
+      await screen.findByRole("button", { name: "Move to Trash" }),
+    );
+    await waitFor(() =>
+      expect(within(list).queryByText("Unread thread")).not.toBeInTheDocument(),
+    );
+
+    await act(async () => resolveCleanup({ matched: 2, moved: 1, failed: 1 }));
+
+    expect(await within(list).findByText("Unread thread")).toBeVisible();
+    expect(
+      await screen.findByText(
+        "Moved 1 of 2 emails to Trash; 1 could not be moved",
+      ),
+    ).toBeVisible();
+  });
+
+  it("keeps unsubscribe successful when no safe cleanup target is available", async () => {
+    mocks.api.search.mockResolvedValue({
+      conversations: groupMessages([
+        { ...mocks.message, unsubscribe_kind: "one_click" },
+      ]),
+      nextCursor: null,
+    });
+    mocks.api.content.mockResolvedValue({
+      body_text: "Message body",
+      unsubscribe_kind: "one_click",
+      attachments: [],
+    });
+    mocks.api.unsubscribe.mockResolvedValueOnce({
+      kind: "completed",
+      cleanupTarget: null,
+    });
+
+    render(
+      <MantineProvider>
+        <App />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(
+      (await screen.findByText("Unread thread")).closest("button")!,
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+
+    expect(await screen.findByText("Unsubscribe request sent.")).toBeVisible();
+    expect(
+      screen.queryByRole("button", { name: "Move to Trash" }),
+    ).not.toBeInTheDocument();
   });
 
   it("uses incremental sync from the inbox toolbar", async () => {

--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -3,7 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 import type { TFunction } from "i18next";
 import { getCurrentWindow } from "@tauri-apps/api/window";
-import { api } from "./api";
+import {
+  api,
+  type SenderCleanupTarget,
+  type TrashMessagesFromSenderResult,
+} from "./api";
 import { AI_FEATURES_VISIBLE } from "./features";
 import { parseEmailAddressMenuAction } from "./emailAddressMenu";
 import {
@@ -145,6 +149,81 @@ function emptySmartSections(): Record<SmartSectionId, SmartSection> {
   );
 }
 
+type ActionStatusState = {
+  id: number;
+  message: string;
+  tone: "success" | "error";
+  action?: { label: string; onAction: () => void; disabled?: boolean };
+};
+
+function normalizeSenderAddress(address: string) {
+  return address
+    .trim()
+    .replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
+function isSenderCleanupMessage(
+  message: MailSummary,
+  target: SenderCleanupTarget,
+) {
+  return (
+    message.account_id === target.accountId &&
+    normalizeSenderAddress(message.from_address) ===
+      normalizeSenderAddress(target.senderAddress)
+  );
+}
+
+function removeSenderCleanupMessages(
+  threads: MailThread[],
+  target: SenderCleanupTarget,
+) {
+  return threads.flatMap((thread) => {
+    const messages = concreteThreadMessages(thread);
+    const remaining = messages.filter(
+      (message) => !isSenderCleanupMessage(message, target),
+    );
+    if (remaining.length === messages.length) return [thread];
+    return remaining.length ? groupMessages(remaining) : [];
+  });
+}
+
+function restoreSenderCleanupMessages(
+  current: MailThread[],
+  original: MailThread[],
+  target: SenderCleanupTarget,
+) {
+  const messages = new Map(
+    current
+      .flatMap(concreteThreadMessages)
+      .map((message) => [message.id, message] as const),
+  );
+  for (const message of original.flatMap(concreteThreadMessages)) {
+    if (isSenderCleanupMessage(message, target) && !messages.has(message.id))
+      messages.set(message.id, message);
+  }
+  return groupMessages([...messages.values()]);
+}
+
+function sameStringSet(left: Set<string>, right: Set<string>) {
+  return (
+    left.size === right.size && [...left].every((value) => right.has(value))
+  );
+}
+
+function senderCleanupOutcome(
+  t: ReturnType<typeof useTranslation>["t"],
+  result: TrashMessagesFromSenderResult,
+) {
+  if (result.matched === 0) return t("feedback.unsubscribeCleanupNone");
+  if (result.moved === result.matched && result.failed === 0) {
+    return t("feedback.unsubscribeCleanupSuccess", { count: result.moved });
+  }
+  if (result.moved > 0) {
+    return t("feedback.unsubscribeCleanupPartial", result);
+  }
+  return t("feedback.unsubscribeCleanupFailed");
+}
+
 export default function App() {
   const { t, i18n } = useTranslation();
   const [accounts, setAccounts] = useState<Account[]>([]);
@@ -185,6 +264,7 @@ export default function App() {
   const [aiLoading, setAiLoading] = useState(false);
   const [aiConnected, setAiConnected] = useState(false);
   const [unsubscribeLoading, setUnsubscribeLoading] = useState(false);
+  const [senderCleanupLoading, setSenderCleanupLoading] = useState(false);
   const [permanentDeleteLoading, setPermanentDeleteLoading] = useState(false);
   const [pendingActions, setPendingActions] = useState<PendingMailActions>({});
   const [outbox, setOutbox] = useState<MailSummary[]>([]);
@@ -195,15 +275,13 @@ export default function App() {
   const [retainedSmartThreads, setRetainedSmartThreads] = useState(
     new Map<string, { sectionId: SmartSectionId; thread: MailThread }>(),
   );
-  const [actionStatus, setActionStatus] = useState<{
-    id: number;
-    message: string;
-    tone: "success" | "error";
-  }>();
+  const [actionStatus, setActionStatus] = useState<ActionStatusState>();
   const [updateState, setUpdateState] = useState<UpdateBannerState>();
   const searchRef = useRef<HTMLInputElement>(null);
   const statusId = useRef(0);
   const actionBusyRef = useRef(false);
+  const senderCleanupInFlightRef = useRef(false);
+  const activeThreadRef = useRef<MailThread | undefined>(undefined);
   const mailboxActionsInFlightRef = useRef(0);
   const mailboxActionThreadIdsRef = useRef(new Set<string>());
   const readMutationGenerationRef = useRef(0);
@@ -223,9 +301,24 @@ export default function App() {
   const selectedAccountIdRef = useRef<string | undefined>(undefined);
   const removedAccountIdsRef = useRef(new Set<string>());
   const accountStateGenerationRef = useRef(0);
+  const senderCleanupTargetRef = useRef<SenderCleanupTarget | undefined>(
+    undefined,
+  );
+  const threadsRef = useRef<MailThread[]>([]);
+  const smartSectionsRef = useRef(smartSections);
+  const retainedSmartThreadsRef = useRef(retainedSmartThreads);
+  const activeRef = useRef(active);
+  const activeThreadSnapshotRef = useRef(activeThreadSnapshot);
+  const selectedRef = useRef(selected);
 
   accountsRef.current = accounts;
   selectedAccountIdRef.current = selectedAccountId;
+  threadsRef.current = threads;
+  smartSectionsRef.current = smartSections;
+  retainedSmartThreadsRef.current = retainedSmartThreads;
+  activeRef.current = active;
+  activeThreadSnapshotRef.current = activeThreadSnapshot;
+  selectedRef.current = selected;
 
   useEffect(
     () => () => {
@@ -235,15 +328,19 @@ export default function App() {
   );
 
   const showStatus = useCallback(
-    (message: string, tone: "success" | "error" = "success") => {
+    (
+      message: string,
+      tone: "success" | "error" = "success",
+      action?: ActionStatusState["action"],
+    ) => {
       statusId.current += 1;
-      setActionStatus({ id: statusId.current, message, tone });
+      setActionStatus({ id: statusId.current, message, tone, action });
     },
     [],
   );
 
   useEffect(() => {
-    if (!actionStatus) return;
+    if (!actionStatus || actionStatus.action) return;
     const timer = window.setTimeout(() => setActionStatus(undefined), 2500);
     return () => window.clearTimeout(timer);
   }, [actionStatus]);
@@ -465,12 +562,18 @@ export default function App() {
           setSmartSections(() => {
             const next = emptySmartSections();
             for (const section of page.sections) {
+              const visible = excludeThreads(
+                section.conversations,
+                mailboxActionThreadIdsRef.current,
+              );
               next[section.id] = {
                 id: section.id,
-                threads: excludeThreads(
-                  section.conversations,
-                  mailboxActionThreadIdsRef.current,
-                ),
+                threads: senderCleanupTargetRef.current
+                  ? removeSenderCleanupMessages(
+                      visible,
+                      senderCleanupTargetRef.current,
+                    )
+                  : visible,
                 nextCursor: section.nextCursor,
                 loadingMore: false,
               };
@@ -503,8 +606,17 @@ export default function App() {
         sameMailView(currentView, currentViewRef.current)
       ) {
         nextCursorRef.current = page.nextCursor;
+        const visible = excludeThreads(
+          page.conversations,
+          mailboxActionThreadIdsRef.current,
+        );
         setThreads(
-          excludeThreads(page.conversations, mailboxActionThreadIdsRef.current),
+          senderCleanupTargetRef.current
+            ? removeSenderCleanupMessages(
+                visible,
+                senderCleanupTargetRef.current,
+              )
+            : visible,
         );
         setHasMore(page.nextCursor !== null);
       }
@@ -527,15 +639,21 @@ export default function App() {
             for (const thread of groupMessages(remote)) {
               if (!merged.has(thread.id)) merged.set(thread.id, thread);
             }
-            setThreads(
-              excludeThreads(
-                [...merged.values()].sort(
-                  (left, right) =>
-                    new Date(right.latest.received_at).getTime() -
-                    new Date(left.latest.received_at).getTime(),
-                ),
-                mailboxActionThreadIdsRef.current,
+            const visible = excludeThreads(
+              [...merged.values()].sort(
+                (left, right) =>
+                  new Date(right.latest.received_at).getTime() -
+                  new Date(left.latest.received_at).getTime(),
               ),
+              mailboxActionThreadIdsRef.current,
+            );
+            setThreads(
+              senderCleanupTargetRef.current
+                ? removeSenderCleanupMessages(
+                    visible,
+                    senderCleanupTargetRef.current,
+                  )
+                : visible,
             );
           }
         } catch {
@@ -1202,6 +1320,7 @@ export default function App() {
         : undefined,
     [active, activeThreadSnapshot, displayedThreads],
   );
+  activeThreadRef.current = activeThread;
   const targetThreads = selected.size
     ? displayedThreads.filter((thread) => selected.has(thread.id))
     : activeThread
@@ -1949,16 +2068,209 @@ export default function App() {
     }
     if (smartInboxActive) await loadMessages();
   };
+  const trashMessagesFromSender = async (target: SenderCleanupTarget) => {
+    if (senderCleanupInFlightRef.current) return;
+    senderCleanupInFlightRef.current = true;
+    senderCleanupTargetRef.current = target;
+    const originalThreads = threadsRef.current;
+    const originalSmartSections = smartSectionsRef.current;
+    const originalRetainedSmartThreads = retainedSmartThreadsRef.current;
+    const originalActive = activeRef.current;
+    const originalActiveThreadSnapshot = activeThreadSnapshotRef.current;
+    const originalSelected = new Set(selectedRef.current);
+    const originalVisibleThreads = [
+      ...originalThreads,
+      ...smartSectionIds.flatMap((id) => originalSmartSections[id].threads),
+    ];
+    const optimisticSelected = new Set(originalSelected);
+    for (const id of originalSelected) {
+      const matchingThreads = originalVisibleThreads.filter(
+        (thread) => thread.id === id,
+      );
+      if (
+        matchingThreads.length > 0 &&
+        matchingThreads.every(
+          (thread) =>
+            removeSenderCleanupMessages([thread], target).length === 0,
+        )
+      )
+        optimisticSelected.delete(id);
+    }
+    const originalView = {
+      ...currentViewRef.current,
+      accountIds: [...currentViewRef.current.accountIds],
+    };
+    const restoreOptimisticMessages = () => {
+      if (!sameMailView(originalView, currentViewRef.current)) return;
+      setSelected((current) =>
+        sameStringSet(current, optimisticSelected) ? originalSelected : current,
+      );
+      setThreads((current) =>
+        restoreSenderCleanupMessages(current, originalThreads, target),
+      );
+      setSmartSections(
+        (current) =>
+          Object.fromEntries(
+            smartSectionIds.map((id) => [
+              id,
+              {
+                ...current[id],
+                threads: restoreSenderCleanupMessages(
+                  current[id].threads,
+                  originalSmartSections[id].threads,
+                  target,
+                ),
+              },
+            ]),
+          ) as Record<SmartSectionId, SmartSection>,
+      );
+      setRetainedSmartThreads((current) => {
+        const next = new Map(current);
+        for (const [id, retained] of originalRetainedSmartThreads) {
+          if (
+            concreteThreadMessages(retained.thread).some((message) =>
+              isSenderCleanupMessage(message, target),
+            )
+          ) {
+            const currentRetained = next.get(id);
+            next.set(
+              id,
+              currentRetained
+                ? {
+                    ...currentRetained,
+                    thread: restoreSenderCleanupMessages(
+                      [currentRetained.thread],
+                      [retained.thread],
+                      target,
+                    )[0],
+                  }
+                : retained,
+            );
+          }
+        }
+        return next;
+      });
+      setActive((current) => {
+        if (current) return current;
+        return originalActive && isSenderCleanupMessage(originalActive, target)
+          ? originalActive
+          : current;
+      });
+      setActiveThreadSnapshot((current) => {
+        if (!originalActiveThreadSnapshot) return current;
+        if (current && current.id !== originalActiveThreadSnapshot.id)
+          return current;
+        return restoreSenderCleanupMessages(
+          current ? [current] : [],
+          [originalActiveThreadSnapshot],
+          target,
+        )[0];
+      });
+    };
+    setActionStatus(undefined);
+    setSenderCleanupLoading(true);
+    loadRequestIdRef.current += 1;
+    smartLoadRequestIdRef.current += 1;
+    setSelected(optimisticSelected);
+    setThreads((current) => removeSenderCleanupMessages(current, target));
+    setSmartSections(
+      (current) =>
+        Object.fromEntries(
+          smartSectionIds.map((id) => [
+            id,
+            {
+              ...current[id],
+              threads: removeSenderCleanupMessages(current[id].threads, target),
+            },
+          ]),
+        ) as Record<SmartSectionId, SmartSection>,
+    );
+    setRetainedSmartThreads((current) => {
+      const next = new Map(current);
+      for (const [id, retained] of next) {
+        const thread = removeSenderCleanupMessages(
+          [retained.thread],
+          target,
+        )[0];
+        if (thread) next.set(id, { ...retained, thread });
+        else next.delete(id);
+      }
+      return next;
+    });
+    const currentActiveThread = activeThreadRef.current;
+    const remainingActiveThread = currentActiveThread
+      ? removeSenderCleanupMessages([currentActiveThread], target)[0]
+      : undefined;
+    setActive((current) =>
+      current && isSenderCleanupMessage(current, target)
+        ? remainingActiveThread?.latest
+        : current,
+    );
+    setActiveThreadSnapshot((current) =>
+      current ? removeSenderCleanupMessages([current], target)[0] : current,
+    );
+    setAiResult(undefined);
+    try {
+      let result: TrashMessagesFromSenderResult;
+      try {
+        result = await api.trashMessagesFromSender(
+          target.accountId,
+          target.senderAddress,
+        );
+      } catch {
+        senderCleanupTargetRef.current = undefined;
+        restoreOptimisticMessages();
+        try {
+          await loadMessages();
+        } catch (error) {
+          console.warn("Could not reconcile sender cleanup", error);
+        }
+        showStatus(t("feedback.unsubscribeCleanupFailed"), "error");
+        return;
+      }
+      senderCleanupTargetRef.current = undefined;
+      if (
+        result.failed > 0 ||
+        result.moved === 0 ||
+        result.moved !== result.matched
+      )
+        restoreOptimisticMessages();
+      try {
+        await loadMessages();
+      } catch (error) {
+        console.warn("Could not reconcile sender cleanup", error);
+      }
+      showStatus(
+        senderCleanupOutcome(t, result),
+        result.failed || result.moved !== result.matched ? "error" : "success",
+      );
+    } finally {
+      senderCleanupTargetRef.current = undefined;
+      senderCleanupInFlightRef.current = false;
+      setSenderCleanupLoading(false);
+    }
+  };
   const unsubscribe = async (message: MailSummary) => {
     if (unsubscribeLoading) return;
     setUnsubscribeLoading(true);
     try {
       const result = await api.unsubscribe(message.id);
-      if (result.kind === "opened_web") {
-        showStatus(t("feedback.unsubscribeWeb"));
-      } else {
-        showStatus(t("feedback.unsubscribeSuccess"));
-      }
+      showStatus(
+        t(
+          result.kind === "opened_web"
+            ? "feedback.unsubscribeWeb"
+            : "feedback.unsubscribeSuccess",
+        ),
+        "success",
+        result.cleanupTarget
+          ? {
+              label: t("feedback.unsubscribeCleanupAction"),
+              onAction: () =>
+                void trashMessagesFromSender(result.cleanupTarget!),
+              disabled: senderCleanupLoading,
+            }
+          : undefined,
+      );
     } catch (error) {
       showStatus(
         error instanceof Error
@@ -2523,6 +2835,11 @@ export default function App() {
           key={actionStatus.id}
           message={actionStatus.message}
           tone={actionStatus.tone}
+          action={actionStatus.action}
+          dismiss={{
+            label: t("actions.close"),
+            onDismiss: () => setActionStatus(undefined),
+          }}
         />
       ) : null}
       {analyticsConsentDialog}

--- a/apps/desktop/src/ReaderWindowApp.test.tsx
+++ b/apps/desktop/src/ReaderWindowApp.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@testing-library/react";
 import { MantineProvider } from "@mantine/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ReaderWindowSeed } from "./readerWindow";
 import type { MailSummary, MailThread } from "./types";
 
 const mocks = vi.hoisted(() => ({
@@ -21,6 +22,7 @@ const mocks = vi.hoisted(() => ({
     showEmailAddressContextMenu: vi.fn(),
     summarize: vi.fn(),
     unsubscribe: vi.fn(),
+    trashMessagesFromSender: vi.fn(),
   },
   closeReaderWindow: vi.fn(),
   notifyReaderWindowMutated: vi.fn(),
@@ -61,6 +63,7 @@ vi.mock("./components/Reader", () => ({
     onAddressContextMenu,
     onPermanentDelete,
     onSendAgain,
+    onUnsubscribe,
   }: {
     message?: MailSummary;
     messages?: MailSummary[];
@@ -69,6 +72,7 @@ vi.mock("./components/Reader", () => ({
     onAddressContextMenu: (message: MailSummary, address: string) => void;
     onPermanentDelete: (message: MailSummary) => void;
     onSendAgain: (message: MailSummary) => void;
+    onUnsubscribe: (message: MailSummary) => void;
   }) => (
     <div>
       <span data-testid="focused-message">{message?.id}</span>
@@ -100,6 +104,9 @@ vi.mock("./components/Reader", () => ({
         onClick={() => message && onPermanentDelete(message)}
       >
         Permanently delete
+      </button>
+      <button type="button" onClick={() => message && onUnsubscribe(message)}>
+        Unsubscribe
       </button>
     </div>
   ),
@@ -181,6 +188,19 @@ describe("ReaderWindowApp", () => {
     mocks.api.action.mockResolvedValue(undefined);
     mocks.api.setRead.mockResolvedValue(undefined);
     mocks.api.showEmailAddressContextMenu.mockResolvedValue(undefined);
+    mocks.api.unsubscribe.mockResolvedValue({
+      kind: "completed",
+      cleanupTarget: {
+        accountId: "account-1",
+        senderName: "Mara",
+        senderAddress: "mara@example.com",
+      },
+    });
+    mocks.api.trashMessagesFromSender.mockResolvedValue({
+      matched: 1,
+      moved: 1,
+      failed: 0,
+    });
     mocks.onReaderTarget.mockResolvedValue(() => undefined);
     mocks.notifyReaderWindowMutated.mockResolvedValue(undefined);
   });
@@ -257,6 +277,201 @@ describe("ReaderWindowApp", () => {
       messageIds: ["message-1"],
       mutation: "archive",
     });
+  });
+
+  it("offers sender cleanup, preserves mixed-sender mail, and refreshes main", async () => {
+    const remainingThread = {
+      ...thread,
+      messages: [messages[1]],
+      sourceMessages: [messages[1]],
+      latest: messages[1],
+      unread: true,
+    };
+    mocks.api.conversationForTarget
+      .mockResolvedValueOnce(thread)
+      .mockResolvedValueOnce(remainingThread);
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    expect(
+      await screen.findByText("feedback.unsubscribeSuccess"),
+    ).toBeVisible();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "feedback.unsubscribeCleanupAction",
+      }),
+    );
+
+    await waitFor(() =>
+      expect(mocks.api.trashMessagesFromSender).toHaveBeenCalledWith(
+        "account-1",
+        "mara@example.com",
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("conversation-count")).toHaveTextContent("1"),
+    );
+    expect(mocks.notifyReaderWindowMutated).toHaveBeenLastCalledWith({
+      accountId: "account-1",
+      threadId: "thread-1",
+      messageIds: ["message-1"],
+      mutation: "trash",
+    });
+  });
+
+  it("does not replace a new reader target when an old sender cleanup finishes", async () => {
+    let readerTargetHandler: (seed: ReaderWindowSeed) => void = () => undefined;
+    let resolveCleanup: (
+      result: import("./api").TrashMessagesFromSenderResult,
+    ) => void = () => undefined;
+    const messageB: MailSummary = {
+      ...messages[1],
+      id: "message-b",
+      account_id: "account-2",
+      thread_id: "thread-b",
+      subject: "Target B",
+    };
+    const threadB: MailThread = {
+      ...thread,
+      id: "account-2:thread-b",
+      accountId: "account-2",
+      threadId: "thread-b",
+      messages: [messageB],
+      latest: messageB,
+    };
+    const seedB: ReaderWindowSeed = {
+      target: {
+        accountId: "account-2",
+        threadId: "thread-b",
+        localMessageId: "message-b",
+      },
+      focusedMessageId: "message-b",
+    };
+    mocks.onReaderTarget.mockImplementationOnce(async (handler) => {
+      readerTargetHandler = handler;
+      return () => undefined;
+    });
+    mocks.api.accounts.mockResolvedValue([
+      { id: "account-1", email: "alex@example.com" },
+      { id: "account-2", email: "sam@example.com" },
+    ]);
+    mocks.api.conversationForTarget.mockImplementation(async (target) =>
+      target.accountId === "account-2" ? threadB : thread,
+    );
+    mocks.api.trashMessagesFromSender.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveCleanup = resolve;
+        }),
+    );
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "feedback.unsubscribeCleanupAction",
+      }),
+    );
+    await waitFor(() =>
+      expect(mocks.api.trashMessagesFromSender).toHaveBeenCalledOnce(),
+    );
+
+    act(() => readerTargetHandler(seedB));
+    expect(await screen.findByTestId("focused-message")).toHaveTextContent(
+      "message-b",
+    );
+
+    await act(async () => resolveCleanup({ matched: 1, moved: 1, failed: 0 }));
+    await waitFor(() =>
+      expect(mocks.api.conversationForTarget.mock.calls.length).toBeGreaterThan(
+        2,
+      ),
+    );
+    expect(screen.getByTestId("focused-message")).toHaveTextContent(
+      "message-b",
+    );
+  });
+
+  it("restores the reader snapshot when partial cleanup cannot reconcile", async () => {
+    mocks.api.conversationForTarget
+      .mockResolvedValueOnce(thread)
+      .mockRejectedValueOnce(new Error("catalogue unavailable"));
+    mocks.api.trashMessagesFromSender.mockResolvedValueOnce({
+      matched: 2,
+      moved: 1,
+      failed: 1,
+    });
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "feedback.unsubscribeCleanupAction",
+      }),
+    );
+
+    expect(
+      await screen.findByText("feedback.unsubscribeCleanupPartial"),
+    ).toBeVisible();
+    expect(screen.getByTestId("conversation-count")).toHaveTextContent("2");
+    expect(mocks.closeReaderWindow).not.toHaveBeenCalled();
+  });
+
+  it("closes an empty reader even when notifying the main window fails", async () => {
+    const senderOnlyThread: MailThread = {
+      ...thread,
+      messages: [messages[0]],
+      latest: messages[0],
+      unread: false,
+    };
+    mocks.readReaderSeed.mockReturnValue({
+      target: {
+        accountId: "account-1",
+        threadId: "thread-1",
+        localMessageId: "message-1",
+      },
+      focusedMessageId: "message-1",
+    });
+    mocks.api.conversationForTarget
+      .mockResolvedValueOnce(senderOnlyThread)
+      .mockResolvedValueOnce(null);
+    mocks.notifyReaderWindowMutated
+      .mockRejectedValueOnce(new Error("main window unavailable"))
+      .mockRejectedValueOnce(new Error("main window unavailable"));
+    const { ReaderWindowApp } = await import("./ReaderWindowApp");
+    render(
+      <MantineProvider>
+        <ReaderWindowApp />
+      </MantineProvider>,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: "Unsubscribe" }));
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "feedback.unsubscribeCleanupAction",
+      }),
+    );
+
+    await waitFor(() => expect(mocks.closeReaderWindow).toHaveBeenCalledOnce());
+    expect(mocks.api.trashMessagesFromSender).toHaveBeenCalledWith(
+      "account-1",
+      "mara@example.com",
+    );
   });
 
   it("routes a native archive command to the visible reader conversation", async () => {

--- a/apps/desktop/src/ReaderWindowApp.tsx
+++ b/apps/desktop/src/ReaderWindowApp.tsx
@@ -1,8 +1,13 @@
 import { Loader } from "@mantine/core";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { api } from "./api";
+import {
+  api,
+  type SenderCleanupTarget,
+  type TrashMessagesFromSenderResult,
+} from "./api";
 import { openComposeWindow } from "./composeWindow";
+import { ActionStatus } from "./components/ActionStatus";
 import { Reader } from "./components/Reader";
 import { parseEmailAddressMenuAction } from "./emailAddressMenu";
 import { AI_FEATURES_VISIBLE } from "./features";
@@ -26,7 +31,7 @@ import {
 import { replyRecipients } from "./recipients";
 import { formatReplyHistory } from "./replyHistory";
 import type { AiSettings, MailSummary, MailThread } from "./types";
-import { concreteThreadMessages } from "./threads";
+import { concreteThreadMessages, groupMessages } from "./threads";
 
 const defaultAi: AiSettings = {
   provider: "ollama",
@@ -39,6 +44,58 @@ const defaultAi: AiSettings = {
 
 const readerApi = api;
 
+type ActionStatusState = {
+  id: number;
+  message: string;
+  tone: "success" | "error";
+  action?: { label: string; onAction: () => void; disabled?: boolean };
+};
+
+function normalizeSenderAddress(address: string) {
+  return address
+    .trim()
+    .replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
+function isSenderCleanupMessage(
+  message: MailSummary,
+  target: SenderCleanupTarget,
+) {
+  return (
+    message.account_id === target.accountId &&
+    normalizeSenderAddress(message.from_address) ===
+      normalizeSenderAddress(target.senderAddress)
+  );
+}
+
+function removeSenderCleanupMessages(
+  thread: MailThread,
+  target: SenderCleanupTarget,
+) {
+  const messages = concreteThreadMessages(thread);
+  const remaining = messages.filter(
+    (message) => !isSenderCleanupMessage(message, target),
+  );
+  if (remaining.length === messages.length) return thread;
+  return remaining.length
+    ? { ...thread, ...groupMessages(remaining)[0] }
+    : undefined;
+}
+
+function senderCleanupOutcome(
+  t: ReturnType<typeof useTranslation>["t"],
+  result: TrashMessagesFromSenderResult,
+) {
+  if (result.matched === 0) return t("feedback.unsubscribeCleanupNone");
+  if (result.moved === result.matched && result.failed === 0) {
+    return t("feedback.unsubscribeCleanupSuccess", { count: result.moved });
+  }
+  if (result.moved > 0) {
+    return t("feedback.unsubscribeCleanupPartial", result);
+  }
+  return t("feedback.unsubscribeCleanupFailed");
+}
+
 export function ReaderWindowApp() {
   const { t } = useTranslation();
   const [seed, setSeed] = useState<ReaderWindowSeed | undefined>(
@@ -49,16 +106,25 @@ export function ReaderWindowApp() {
   const [loading, setLoading] = useState(Boolean(seed));
   const [actionBusy, setActionBusy] = useState(false);
   const [unsubscribeLoading, setUnsubscribeLoading] = useState(false);
+  const [senderCleanupLoading, setSenderCleanupLoading] = useState(false);
+  const [actionStatus, setActionStatus] = useState<ActionStatusState>();
   const [aiLoading, setAiLoading] = useState(false);
   const [aiResult, setAiResult] = useState<string>();
   const [aiConnected, setAiConnected] = useState(false);
   const loadGeneration = useRef(0);
+  const statusId = useRef(0);
+  const senderCleanupInFlightRef = useRef(false);
+  const actionBusyRef = useRef(false);
+  const threadRef = useRef<MailThread | undefined>(undefined);
   const translate = useRef(t);
   translate.current = t;
   const aiSettings = useMemo(() => readAiSettings(), []);
+  actionBusyRef.current = actionBusy;
+  threadRef.current = thread;
 
   const loadThread = useCallback(async (nextSeed: ReaderWindowSeed) => {
     const generation = ++loadGeneration.current;
+    setActionStatus(undefined);
     setLoading(true);
     setThread(undefined);
     setAiResult(undefined);
@@ -160,7 +226,11 @@ export function ReaderWindowApp() {
   useEffect(() => {
     let dispose: () => void = () => undefined;
     let disposed = false;
-    void onReaderTarget((nextSeed) => setSeed(nextSeed)).then((unlisten) => {
+    void onReaderTarget((nextSeed) => {
+      loadGeneration.current += 1;
+      setActionStatus(undefined);
+      setSeed(nextSeed);
+    }).then((unlisten) => {
       if (disposed) unlisten();
       else dispose = unlisten;
     });
@@ -453,14 +523,135 @@ export function ReaderWindowApp() {
     }
   };
 
+  const showStatus = useCallback(
+    (
+      message: string,
+      tone: "success" | "error" = "success",
+      action?: ActionStatusState["action"],
+    ) => {
+      statusId.current += 1;
+      setActionStatus({ id: statusId.current, message, tone, action });
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!actionStatus || actionStatus.action) return;
+    const timer = window.setTimeout(() => setActionStatus(undefined), 2500);
+    return () => window.clearTimeout(timer);
+  }, [actionStatus]);
+
+  const refreshAfterSenderCleanup = async (expectedGeneration: number) => {
+    if (!seed) return;
+    const refreshed = await readerApi.conversationForTarget(seed.target);
+    if (loadGeneration.current !== expectedGeneration) return;
+    setThread(refreshed ?? undefined);
+    if (!refreshed) await closeReaderWindow();
+  };
+
+  const trashMessagesFromSender = async (target: SenderCleanupTarget) => {
+    const currentThread = threadRef.current;
+    if (
+      senderCleanupInFlightRef.current ||
+      actionBusyRef.current ||
+      !currentThread
+    )
+      return;
+    senderCleanupInFlightRef.current = true;
+    const cleanupGeneration = loadGeneration.current;
+    const removedMessageIds = concreteThreadMessages(currentThread)
+      .filter((message) => isSenderCleanupMessage(message, target))
+      .map((message) => message.id);
+    setActionStatus(undefined);
+    setSenderCleanupLoading(true);
+    setThread((current) =>
+      current ? removeSenderCleanupMessages(current, target) : current,
+    );
+    let result: TrashMessagesFromSenderResult;
+    try {
+      result = await readerApi.trashMessagesFromSender(
+        target.accountId,
+        target.senderAddress,
+      );
+    } catch (error) {
+      if (loadGeneration.current === cleanupGeneration)
+        setThread(currentThread);
+      try {
+        await refreshAfterSenderCleanup(cleanupGeneration);
+      } catch (refreshError) {
+        console.warn("Could not reconcile sender cleanup", refreshError);
+      }
+      if (loadGeneration.current === cleanupGeneration)
+        showStatus(t("feedback.unsubscribeCleanupFailed"), "error");
+      console.warn("Could not move sender messages to Trash", error);
+      senderCleanupInFlightRef.current = false;
+      setSenderCleanupLoading(false);
+      return;
+    }
+    if (
+      loadGeneration.current === cleanupGeneration &&
+      (result.failed > 0 ||
+        result.moved === 0 ||
+        result.moved !== result.matched)
+    )
+      setThread(currentThread);
+    try {
+      await notifyMutation("trash", removedMessageIds);
+    } catch (error) {
+      console.warn(
+        "Could not notify the main window about sender cleanup",
+        error,
+      );
+    }
+    try {
+      await refreshAfterSenderCleanup(cleanupGeneration);
+    } catch (error) {
+      console.warn("Could not reconcile sender cleanup", error);
+    }
+    if (loadGeneration.current === cleanupGeneration)
+      showStatus(
+        senderCleanupOutcome(t, result),
+        result.failed || result.moved !== result.matched ? "error" : "success",
+      );
+    senderCleanupInFlightRef.current = false;
+    setSenderCleanupLoading(false);
+  };
+
   const unsubscribe = async (message: MailSummary) => {
     if (unsubscribeLoading) return;
     setUnsubscribeLoading(true);
     try {
-      await readerApi.unsubscribe(message.id);
-      await notifyMutation("unsubscribe", [message.id]);
-    } catch (error) {
-      showError(error);
+      let result: Awaited<ReturnType<typeof readerApi.unsubscribe>>;
+      try {
+        result = await readerApi.unsubscribe(message.id);
+      } catch (error) {
+        showError(error);
+        return;
+      }
+      try {
+        await notifyMutation("unsubscribe", [message.id]);
+      } catch (error) {
+        console.warn(
+          "Could not notify the main window about unsubscribe",
+          error,
+        );
+      }
+      showStatus(
+        t(
+          result.kind === "opened_web"
+            ? "feedback.unsubscribeWeb"
+            : "feedback.unsubscribeSuccess",
+        ),
+        "success",
+        result.cleanupTarget
+          ? {
+              label: t("feedback.unsubscribeCleanupAction"),
+              onAction: () =>
+                void trashMessagesFromSender(result.cleanupTarget!),
+              disabled: senderCleanupLoading,
+            }
+          : undefined,
+      );
     } finally {
       setUnsubscribeLoading(false);
     }
@@ -587,6 +778,18 @@ export function ReaderWindowApp() {
         onUnsubscribe={(message) => void unsubscribe(message)}
         onToggleStar={(message, starred) => void toggleStar(message, starred)}
       />
+      {actionStatus ? (
+        <ActionStatus
+          key={actionStatus.id}
+          message={actionStatus.message}
+          tone={actionStatus.tone}
+          action={actionStatus.action}
+          dismiss={{
+            label: t("actions.close"),
+            onDismiss: () => setActionStatus(undefined),
+          }}
+        />
+      ) : null}
     </div>
   );
 

--- a/apps/desktop/src/api.ts
+++ b/apps/desktop/src/api.ts
@@ -35,6 +35,12 @@ const messageContentErrorKinds = new Set<MessageContentErrorKind>([
   "transient",
 ]);
 
+function normalizeSenderAddress(address: string) {
+  return address
+    .trim()
+    .replace(/[A-Z]/g, (character) => character.toLowerCase());
+}
+
 export class MessageContentError extends Error {
   readonly retryable: boolean;
 
@@ -228,6 +234,11 @@ const desktopApi = {
   openExternal: (url: string) => invoke<void>("open_external_url", { url }),
   unsubscribe: (messageId: string) =>
     invoke<UnsubscribeResult>("unsubscribe_message", { messageId }),
+  trashMessagesFromSender: (accountId: string, senderAddress: string) =>
+    invoke<TrashMessagesFromSenderResult>("trash_messages_from_sender", {
+      accountId,
+      senderAddress,
+    }),
   summarize: (settings: AiSettings, messageIds: string[]) =>
     invoke<string>("ai_summarize", { input: aiInput(settings, messageIds) }),
   draft: (settings: AiSettings, messageIds: string[], instruction: string) =>
@@ -262,7 +273,21 @@ const desktopApi = {
     invoke<void>("translation_remove_model", { source }),
 };
 
-export type UnsubscribeResult = { kind: "completed" } | { kind: "opened_web" };
+export type SenderCleanupTarget = {
+  readonly accountId: string;
+  readonly senderName: string | null;
+  readonly senderAddress: string;
+};
+
+export type UnsubscribeResult =
+  | { kind: "completed"; cleanupTarget: SenderCleanupTarget | null }
+  | { kind: "opened_web"; cleanupTarget: SenderCleanupTarget | null };
+
+export type TrashMessagesFromSenderResult = {
+  matched: number;
+  moved: number;
+  failed: number;
+};
 
 const aiInput = (settings: AiSettings, messageIds: string[]) => ({
   provider: settings.provider,
@@ -688,7 +713,24 @@ const demoApi: typeof desktopApi = {
   openExternal: async (url) => {
     window.open(url, "_blank", "noopener,noreferrer");
   },
-  unsubscribe: async () => ({ kind: "completed" }),
+  unsubscribe: async () => ({
+    kind: "completed" as const,
+    cleanupTarget: {
+      accountId: demoAccount.id,
+      senderName: "Mara Chen",
+      senderAddress: "mara@example.com",
+    },
+  }),
+  trashMessagesFromSender: async (accountId, senderAddress) => {
+    const normalized = normalizeSenderAddress(senderAddress);
+    const matches = demoMessages.filter(
+      (message) =>
+        message.account_id === accountId &&
+        normalizeSenderAddress(message.from_address) === normalized,
+    );
+    for (const message of matches) message.mailbox = "Trash";
+    return { matched: matches.length, moved: matches.length, failed: 0 };
+  },
   summarize: async () =>
     "Mara confirmed that notarization credentials are ready for Friday and the Linux smoke test is scheduled for Monday. She needs confirmation of who owns the final provider matrix.",
   draft: async () =>

--- a/apps/desktop/src/components/ActionStatus.test.tsx
+++ b/apps/desktop/src/components/ActionStatus.test.tsx
@@ -1,0 +1,23 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ActionStatus } from "./ActionStatus";
+
+describe("ActionStatus", () => {
+  it("exposes an optional action and dismiss control", () => {
+    const onAction = vi.fn();
+    const onDismiss = vi.fn();
+    render(
+      <ActionStatus
+        message="Unsubscribe request sent"
+        action={{ label: "Move to Trash", onAction }}
+        dismiss={{ label: "Dismiss", onDismiss }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Move to Trash" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dismiss" }));
+
+    expect(onAction).toHaveBeenCalledOnce();
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/components/ActionStatus.tsx
+++ b/apps/desktop/src/components/ActionStatus.tsx
@@ -1,11 +1,22 @@
-import { IconAlertCircle, IconCheck } from "@tabler/icons-react";
+import { IconAlertCircle, IconCheck, IconX } from "@tabler/icons-react";
 
 type Props = {
   message: string;
   tone?: "success" | "error";
+  action?: {
+    label: string;
+    onAction: () => void;
+    disabled?: boolean;
+  };
+  dismiss?: { label: string; onDismiss: () => void };
 };
 
-export function ActionStatus({ message, tone = "success" }: Props) {
+export function ActionStatus({
+  message,
+  tone = "success",
+  action,
+  dismiss,
+}: Props) {
   return (
     <div
       className="action-status"
@@ -20,6 +31,26 @@ export function ActionStatus({ message, tone = "success" }: Props) {
         <IconCheck size={16} stroke={2.2} />
       )}
       <span>{message}</span>
+      {action ? (
+        <button
+          type="button"
+          className="action-status-action"
+          onClick={action.onAction}
+          disabled={action.disabled}
+        >
+          {action.label}
+        </button>
+      ) : null}
+      {dismiss ? (
+        <button
+          type="button"
+          className="action-status-dismiss"
+          onClick={dismiss.onDismiss}
+          aria-label={dismiss.label}
+        >
+          <IconX size={16} stroke={2} />
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/locales/en.test.ts
+++ b/apps/desktop/src/locales/en.test.ts
@@ -4,9 +4,11 @@ import { en } from "./en";
 describe("feedback status translations", () => {
   it("contains every status shown after unsubscribing", () => {
     expect(en.translation.feedback).toMatchObject({
-      unsubscribeSuccess: "Unsubscribe request sent",
-      unsubscribeWeb: "Opened the unsubscribe page",
+      unsubscribeSuccess: "Unsubscribe request sent.",
+      unsubscribeWeb: "Unsubscribe page opened.",
       unsubscribeFailed: "Could not unsubscribe",
+      unsubscribeCleanupAction: "Move to Trash",
+      unsubscribeCleanupNone: "No emails from this sender were found",
     });
   });
 

--- a/apps/desktop/src/locales/en.ts
+++ b/apps/desktop/src/locales/en.ts
@@ -300,9 +300,17 @@ export const en = {
       starFailed_one: "Could not update the message star",
       starFailed_other: "Could not update {{count}} message stars",
       sent: "Message sent",
-      unsubscribeSuccess: "Unsubscribe request sent",
-      unsubscribeWeb: "Opened the unsubscribe page",
+      unsubscribeSuccess: "Unsubscribe request sent.",
+      unsubscribeWeb: "Unsubscribe page opened.",
       unsubscribeFailed: "Could not unsubscribe",
+      unsubscribeCleanupAction: "Move to Trash",
+      unsubscribeCleanupSuccess_one: "Moved 1 email to Trash",
+      unsubscribeCleanupSuccess_other: "Moved {{count}} emails to Trash",
+      unsubscribeCleanupNone: "No emails from this sender were found",
+      unsubscribeCleanupPartial:
+        "Moved {{moved}} of {{matched}} emails to Trash; {{failed}} could not be moved",
+      unsubscribeCleanupFailed:
+        "Could not move emails from this sender to Trash",
       categorySaved: "Category saved",
     },
     ai: {

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1796,6 +1796,41 @@ textarea {
   flex: none;
   color: light-dark(#39705f, #83b9a7);
 }
+.action-status-action,
+.action-status-dismiss {
+  flex: none;
+  border: 0;
+  border-radius: 6px;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+}
+.action-status-action {
+  margin-left: auto;
+  padding: 5px 7px;
+  color: light-dark(#24594a, #a9d6c6);
+  background: light-dark(#e6f2ed, #2d4a40);
+}
+.action-status-action:hover:not(:disabled) {
+  background: light-dark(#d8ebe3, #39584d);
+}
+.action-status-action:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+.action-status-dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 3px;
+  background: transparent;
+}
+.action-status-dismiss:hover {
+  background: light-dark(#ecece8, #3a3e3b);
+}
+.action-status-dismiss svg {
+  color: currentColor;
+}
 .action-status[data-tone="error"] svg {
   color: var(--dakia-ember-deep);
 }

--- a/apps/desktop/src/tauriContracts.test.ts
+++ b/apps/desktop/src/tauriContracts.test.ts
@@ -184,6 +184,19 @@ describe("Tauri payload contracts", () => {
     });
   });
 
+  it("uses the sender cleanup command with the immutable account and address", async () => {
+    apiMocks.invoke.mockResolvedValue({ matched: 3, moved: 2, failed: 1 });
+    const { api } = await import("./api");
+
+    await expect(
+      api.trashMessagesFromSender("account-1", "sender@example.test"),
+    ).resolves.toEqual({ matched: 3, moved: 2, failed: 1 });
+    expect(apiMocks.invoke).toHaveBeenCalledWith("trash_messages_from_sender", {
+      accountId: "account-1",
+      senderAddress: "sender@example.test",
+    });
+  });
+
   it("delivers camelCase event envelopes while preserving native null fields", async () => {
     const handlers = new Map<string, ListenHandler>();
     eventMocks.listen.mockImplementation(

--- a/crates/dakia-core/src/lib.rs
+++ b/crates/dakia-core/src/lib.rs
@@ -12,8 +12,9 @@ pub use account::{Account, AccountAuth, AccountDraft, AccountId};
 pub use ai::{AiConfig, AiProvider, AiService};
 pub use classification::{EmailClassificationInput, LocalEmailClassifier, ModelClassification};
 pub use mail::{
-    mailbox_action_destination, remote_mailbox, ComposeMessage, MailService, MailboxAction,
-    RealtimeCycle, RealtimeMode, SyncProgress, SyncResult, UnsubscribeOutcome,
+    mailbox_action_destination, normalize_sender_address, remote_mailbox, ComposeMessage,
+    MailService, MailboxAction, RealtimeCycle, RealtimeMode, SenderTrashResult, SyncProgress,
+    SyncResult, UnsubscribeOutcome,
 };
 pub use oauth::{OAuthFlow, OAuthProviderConfig, OAuthTokens};
 pub use provider::{ProviderPreset, Security};

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -196,6 +196,17 @@ pub enum UnsubscribeOutcome {
     },
 }
 
+/// The provider operation is deliberately expressed as counts rather than a
+/// list of message IDs: remote-only messages have no local ID yet, and a
+/// failure for one message must not hide successful moves for the others.
+#[derive(Debug, Clone, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SenderTrashResult {
+    pub matched: usize,
+    pub moved: usize,
+    pub failed: usize,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SyncProgress {
@@ -6291,6 +6302,43 @@ fn parse_first_address(value: &str) -> (Option<String>, String) {
             .unwrap_or((None, value.to_owned())),
         None => (None, value.to_owned()),
     }
+}
+
+/// Normalizes a bare RFC mailbox address supplied at a command boundary.
+/// Display names, folded headers, and malformed values are rejected so this
+/// cannot turn a sender cleanup into a broad text or display-name match.
+pub fn normalize_sender_address(value: &str) -> Option<String> {
+    let value = value.trim();
+    if value.is_empty() || value.len() > 320 || value.contains(['\r', '\n', '\0']) {
+        return None;
+    }
+    let raw = format!("From: {value}\r\n\r\n");
+    let parsed = parse_header_block(raw.as_bytes()).ok()?;
+    let address = first_parsed_address(&parsed)?.trim().to_ascii_lowercase();
+    // A command accepts only the mailbox, not a syntactically valid display
+    // name plus mailbox. This equality check is also what prevents a parser
+    // fallback from making an arbitrary header value actionable.
+    value.eq_ignore_ascii_case(&address).then_some(address)
+}
+
+fn first_parsed_address(parsed: &ParsedMessage<'_>) -> Option<String> {
+    match parsed.header(HeaderName::From)?.as_address()? {
+        ParsedAddress::List(addresses) => addresses
+            .first()?
+            .address
+            .as_ref()
+            .map(ToString::to_string),
+        ParsedAddress::Group(groups) => groups
+            .iter()
+            .flat_map(|group| group.addresses.iter())
+            .find_map(|address| address.address.as_ref().map(ToString::to_string)),
+    }
+}
+
+fn sender_address_from_headers(headers: &[u8]) -> Option<String> {
+    let parsed = parse_header_block(headers).ok()?;
+    let address = first_parsed_address(&parsed)?;
+    normalize_sender_address(&address)
 }
 
 pub(crate) fn parsed_header_mailboxes(value: &str) -> Vec<String> {

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -186,6 +186,27 @@ pub fn mailbox_action_destination(action: MailboxAction) -> Option<&'static str>
 }
 
 #[derive(Debug, Clone)]
+struct SenderTrashCandidate {
+    remote: String,
+    /// Every local catalogue locator, when this provider folder has been
+    /// indexed. Remote-only candidates still move remotely and appear on a
+    /// later sync.
+    local_locators: Vec<SenderTrashLocalLocator>,
+    uid: u32,
+    uid_validity: u32,
+    gmail_message_id: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct SenderTrashLocalLocator {
+    remote: String,
+    mailbox: String,
+    uid: u32,
+    discovered_uid_validity: u32,
+    catalogue_uid_validity: i64,
+}
+
+#[derive(Debug, Clone)]
 pub enum UnsubscribeOutcome {
     Completed,
     Web(String),
@@ -2174,6 +2195,179 @@ impl MailService {
             expected_uid_validity,
         )
         .await
+    }
+
+    /// Moves every received message whose RFC-parsed From mailbox is exactly
+    /// `sender_address` to Trash. Discovery completes before the first move,
+    /// so a partially completed move cannot change which messages qualify.
+    pub async fn trash_messages_from_sender(
+        &self,
+        account: &Account,
+        sender_address: &str,
+    ) -> Result<SenderTrashResult> {
+        let secret = self.credentials.secret(account).await?;
+        let mut client = ImapClient::connect(account).await?;
+        self.trash_messages_from_sender_with_client(&mut client, account, &secret, sender_address)
+            .await
+    }
+
+    async fn trash_messages_from_sender_with_client<S>(
+        &self,
+        client: &mut ImapClient<S>,
+        account: &Account,
+        secret: &str,
+        sender_address: &str,
+    ) -> Result<SenderTrashResult>
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let sender_address =
+            normalize_sender_address(sender_address).context("sender address is invalid")?;
+        client.authenticate(account, &secret).await?;
+        let listing = client.command("LIST \"\" \"*\"").await?;
+        let mut candidates = Vec::new();
+        let mut seen_mailboxes = BTreeSet::new();
+        for (flags, remote) in listing.iter().filter_map(|line| parse_list_mailbox(line)) {
+            if !seen_mailboxes.insert(remote.to_ascii_lowercase()) {
+                continue;
+            }
+            let catalogue_states = self
+                .store
+                .mailbox_catalog_states_for_remote(account.id, &remote)
+                .await?;
+            if !sender_cleanup_mailbox_is_received(account, &flags, &remote)
+                || !sender_cleanup_catalogue_roles_are_received(&catalogue_states)
+                || (account.provider_id == "gmail"
+                    && !gmail_sender_cleanup_mailbox_is_received(account, &flags, &remote))
+            {
+                continue;
+            }
+            let selected = client
+                .command(&format!("SELECT {}", quote_imap(&remote)))
+                .await
+                .with_context(|| format!("cannot inspect received mailbox {remote}"))?;
+            let uid_validity = parse_uid_validity(&selected).with_context(|| {
+                format!("provider omitted UIDVALIDITY for received mailbox {remote}")
+            })?;
+            for state in &catalogue_states {
+                verify_mailbox_uid_validity(
+                    uid_validity,
+                    state.uid_validity,
+                    "cleaning up this sender from",
+                )?;
+            }
+            // IMAP FROM narrows the potentially large mailbox on the server.
+            // It is only a candidate filter: the parsed header comparison
+            // below remains the authority for exact matching.
+            let search = client
+                .command(&format!("UID SEARCH FROM {}", quote_imap(&sender_address)))
+                .await
+                .with_context(|| format!("cannot search received mailbox {remote}"))?;
+            for uid in parse_search_uids(&search)? {
+                let fields = sender_cleanup_fetch_fields(account);
+                let mut response = client
+                    .command_with_literal_limited(
+                        &format!("UID FETCH {uid} ({fields})"),
+                        MAX_MIME_HEADER_BYTES,
+                    )
+                    .await
+                    .with_context(|| format!("cannot verify sender in {remote} UID {uid}"))?;
+                let headers = response.take_header_literal_for(uid).with_context(|| {
+                    format!("provider omitted From header for {remote} UID {uid}")
+                })?;
+                if sender_address_from_headers(&headers).as_deref() != Some(&sender_address) {
+                    continue;
+                }
+                let gmail_message_id = if account.provider_id == "gmail" {
+                    if !gmail_sender_cleanup_is_received(&response.lines).with_context(|| {
+                        format!("provider omitted or malformed X-GM-LABELS for {remote} UID {uid}")
+                    })? {
+                        continue;
+                    }
+                    Some(gmail_message_id(&response.lines).with_context(|| {
+                        format!("provider omitted or malformed X-GM-MSGID for {remote} UID {uid}")
+                    })?)
+                } else {
+                    None
+                };
+                candidates.push(SenderTrashCandidate {
+                    remote: remote.clone(),
+                    local_locators: catalogue_states
+                        .iter()
+                        .map(|state| SenderTrashLocalLocator {
+                            remote: remote.clone(),
+                            mailbox: state.mailbox.clone(),
+                            uid,
+                            discovered_uid_validity: uid_validity,
+                            catalogue_uid_validity: state.uid_validity,
+                        })
+                        .collect(),
+                    uid,
+                    uid_validity,
+                    gmail_message_id,
+                });
+            }
+        }
+        let candidates = deduplicate_sender_trash_candidates(account, candidates);
+        let mut result = SenderTrashResult {
+            matched: candidates.len(),
+            ..Default::default()
+        };
+        for candidate in candidates {
+            let moved = async {
+                let identities = sender_trash_remote_identities(&candidate)?;
+                for (remote, expected_uid_validity) in identities {
+                    let selected = client
+                        .command(&format!("SELECT {}", quote_imap(&remote)))
+                        .await?;
+                    let current_uid_validity = parse_uid_validity(&selected)
+                        .context("IMAP server omitted UIDVALIDITY before sender cleanup move")?;
+                    verify_mailbox_uid_validity(
+                        current_uid_validity,
+                        i64::from(expected_uid_validity),
+                        "moving sender cleanup messages",
+                    )?;
+                    for locator in candidate
+                        .local_locators
+                        .iter()
+                        .filter(|locator| locator.remote.eq_ignore_ascii_case(&remote))
+                    {
+                        verify_mailbox_uid_validity(
+                            current_uid_validity,
+                            locator.catalogue_uid_validity,
+                            "moving sender cleanup messages",
+                        )?;
+                    }
+                }
+                let destination_uid =
+                    move_selected_message_to_trash(client, account, candidate.uid).await?;
+                let sources = candidate
+                    .local_locators
+                    .iter()
+                    .map(|locator| (locator.mailbox.clone(), locator.uid))
+                    .collect::<Vec<_>>();
+                self.store
+                    .move_messages_to_destination(account.id, &sources, "Trash", destination_uid)
+                    .await?;
+                Result::<(), anyhow::Error>::Ok(())
+            }
+            .await;
+            match moved {
+                Ok(()) => result.moved += 1,
+                Err(failure) => {
+                    // Keep going: each UID is independently movable, and a
+                    // user needs an honest partial result rather than an
+                    // all-or-nothing claim after the first provider error.
+                    eprintln!(
+                        "Dakia could not move sender-cleanup UID {} from {}: {failure}",
+                        candidate.uid, candidate.remote
+                    );
+                    result.failed += 1;
+                }
+            }
+        }
+        let _ = client.command("LOGOUT").await;
+        Ok(result)
     }
 
     async fn apply_action_with_client<S>(
@@ -6323,11 +6517,9 @@ pub fn normalize_sender_address(value: &str) -> Option<String> {
 
 fn first_parsed_address(parsed: &ParsedMessage<'_>) -> Option<String> {
     match parsed.header(HeaderName::From)?.as_address()? {
-        ParsedAddress::List(addresses) => addresses
-            .first()?
-            .address
-            .as_ref()
-            .map(ToString::to_string),
+        ParsedAddress::List(addresses) => {
+            addresses.first()?.address.as_ref().map(ToString::to_string)
+        }
         ParsedAddress::Group(groups) => groups
             .iter()
             .flat_map(|group| group.addresses.iter())
@@ -6339,6 +6531,262 @@ fn sender_address_from_headers(headers: &[u8]) -> Option<String> {
     let parsed = parse_header_block(headers).ok()?;
     let address = first_parsed_address(&parsed)?;
     normalize_sender_address(&address)
+}
+
+fn sender_cleanup_fetch_fields(account: &Account) -> &'static str {
+    if account.provider_id == "gmail" {
+        "X-GM-MSGID X-GM-LABELS BODY.PEEK[HEADER.FIELDS (FROM)]"
+    } else {
+        "BODY.PEEK[HEADER.FIELDS (FROM)]"
+    }
+}
+
+fn gmail_sender_cleanup_is_received(lines: &[String]) -> Option<bool> {
+    let metadata = lines.join(" ").to_ascii_lowercase();
+    let (_, labels) = metadata.split_once("x-gm-labels")?;
+    let labels = labels.trim_start();
+    let mut depth = 0usize;
+    let mut quoted = false;
+    let mut escaped = false;
+    let mut end = None;
+    for (index, character) in labels.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        if quoted && character == '\\' {
+            escaped = true;
+            continue;
+        }
+        if character == '"' {
+            quoted = !quoted;
+            continue;
+        }
+        if quoted {
+            continue;
+        }
+        match character {
+            '(' => depth += 1,
+            ')' if depth == 1 => {
+                end = Some(index + 1);
+                break;
+            }
+            ')' if depth > 1 => depth -= 1,
+            _ => {}
+        }
+    }
+    let labels = labels.get(..end?)?;
+    if !labels.starts_with('(') || quoted || depth != 1 {
+        return None;
+    }
+    Some(
+        !["\\sent", "\\draft", "\\trash"]
+            .iter()
+            .any(|label| labels.contains(label)),
+    )
+}
+
+fn gmail_sender_cleanup_mailbox_is_received(
+    account: &Account,
+    flags: &[String],
+    remote: &str,
+) -> bool {
+    flags
+        .iter()
+        .any(|flag| matches!(flag.as_str(), "\\inbox" | "\\all" | "\\junk"))
+        || remote.eq_ignore_ascii_case("INBOX")
+        || remote.eq_ignore_ascii_case(&account.archive_mailbox)
+        || remote.eq_ignore_ascii_case(&account.spam_mailbox)
+}
+
+fn sender_cleanup_mailbox_is_received(account: &Account, flags: &[String], remote: &str) -> bool {
+    if remote.trim().is_empty()
+        || flags.iter().any(|flag| {
+            matches!(
+                flag.as_str(),
+                "\\noselect" | "\\sent" | "\\drafts" | "\\trash"
+            )
+        })
+    {
+        return false;
+    }
+    // Some providers omit special-use attributes. Never let their configured
+    // sent, drafts, or trash folders become a received-mail cleanup target.
+    ![
+        remote_mailbox(account, "Sent"),
+        remote_mailbox(account, "Drafts"),
+        remote_mailbox(account, "Trash"),
+        "Sent".into(),
+        "Drafts".into(),
+        "Trash".into(),
+    ]
+    .iter()
+    .any(|excluded| remote.eq_ignore_ascii_case(excluded))
+}
+
+fn sender_cleanup_catalogue_roles_are_received(
+    states: &[crate::storage::MailboxCatalogState],
+) -> bool {
+    !states.iter().any(|state| {
+        let role = state
+            .mailbox
+            .split_once("::")
+            .map_or(state.mailbox.as_str(), |(role, _)| role);
+        matches!(role, "Sent" | "Drafts" | "Trash")
+    })
+}
+
+fn gmail_message_id(lines: &[String]) -> Option<String> {
+    lines.iter().find_map(|line| {
+        let (_, value) = line.split_once("X-GM-MSGID ")?;
+        let value = value.trim_start();
+        let end = value
+            .find(|character: char| !character.is_ascii_digit())
+            .unwrap_or(value.len());
+        let suffix = &value[end..];
+        (end > 0
+            && suffix
+                .chars()
+                .next()
+                .is_none_or(|character| character.is_whitespace() || character == ')'))
+        .then(|| value[..end].to_owned())
+    })
+}
+
+fn sender_trash_candidate_rank(candidate: &SenderTrashCandidate) -> (u8, u8, String, u32) {
+    let storage_rank = candidate
+        .local_locators
+        .iter()
+        .map(|locator| match locator.mailbox.as_str() {
+            "INBOX" => 0,
+            "Archive" => 1,
+            "Spam" => 2,
+            _ => 3,
+        })
+        .min()
+        .unwrap_or(4);
+    (
+        storage_rank,
+        u8::from(candidate.local_locators.is_empty()),
+        candidate.remote.to_ascii_lowercase(),
+        candidate.uid,
+    )
+}
+
+fn deduplicate_sender_trash_candidates(
+    account: &Account,
+    candidates: Vec<SenderTrashCandidate>,
+) -> Vec<SenderTrashCandidate> {
+    let mut deduplicated = BTreeMap::new();
+    for candidate in candidates {
+        let key = if account.provider_id == "gmail" {
+            candidate
+                .gmail_message_id
+                .as_ref()
+                .map(|id| format!("gmail:{id}"))
+                .unwrap_or_else(|| format!("locator:{}:{}", candidate.remote, candidate.uid))
+        } else {
+            format!("locator:{}:{}", candidate.remote, candidate.uid)
+        };
+        match deduplicated.get_mut(&key) {
+            Some(existing) => {
+                if sender_trash_candidate_rank(&candidate) < sender_trash_candidate_rank(existing) {
+                    let mut replacement = candidate;
+                    replacement
+                        .local_locators
+                        .extend(existing.local_locators.clone());
+                    *existing = replacement;
+                } else {
+                    existing.local_locators.extend(candidate.local_locators);
+                }
+                deduplicate_sender_trash_local_locators(&mut existing.local_locators);
+            }
+            None => {
+                deduplicated.insert(key, candidate);
+            }
+        }
+    }
+    deduplicated.into_values().collect()
+}
+
+fn deduplicate_sender_trash_local_locators(locators: &mut Vec<SenderTrashLocalLocator>) {
+    let mut unique = BTreeMap::new();
+    for locator in std::mem::take(locators) {
+        let key = (
+            locator.remote.to_ascii_lowercase(),
+            locator.mailbox.clone(),
+            locator.uid,
+        );
+        unique.entry(key).or_insert(locator);
+    }
+    *locators = unique.into_values().collect();
+}
+
+fn sender_trash_remote_identities(candidate: &SenderTrashCandidate) -> Result<Vec<(String, u32)>> {
+    let mut identities = BTreeMap::new();
+    identities.insert(
+        candidate.remote.to_ascii_lowercase(),
+        (candidate.remote.clone(), candidate.uid_validity),
+    );
+    for locator in &candidate.local_locators {
+        let key = locator.remote.to_ascii_lowercase();
+        match identities.get(&key) {
+            Some((_, uid_validity)) if *uid_validity != locator.discovered_uid_validity => {
+                bail!("mailbox identity changed during sender cleanup discovery")
+            }
+            Some(_) => {}
+            None => {
+                identities.insert(
+                    key,
+                    (locator.remote.clone(), locator.discovered_uid_validity),
+                );
+            }
+        }
+    }
+    let mut identities = identities.into_values().collect::<Vec<_>>();
+    // Keep the selected primary mailbox active for the one remote mutation.
+    identities.sort_by_key(|(remote, _)| remote.eq_ignore_ascii_case(&candidate.remote));
+    Ok(identities)
+}
+
+async fn move_selected_message_to_trash<S>(
+    client: &mut ImapClient<S>,
+    account: &Account,
+    uid: u32,
+) -> Result<Option<u32>>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let destination = if account.provider_id == "gmail" {
+        "[Gmail]/Trash"
+    } else {
+        "Trash"
+    };
+    let response = client
+        .command(&format!("UID MOVE {uid} {}", quote_imap(destination)))
+        .await;
+    if let Ok(lines) = response {
+        return Ok(parse_copy_uid(&lines));
+    }
+    let capabilities = client.command("CAPABILITY").await?;
+    if !supports_uidplus(&capabilities) {
+        bail!("moving sender cleanup messages requires IMAP UIDPLUS when UID MOVE is unavailable");
+    }
+    let lines = client
+        .command(&format!("UID COPY {uid} {}", quote_imap(destination)))
+        .await?;
+    client
+        .command(&format!("UID STORE {uid} +FLAGS.SILENT (\\Deleted)"))
+        .await?;
+    if let Err(error) = client.command(&format!("UID EXPUNGE {uid}")).await {
+        // Never leave a message marked Deleted after an exact expunge failure:
+        // a later unrelated EXPUNGE must not permanently remove it.
+        let _ = client
+            .command(&format!("UID STORE {uid} -FLAGS.SILENT (\\Deleted)"))
+            .await;
+        return Err(error);
+    }
+    Ok(parse_copy_uid(&lines))
 }
 
 pub(crate) fn parsed_header_mailboxes(value: &str) -> Vec<String> {
@@ -16115,5 +16563,597 @@ For you, Alex =E2=80=94 related to your saved topic."
             ]
         );
         assert!(parsed_header_mailboxes("victim@example.com in prose").is_empty());
+    }
+
+    #[test]
+    fn sender_cleanup_uses_only_a_normalized_bare_rfc_mailbox() {
+        assert_eq!(
+            normalize_sender_address("  Sender@Example.TEST "),
+            Some("sender@example.test".into())
+        );
+        assert_eq!(
+            sender_address_from_headers(b"From: Sender <sender@example.test>\r\n\r\n"),
+            Some("sender@example.test".into())
+        );
+        assert!(normalize_sender_address("Sender <sender@example.test>").is_none());
+        assert!(
+            normalize_sender_address("sender@example.test\r\nBcc: victim@example.test").is_none()
+        );
+        assert_ne!(
+            sender_address_from_headers(b"From: sender+offers@example.test\r\n\r\n"),
+            Some("sender@example.test".into())
+        );
+        assert!(sender_address_from_headers(b"From: malformed sender\r\n\r\n").is_none());
+    }
+
+    #[test]
+    fn sender_cleanup_excludes_non_received_special_use_folders_but_keeps_custom_and_junk() {
+        let account = test_account();
+        assert!(sender_cleanup_mailbox_is_received(
+            &account,
+            &[],
+            "Projects"
+        ));
+        assert!(sender_cleanup_mailbox_is_received(
+            &account,
+            &["\\junk".into()],
+            "Spam"
+        ));
+        for mailbox in ["Sent", "Drafts", "Trash"] {
+            assert!(
+                !sender_cleanup_mailbox_is_received(&account, &[], mailbox),
+                "a missing special-use flag must not include {mailbox}"
+            );
+        }
+        for (flags, mailbox) in [
+            (vec!["\\sent".into()], "Sent"),
+            (vec!["\\drafts".into()], "Drafts"),
+            (vec!["\\trash".into()], "Trash"),
+            (vec!["\\noselect".into()], "Not selectable"),
+        ] {
+            assert!(
+                !sender_cleanup_mailbox_is_received(&account, &flags, mailbox),
+                "{mailbox} must not be a cleanup source"
+            );
+        }
+    }
+
+    #[test]
+    fn sender_cleanup_excludes_flagless_folders_mapped_to_non_received_catalogue_roles() {
+        let state = |mailbox: &str| crate::storage::MailboxCatalogState {
+            account_id: uuid::Uuid::nil().to_string(),
+            mailbox: mailbox.into(),
+            remote_name: "Sent Items".into(),
+            uid_validity: 7,
+            remote_total: 0,
+            historical_complete: true,
+            uid_next: None,
+            highest_modseq: None,
+        };
+        assert!(!sender_cleanup_catalogue_roles_are_received(&[state(
+            "Sent::Sent Items"
+        )]));
+        assert!(!sender_cleanup_catalogue_roles_are_received(&[state(
+            "Drafts::Brouillons"
+        )]));
+        assert!(!sender_cleanup_catalogue_roles_are_received(&[state(
+            "Trash::Deleted Items"
+        )]));
+        assert!(sender_cleanup_catalogue_roles_are_received(&[state(
+            "Projects"
+        )]));
+        assert!(sender_cleanup_catalogue_roles_are_received(&[]));
+    }
+
+    #[test]
+    fn gmail_sender_cleanup_excludes_sent_draft_and_trash_labels_in_every_selected_folder() {
+        assert_eq!(
+            gmail_sender_cleanup_is_received(&[
+                "* 1 FETCH (X-GM-LABELS (\\Inbox custom-label))".into()
+            ]),
+            Some(true)
+        );
+        assert_eq!(
+            gmail_sender_cleanup_is_received(&[
+                "* 1 FETCH (X-GM-LABELS (\\Spam custom-label))".into()
+            ]),
+            Some(true)
+        );
+        assert_eq!(
+            gmail_sender_cleanup_is_received(&[
+                "* 1 FETCH (X-GM-LABELS (\"project) x\" \\Sent))".into()
+            ]),
+            Some(false)
+        );
+        for label in ["\\Sent", "\\Draft", "\\Trash"] {
+            assert!(
+                gmail_sender_cleanup_is_received(&[format!(
+                    "* 1 FETCH (X-GM-LABELS ({label} custom-label))"
+                )]) == Some(false),
+                "{label} must not be moved from a custom Gmail label"
+            );
+        }
+    }
+
+    #[test]
+    fn gmail_sender_cleanup_rejects_missing_or_malformed_stable_metadata() {
+        assert!(gmail_sender_cleanup_is_received(&[]).is_none());
+        assert!(
+            gmail_sender_cleanup_is_received(&["* 1 FETCH (X-GM-LABELS malformed)".into()])
+                .is_none()
+        );
+        assert!(gmail_message_id(&[]).is_none());
+        assert!(gmail_message_id(&["* 1 FETCH (X-GM-MSGID invalid)".into()]).is_none());
+        assert!(gmail_message_id(&["* 1 FETCH (X-GM-MSGID 123malformed)".into()]).is_none());
+        assert_eq!(
+            gmail_message_id(&["* 1 FETCH (X-GM-MSGID 12345)".into()]),
+            Some("12345".into())
+        );
+    }
+
+    #[test]
+    fn gmail_sender_cleanup_limits_discovery_to_inbox_all_mail_and_junk() {
+        let mut account = test_account();
+        account.provider_id = "gmail".into();
+        account.archive_mailbox = "[Google Mail]/Alle Nachrichten".into();
+        account.spam_mailbox = "[Google Mail]/Spam".into();
+
+        assert!(gmail_sender_cleanup_mailbox_is_received(
+            &account,
+            &["\\inbox".into()],
+            "Posteingang"
+        ));
+        assert!(gmail_sender_cleanup_mailbox_is_received(
+            &account,
+            &["\\all".into()],
+            "Alle Nachrichten"
+        ));
+        assert!(gmail_sender_cleanup_mailbox_is_received(
+            &account,
+            &["\\junk".into()],
+            "Spam"
+        ));
+        assert!(gmail_sender_cleanup_mailbox_is_received(
+            &account,
+            &[],
+            "[Google Mail]/Alle Nachrichten"
+        ));
+        assert!(gmail_sender_cleanup_mailbox_is_received(
+            &account,
+            &[],
+            "[Google Mail]/Spam"
+        ));
+        assert!(!gmail_sender_cleanup_mailbox_is_received(
+            &account,
+            &[],
+            "Custom label"
+        ));
+    }
+
+    #[test]
+    fn gmail_sender_cleanup_deduplicates_by_gmail_message_id_and_prefers_inbox_locator() {
+        let mut account = test_account();
+        account.provider_id = "gmail".into();
+        let local_locator = |remote: &str, mailbox: &str, uid| SenderTrashLocalLocator {
+            remote: remote.into(),
+            mailbox: mailbox.into(),
+            uid,
+            discovered_uid_validity: 7,
+            catalogue_uid_validity: 7,
+        };
+        let candidates = vec![
+            SenderTrashCandidate {
+                remote: "[Gmail]/All Mail".into(),
+                local_locators: vec![local_locator("[Gmail]/All Mail", "Archive", 40)],
+                uid: 40,
+                uid_validity: 7,
+                gmail_message_id: Some("100".into()),
+            },
+            SenderTrashCandidate {
+                remote: "INBOX".into(),
+                local_locators: vec![local_locator("INBOX", "INBOX", 4)],
+                uid: 4,
+                uid_validity: 7,
+                gmail_message_id: Some("100".into()),
+            },
+        ];
+        let selected = deduplicate_sender_trash_candidates(&account, candidates);
+        // One selected candidate means the operation issues one provider move,
+        // while the retained locators reconcile both local Gmail projections.
+        assert_eq!(selected.len(), 1);
+        let inbox = selected
+            .iter()
+            .find(|candidate| candidate.remote == "INBOX" && candidate.uid == 4)
+            .unwrap();
+        assert_eq!(inbox.local_locators.len(), 2);
+        assert!(inbox
+            .local_locators
+            .iter()
+            .any(|locator| locator.mailbox == "INBOX" && locator.uid == 4));
+        assert!(inbox
+            .local_locators
+            .iter()
+            .any(|locator| locator.mailbox == "Archive" && locator.uid == 40));
+    }
+
+    #[tokio::test]
+    async fn sender_cleanup_verifies_from_after_server_filter_and_moves_only_after_discovery() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store);
+        let account = test_account();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "LOGIN \"reader@example.test\" \"sync secret\"",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} OK authenticated\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+            write
+                .write_all(
+                    format!(
+                        "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n* LIST (\\HasNoChildren) \"/\" \"Projects\"\r\n* LIST (\\HasNoChildren \\Sent) \"/\" \"Sent\"\r\n{tag} OK listed\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(
+                    format!("* OK [UIDVALIDITY 7] UIDs valid\r\n{tag} OK selected\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID SEARCH FROM \"sender@example.test\"",
+            )
+            .await;
+            write
+                .write_all(format!("* SEARCH 2 3\r\n{tag} OK searched\r\n").as_bytes())
+                .await
+                .unwrap();
+            for (uid, from) in [
+                (2, "sender+lookalike@example.test"),
+                (3, "Sender <sender@example.test>"),
+            ] {
+                let tag = scripted_expect_command(
+                    &mut read,
+                    &mut transcript,
+                    &format!("UID FETCH {uid} (BODY.PEEK[HEADER.FIELDS (FROM)])"),
+                )
+                .await;
+                let headers = format!("From: {from}\r\n\r\n");
+                write
+                    .write_all(
+                        format!(
+                            "* 1 FETCH (UID {uid} BODY[HEADER.FIELDS (FROM)] {{{}}}\r\n{} )\r\n{tag} OK fetched\r\n",
+                            headers.len(), headers
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+            }
+
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"Projects\"").await;
+            write
+                .write_all(
+                    format!("* OK [UIDVALIDITY 7] UIDs valid\r\n{tag} OK selected\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID SEARCH FROM \"sender@example.test\"",
+            )
+            .await;
+            write
+                .write_all(format!("* SEARCH\r\n{tag} OK searched\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(
+                    format!("* OK [UIDVALIDITY 7] UIDs valid\r\n{tag} OK selected\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "UID MOVE 3 \"Trash\"").await;
+            write
+                .write_all(format!("{tag} OK moved\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK bye\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        let result = service
+            .trash_messages_from_sender_with_client(
+                &mut client,
+                &account,
+                "sync secret",
+                "sender@example.test",
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.matched, 1);
+        assert_eq!(result.moved, 1);
+        assert_eq!(result.failed, 0);
+        let transcript = server.await.unwrap();
+        assert!(
+            transcript
+                .iter()
+                .position(|command| command.starts_with("UID MOVE"))
+                > transcript
+                    .iter()
+                    .position(|command| command == "SELECT \"Projects\""),
+            "no mutation may begin before every selected received folder is discovered"
+        );
+    }
+
+    #[tokio::test]
+    async fn sender_cleanup_skips_a_flagless_catalogued_sent_folder_but_discovers_custom_mail() {
+        let store = Store::in_memory().await.unwrap();
+        let account = test_account();
+        store.save_account(&account).await.unwrap();
+        store
+            .save_mailbox_catalog_state(account.id, "Sent::Sent Items", "Sent Items", 7, 0, true)
+            .await
+            .unwrap();
+        let service = MailService::new(store);
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "LOGIN \"reader@example.test\" \"sync secret\"",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} OK authenticated\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+            write
+                .write_all(
+                    format!(
+                        "* LIST (\\HasNoChildren) \"/\" \"Sent Items\"\r\n* LIST (\\HasNoChildren) \"/\" \"Projects\"\r\n{tag} OK listed\r\n"
+                    )
+                    .as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "SELECT \"Projects\"").await;
+            write
+                .write_all(
+                    format!("* OK [UIDVALIDITY 7] UIDs valid\r\n{tag} OK selected\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID SEARCH FROM \"sender@example.test\"",
+            )
+            .await;
+            write
+                .write_all(format!("* SEARCH\r\n{tag} OK searched\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK bye\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        let result = service
+            .trash_messages_from_sender_with_client(
+                &mut client,
+                &account,
+                "sync secret",
+                "sender@example.test",
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.matched, 0);
+        let transcript = server.await.unwrap();
+        assert!(transcript
+            .iter()
+            .all(|command| !command.contains("Sent Items")));
+        assert!(transcript
+            .iter()
+            .any(|command| command == "SELECT \"Projects\""));
+    }
+
+    #[tokio::test]
+    async fn sender_cleanup_counts_a_failed_move_and_continues_with_later_matches() {
+        let store = Store::in_memory().await.unwrap();
+        let service = MailService::new(store);
+        let account = test_account();
+        let (mut client, server) = duplex_imap_client_and_server();
+        let server = tokio::spawn(async move {
+            let (read, mut write) = split(server);
+            let mut read = BufReader::new(read);
+            let mut transcript = Vec::new();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "LOGIN \"reader@example.test\" \"sync secret\"",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} OK authenticated\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LIST \"\" \"*\"").await;
+            write
+                .write_all(
+                    format!("* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n{tag} OK listed\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(
+                    format!("* OK [UIDVALIDITY 7] UIDs valid\r\n{tag} OK selected\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID SEARCH FROM \"sender@example.test\"",
+            )
+            .await;
+            write
+                .write_all(format!("* SEARCH 2 3\r\n{tag} OK searched\r\n").as_bytes())
+                .await
+                .unwrap();
+            for uid in [2, 3] {
+                let tag = scripted_expect_command(
+                    &mut read,
+                    &mut transcript,
+                    &format!("UID FETCH {uid} (BODY.PEEK[HEADER.FIELDS (FROM)])"),
+                )
+                .await;
+                let headers = b"From: Sender <sender@example.test>\r\n\r\n";
+                write
+                    .write_all(
+                        format!(
+                            "* 1 FETCH (UID {uid} BODY[HEADER.FIELDS (FROM)] {{{}}}\r\n",
+                            headers.len()
+                        )
+                        .as_bytes(),
+                    )
+                    .await
+                    .unwrap();
+                write.write_all(headers).await.unwrap();
+                write
+                    .write_all(format!(")\r\n{tag} OK fetched\r\n").as_bytes())
+                    .await
+                    .unwrap();
+            }
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(
+                    format!("* OK [UIDVALIDITY 7] UIDs valid\r\n{tag} OK selected\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "UID MOVE 2 \"Trash\"").await;
+            write
+                .write_all(format!("{tag} NO MOVE unavailable\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "CAPABILITY").await;
+            write
+                .write_all(
+                    format!("* CAPABILITY IMAP4rev1 UIDPLUS\r\n{tag} OK capabilities\r\n")
+                        .as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "UID COPY 2 \"Trash\"").await;
+            write
+                .write_all(format!("{tag} OK copied\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID STORE 2 +FLAGS.SILENT (\\Deleted)",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} OK marked\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "UID EXPUNGE 2").await;
+            write
+                .write_all(format!("{tag} NO expunge unavailable\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(
+                &mut read,
+                &mut transcript,
+                "UID STORE 2 -FLAGS.SILENT (\\Deleted)",
+            )
+            .await;
+            write
+                .write_all(format!("{tag} OK restored\r\n").as_bytes())
+                .await
+                .unwrap();
+
+            let tag = scripted_expect_command(&mut read, &mut transcript, "SELECT \"INBOX\"").await;
+            write
+                .write_all(
+                    format!("* OK [UIDVALIDITY 7] UIDs valid\r\n{tag} OK selected\r\n").as_bytes(),
+                )
+                .await
+                .unwrap();
+            let tag =
+                scripted_expect_command(&mut read, &mut transcript, "UID MOVE 3 \"Trash\"").await;
+            write
+                .write_all(format!("{tag} OK moved\r\n").as_bytes())
+                .await
+                .unwrap();
+            let tag = scripted_expect_command(&mut read, &mut transcript, "LOGOUT").await;
+            write
+                .write_all(format!("{tag} OK bye\r\n").as_bytes())
+                .await
+                .unwrap();
+            transcript
+        });
+
+        let result = service
+            .trash_messages_from_sender_with_client(
+                &mut client,
+                &account,
+                "sync secret",
+                "sender@example.test",
+            )
+            .await
+            .unwrap();
+        assert_eq!(result.matched, 2);
+        assert_eq!(result.moved, 1);
+        assert_eq!(result.failed, 1);
+        let transcript = server.await.unwrap();
+        assert!(
+            transcript
+                .iter()
+                .any(|command| command == "UID MOVE 3 \"Trash\""),
+            "a move failure must not prevent later sender matches from being processed"
+        );
     }
 }

--- a/crates/dakia-core/src/mail.rs
+++ b/crates/dakia-core/src/mail.rs
@@ -2223,7 +2223,7 @@ impl MailService {
     {
         let sender_address =
             normalize_sender_address(sender_address).context("sender address is invalid")?;
-        client.authenticate(account, &secret).await?;
+        client.authenticate(account, secret).await?;
         let listing = client.command("LIST \"\" \"*\"").await?;
         let mut candidates = Vec::new();
         let mut seen_mailboxes = BTreeSet::new();

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -2012,24 +2012,21 @@ impl Store {
         .await?)
     }
 
-    /// Returns the local catalogue mailbox or mailboxes backed by a provider
-    /// mailbox. A provider can expose the same special-use mailbox under more
-    /// than one catalogue entry, so callers must still choose one locator.
-    pub async fn mailbox_catalog_storages_for_remote(
+    /// Returns every local catalogue state backed by a provider mailbox. One
+    /// provider mailbox can have multiple local locators, all of which need a
+    /// tombstone when a remote move succeeds.
+    pub async fn mailbox_catalog_states_for_remote(
         &self,
         account_id: AccountId,
         remote_name: &str,
-    ) -> Result<Vec<String>> {
-        Ok(sqlx::query_as::<_, (String,)>(
-            "SELECT mailbox FROM mailbox_catalog_state WHERE account_id = ? AND LOWER(remote_name) = LOWER(?) ORDER BY CASE mailbox WHEN 'INBOX' THEN 0 WHEN 'Archive' THEN 1 WHEN 'Spam' THEN 2 ELSE 3 END, mailbox",
+    ) -> Result<Vec<MailboxCatalogState>> {
+        Ok(sqlx::query_as::<_, MailboxCatalogState>(
+            "SELECT account_id, mailbox, remote_name, uid_validity, remote_total, historical_complete, uid_next, highest_modseq FROM mailbox_catalog_state WHERE account_id = ? AND LOWER(remote_name) = LOWER(?) ORDER BY CASE mailbox WHEN 'INBOX' THEN 0 WHEN 'Archive' THEN 1 WHEN 'Spam' THEN 2 ELSE 3 END, mailbox",
         )
         .bind(account_id.to_string())
         .bind(remote_name)
         .fetch_all(&self.pool)
-        .await?
-        .into_iter()
-        .map(|(mailbox,)| mailbox)
-        .collect())
+        .await?)
     }
 
     pub async fn save_mailbox_catalog_state(
@@ -3112,6 +3109,123 @@ impl Store {
             .bind(&account_key)
             .bind(source_mailbox)
             .bind(source_uid)
+            .execute(&mut *tx)
+            .await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Reconciles one provider move that represented several local catalogue
+    /// locators. The whole operation is one transaction so a missing duplicate
+    /// cannot delete a Trash row created from an earlier existing source.
+    pub async fn move_messages_to_destination(
+        &self,
+        account_id: AccountId,
+        sources: &[(String, u32)],
+        destination_mailbox: &str,
+        destination_uid: Option<u32>,
+    ) -> Result<()> {
+        let account_key = account_id.to_string();
+        let mut unique_sources = Vec::new();
+        let mut seen = HashSet::new();
+        for (mailbox, uid) in sources {
+            if seen.insert((mailbox.clone(), *uid)) {
+                unique_sources.push((mailbox, *uid));
+            }
+        }
+        if unique_sources.is_empty() {
+            return Ok(());
+        }
+        let mut tx = self.pool.begin().await?;
+        for (mailbox, uid) in &unique_sources {
+            sqlx::query("INSERT OR REPLACE INTO mailbox_action_tombstones(account_id, mailbox, uid, created_at) VALUES (?, ?, ?, ?)")
+                .bind(&account_key)
+                .bind(mailbox)
+                .bind(uid)
+                .bind(Utc::now())
+                .execute(&mut *tx)
+                .await?;
+        }
+        let Some(destination_uid) = destination_uid else {
+            for (mailbox, uid) in &unique_sources {
+                sqlx::query(
+                    "DELETE FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?",
+                )
+                .bind(&account_key)
+                .bind(mailbox)
+                .bind(uid)
+                .execute(&mut *tx)
+                .await?;
+            }
+            tx.commit().await?;
+            return Ok(());
+        };
+
+        let mut chosen = None;
+        for (mailbox, uid) in &unique_sources {
+            let exists: bool = sqlx::query_scalar(
+                "SELECT EXISTS(SELECT 1 FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)",
+            )
+            .bind(&account_key)
+            .bind(mailbox)
+            .bind(uid)
+            .fetch_one(&mut *tx)
+            .await?;
+            if exists && chosen.is_none() {
+                chosen = Some(((*mailbox).clone(), *uid));
+            }
+        }
+        let Some((chosen_mailbox, chosen_uid)) = chosen else {
+            tx.commit().await?;
+            return Ok(());
+        };
+
+        for (mailbox, uid) in &unique_sources {
+            for table in [
+                "message_content_cache",
+                "starred_attachment_metadata",
+                "starred_message_bodies",
+                "message_content_fetches",
+            ] {
+                let query = format!(
+                    "DELETE FROM {table} WHERE message_id IN (SELECT id FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?)"
+                );
+                sqlx::query(&query)
+                    .bind(&account_key)
+                    .bind(mailbox)
+                    .bind(uid)
+                    .execute(&mut *tx)
+                    .await?;
+            }
+        }
+        // Delete a pre-existing destination only after we know an existing
+        // source will replace it. This is what protects a destination from a
+        // later absent alias in the same provider move.
+        sqlx::query("DELETE FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?")
+            .bind(&account_key)
+            .bind(destination_mailbox)
+            .bind(destination_uid)
+            .execute(&mut *tx)
+            .await?;
+        for (mailbox, uid) in &unique_sources {
+            if mailbox.as_str() != chosen_mailbox || *uid != chosen_uid {
+                sqlx::query(
+                    "DELETE FROM messages WHERE account_id = ? AND mailbox = ? AND uid = ?",
+                )
+                .bind(&account_key)
+                .bind(mailbox)
+                .bind(uid)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        sqlx::query("UPDATE messages SET id = ?, mailbox = ?, uid = ? WHERE account_id = ? AND mailbox = ? AND uid = ?")
+            .bind(stable_message_id(account_id, destination_mailbox, destination_uid))
+            .bind(destination_mailbox)
+            .bind(destination_uid)
+            .bind(&account_key)
+            .bind(&chosen_mailbox)
+            .bind(chosen_uid)
             .execute(&mut *tx)
             .await?;
         tx.commit().await?;
@@ -7962,6 +8076,69 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn batch_move_preserves_destination_when_a_later_source_locator_is_absent() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        save_test_account(&store, account_id).await;
+        let mut inbox = message("Newsletter", "Sender cleanup source");
+        inbox.id = stable_message_id(account_id, "INBOX", 41);
+        inbox.account_id = account_id.to_string();
+        inbox.mailbox = "INBOX".into();
+        inbox.uid = 41;
+        store.upsert_messages(&[inbox.clone()]).await.unwrap();
+
+        store
+            .move_messages_to_destination(
+                account_id,
+                &[("INBOX".into(), 41), ("Archive".into(), 99)],
+                "Trash",
+                Some(7),
+            )
+            .await
+            .unwrap();
+
+        assert!(store
+            .message_by_locator(account_id, "INBOX", 41)
+            .await
+            .unwrap()
+            .is_none());
+        let trash = store
+            .message_by_locator(account_id, "Trash", 7)
+            .await
+            .unwrap()
+            .expect("the existing source must become the Trash row");
+        assert_eq!(trash.subject, inbox.subject);
+
+        let mut stale_archive = inbox.clone();
+        stale_archive.id = stable_message_id(account_id, "Archive", 99);
+        stale_archive.mailbox = "Archive".into();
+        stale_archive.uid = 99;
+        store
+            .save_synced_messages(account_id, "INBOX", &[inbox])
+            .await
+            .unwrap();
+        store
+            .save_synced_messages(account_id, "Archive", &[stale_archive])
+            .await
+            .unwrap();
+        assert!(store
+            .message_by_locator(account_id, "INBOX", 41)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .message_by_locator(account_id, "Archive", 99)
+            .await
+            .unwrap()
+            .is_none());
+        assert!(store
+            .message_by_locator(account_id, "Trash", 7)
+            .await
+            .unwrap()
+            .is_some());
+    }
+
+    #[tokio::test]
     async fn permanent_delete_tombstones_only_the_exact_locator_and_preserves_other_rows() {
         let store = Store::in_memory().await.unwrap();
         let account_id = uuid::Uuid::new_v4();
@@ -10255,6 +10432,39 @@ mod tests {
         let restored = store.account(account.id).await.unwrap().unwrap();
         assert_eq!(restored.account_name, restored.email);
     }
+
+    #[tokio::test]
+    async fn looks_up_all_catalogue_states_by_provider_mailbox_case_insensitively() {
+        let store = Store::in_memory().await.unwrap();
+        let account_id = uuid::Uuid::new_v4();
+        store
+            .save_mailbox_catalog_state(account_id, "Archive", "[Gmail]/All Mail", 7, 0, true)
+            .await
+            .unwrap();
+        store
+            .save_mailbox_catalog_state(account_id, "INBOX", "[Gmail]/All Mail", 7, 0, true)
+            .await
+            .unwrap();
+
+        let states = store
+            .mailbox_catalog_states_for_remote(account_id, "[gmail]/all mail")
+            .await
+            .unwrap();
+        assert_eq!(
+            states
+                .iter()
+                .map(|state| state.mailbox.as_str())
+                .collect::<Vec<_>>(),
+            vec!["INBOX", "Archive"]
+        );
+        assert!(states.iter().all(|state| state.uid_validity == 7));
+        assert!(store
+            .mailbox_catalog_states_for_remote(account_id, "Projects")
+            .await
+            .unwrap()
+            .is_empty());
+    }
+
     #[tokio::test]
     async fn synced_message_above_a_gap_does_not_advance_the_contiguous_watermark() {
         let store = Store::in_memory().await.unwrap();

--- a/crates/dakia-core/src/storage.rs
+++ b/crates/dakia-core/src/storage.rs
@@ -2012,6 +2012,26 @@ impl Store {
         .await?)
     }
 
+    /// Returns the local catalogue mailbox or mailboxes backed by a provider
+    /// mailbox. A provider can expose the same special-use mailbox under more
+    /// than one catalogue entry, so callers must still choose one locator.
+    pub async fn mailbox_catalog_storages_for_remote(
+        &self,
+        account_id: AccountId,
+        remote_name: &str,
+    ) -> Result<Vec<String>> {
+        Ok(sqlx::query_as::<_, (String,)>(
+            "SELECT mailbox FROM mailbox_catalog_state WHERE account_id = ? AND LOWER(remote_name) = LOWER(?) ORDER BY CASE mailbox WHEN 'INBOX' THEN 0 WHEN 'Archive' THEN 1 WHEN 'Spam' THEN 2 ELSE 3 END, mailbox",
+        )
+        .bind(account_id.to_string())
+        .bind(remote_name)
+        .fetch_all(&self.pool)
+        .await?
+        .into_iter()
+        .map(|(mailbox,)| mailbox)
+        .collect())
+    }
+
     pub async fn save_mailbox_catalog_state(
         &self,
         account_id: AccountId,


### PR DESCRIPTION
## Summary

- show a persistent cleanup action after both completed and web unsubscribe outcomes
- optimistically remove exact-sender messages in the main and detached reader UIs, then reconcile or restore them with partial-failure feedback
- discover and verify matching received mail live through IMAP, with Gmail deduplication, folder exclusions, account locking, UIDVALIDITY checks, and safe Trash fallback behavior
- tombstone every known local locator so realtime sync cannot restore successfully moved mail

## Verification

- `npm test` (37 files, 347 tests)
- `npm run typecheck`
- `npm run format:check`
- `npm run build:web`
- `cargo test -p dakia-core` (368 unit tests, 5 property tests)
- `cargo test -p dakia-desktop` (92 tests)
- `cargo fmt --check`
- `git diff --check`

Native macOS and live-provider smoke tests were not run. Provider behavior is covered by scripted IMAP tests.
