### PR TITLE
Fix Windows release cache setup

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -379,8 +379,12 @@ jobs:
           key: onnx-runtime-macos-arm64-${{ hashFiles('scripts/prepare-onnx-runtime.sh', 'apps/desktop/src-tauri/Cargo.lock', 'Cargo.lock') }}
       - name: Install verified Rust compiler cache
         run: |
-          archive="$RUNNER_TEMP/${{ matrix.sccache_archive }}"
-          install_dir="$RUNNER_TEMP/sccache-bin"
+          runner_temp="$RUNNER_TEMP"
+          if [[ "${{ matrix.platform }}" == windows ]]; then
+            runner_temp="$(cygpath -u "$runner_temp")"
+          fi
+          archive="$runner_temp/${{ matrix.sccache_archive }}"
+          install_dir="$runner_temp/sccache-bin"
           curl --fail --location --retry 3 --silent --show-error "https://github.com/mozilla/sccache/releases/download/v0.17.0/${{ matrix.sccache_archive }}" --output "$archive"
           if [[ "${{ matrix.platform }}" == macos ]]; then
             printf '%s  %s\n' '${{ matrix.sccache_sha256 }}' "$archive" | shasum -a 256 -c -

--- a/scripts/production-release-workflow.node-test.mjs
+++ b/scripts/production-release-workflow.node-test.mjs
@@ -18,3 +18,19 @@ test("release builds run after the optional preparation job is skipped", () => {
   assert.match(buildJob, /needs\.validate\.result == 'success'/);
   assert.match(buildJob, /needs\.decide\.outputs\.should_release == 'true'/);
 });
+
+test("normalizes Windows runner paths before extracting the compiler cache", () => {
+  assert.match(
+    workflow,
+    /runner_temp="\$RUNNER_TEMP"\n\s+if \[\[ "\$\{\{ matrix\.platform \}\}" == windows \]\]; then\n\s+runner_temp="\$\(cygpath -u "\$runner_temp"\)"\n\s+fi/,
+  );
+  assert.match(
+    workflow,
+    /archive="\$runner_temp\/\$\{\{ matrix\.sccache_archive \}\}"/,
+  );
+  assert.match(workflow, /install_dir="\$runner_temp\/sccache-bin"/);
+  assert.doesNotMatch(
+    workflow,
+    /archive="\$RUNNER_TEMP\/\$\{\{ matrix\.sccache_archive \}\}"/,
+  );
+});


### PR DESCRIPTION
## Summary

- convert the Windows runner temporary directory to a Git Bash path before extracting sccache
- keep the downloaded archive checksum verification unchanged
- add a workflow contract test for the Windows path normalization

## Verification

- production release workflow contract tests: 2 passed
- diff check passed
- Linux source gate in release run 34608023511 passed before this platform-specific failure

The macOS certificate secrets were also replaced outside this PR with an Apple-compatible PKCS#12 that passed a real temporary-keychain import.