### PR TITLE
Fix Windows classifier runtime linking

### DIFF
--- a/.github/workflows/pull-request-validation.yml
+++ b/.github/workflows/pull-request-validation.yml
@@ -116,6 +116,12 @@ jobs:
         name: Validate Rust core scope
         if: needs.classify.outputs.rust_core == 'true'
         run: |
+          feature_tree="$(cargo tree --locked --target x86_64-pc-windows-msvc -p dakia-cli -e features -i esaxx-rs)"
+          printf '%s\n' "$feature_tree"
+          if grep -Fq 'esaxx-rs feature "cpp"' <<<"$feature_tree"; then
+            echo 'esaxx-rs/cpp forces the static MSVC runtime and conflicts with ONNX Runtime.' >&2
+            exit 1
+          fi
           cargo fmt --all -- --check
           cargo clippy -p dakia-core --all-targets -- -D warnings
           cargo test -p dakia-core -- \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,18 +750,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "console"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "const-oid"
 version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1483,12 +1471,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
-
-[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1562,9 +1544,6 @@ name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "etcetera"
@@ -2677,19 +2656,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "indicatif"
-version = "0.18.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9433806cd6b4ec1aba79c021c7e4c58fb4c3b9977c085062e611ac929998fb0c"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
 ]
 
 [[package]]
@@ -6360,7 +6326,6 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "indicatif",
  "itertools",
  "log",
  "macro_rules_attribute",
@@ -6820,22 +6785,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "untrusted"

--- a/crates/dakia-core/Cargo.toml
+++ b/crates/dakia-core/Cargo.toml
@@ -29,7 +29,7 @@ sqlx.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-rustls.workspace = true
-tokenizers = "=0.22.2"
+tokenizers = { version = "=0.22.2", default-features = false, features = ["onig"] }
 tracing.workspace = true
 url.workspace = true
 uuid.workspace = true

--- a/scripts/production-release-workflow.node-test.mjs
+++ b/scripts/production-release-workflow.node-test.mjs
@@ -17,6 +17,14 @@ const classifierManifest = JSON.parse(
   readFileSync(resolve(classifierDirectory, "MANIFEST.json"), "utf8"),
 );
 const gitAttributes = readFileSync(resolve(root, ".gitattributes"), "utf8");
+const pullRequestWorkflow = readFileSync(
+  resolve(root, ".github/workflows/pull-request-validation.yml"),
+  "utf8",
+);
+const coreManifest = readFileSync(
+  resolve(root, "crates/dakia-core/Cargo.toml"),
+  "utf8",
+);
 
 test("release builds run after the optional preparation job is skipped", () => {
   const buildJob = workflow.match(/\n  build:\n([\s\S]*?)\n  publish:\n/)?.[1];
@@ -42,7 +50,6 @@ test("normalizes Windows runner paths before extracting the compiler cache", () 
     /archive="\$RUNNER_TEMP\/\$\{\{ matrix\.sccache_archive \}\}"/,
   );
 });
-
 test("preserves the exact bytes of every pinned classifier asset", () => {
   const binaryPaths = new Set(
     gitAttributes
@@ -59,4 +66,19 @@ test("preserves the exact bytes of every pinned classifier asset", () => {
       `${file} must be exempt from checkout line-ending conversion`,
     );
   }
+});
+
+test("keeps the tokenizer C++ training accelerator out of release builds", () => {
+  assert.match(
+    coreManifest,
+    /^tokenizers = \{ version = "=0\.22\.2", default-features = false, features = \["onig"\] \}$/m,
+  );
+  assert.match(
+    pullRequestWorkflow,
+    /cargo tree --locked --target x86_64-pc-windows-msvc -p dakia-cli -e features -i esaxx-rs/,
+  );
+  assert.match(
+    pullRequestWorkflow,
+    /grep -Fq 'esaxx-rs feature "cpp"'/,
+  );
 });


### PR DESCRIPTION
## Summary

- disable the unused `tokenizers/esaxx_fast` C++ training accelerator
- keep the `onig` regex runtime used by the bundled tokenizer
- reject the conflicting `esaxx-rs/cpp` feature in Rust-core PR validation

## Root cause

The Windows release CLI linked ONNX Runtime objects built with the dynamic MSVC runtime (`/MD`) together with `esaxx-rs` objects forced to the static runtime (`/MT`). MSVC rejected that incompatible mix with LNK2038 and LNK1169. Dakia loads and executes an existing tokenizer and does not train tokenizers, so the accelerator is unused.

## Verification

- 20 classifier and production model tests passed
- release-mode CLI bundle built successfully on macOS
- locked Windows feature graph contains `tokenizers/onig` and no `esaxx-rs/cpp`
- focused production release workflow contract tests passed
- full release-script suite passed 124 of 125 locally; the remaining pre-existing nightly dry-run test depends on Linux path canonicalization and is covered by CI

The authoritative acceptance check is the Windows release link in the next production release run.
