### PR TITLE
Run release publication after skipped preparation

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -580,7 +580,13 @@ jobs:
   publish:
     name: Publish signed release
     needs: [decide, validate, build]
-    if: needs.decide.outputs.should_release == 'true'
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.decide.result == 'success' &&
+      needs.validate.result == 'success' &&
+      needs.build.result == 'success' &&
+      needs.decide.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     environment: production-release
@@ -698,7 +704,13 @@ jobs:
   verify-public:
     name: Verify anonymous public release
     needs: [decide, validate, publish]
-    if: needs.decide.outputs.should_release == 'true'
+    if: >-
+      always() &&
+      !cancelled() &&
+      needs.decide.result == 'success' &&
+      needs.validate.result == 'success' &&
+      needs.publish.result == 'success' &&
+      needs.decide.outputs.should_release == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 20
     permissions:

--- a/scripts/production-release-workflow.node-test.mjs
+++ b/scripts/production-release-workflow.node-test.mjs
@@ -26,6 +26,14 @@ const coreManifest = readFileSync(
   "utf8",
 );
 
+function jobCondition(job) {
+  const condition = job.match(
+    /if:\s*>-\s*\n([\s\S]*?)\n\s+(?:runs-on|strategy):/,
+  )?.[1];
+  assert.ok(condition, "job condition is missing");
+  return condition.trim().replace(/\s+/g, " ");
+}
+
 test("release builds run after the optional preparation job is skipped", () => {
   const buildJob = workflow.match(/\n  build:\n([\s\S]*?)\n  publish:\n/)?.[1];
   assert.ok(buildJob, "production release build job is missing");
@@ -33,6 +41,24 @@ test("release builds run after the optional preparation job is skipped", () => {
   assert.match(buildJob, /needs\.decide\.result == 'success'/);
   assert.match(buildJob, /needs\.validate\.result == 'success'/);
   assert.match(buildJob, /needs\.decide\.outputs\.should_release == 'true'/);
+});
+
+test("release publication runs after the optional preparation job is skipped", () => {
+  const publishJob = workflow.match(/\n  publish:\n([\s\S]*?)\n  verify-public:\n/)?.[1];
+  assert.ok(publishJob, "production release publish job is missing");
+  assert.match(publishJob, /needs: \[decide, validate, build\]/);
+  assert.equal(
+    jobCondition(publishJob),
+    "always() && !cancelled() && needs.decide.result == 'success' && needs.validate.result == 'success' && needs.build.result == 'success' && needs.decide.outputs.should_release == 'true'",
+  );
+
+  const verifyJob = workflow.match(/\n  verify-public:\n([\s\S]*)$/)?.[1];
+  assert.ok(verifyJob, "production release verification job is missing");
+  assert.match(verifyJob, /needs: \[decide, validate, publish\]/);
+  assert.equal(
+    jobCondition(verifyJob),
+    "always() && !cancelled() && needs.decide.result == 'success' && needs.validate.result == 'success' && needs.publish.result == 'success' && needs.decide.outputs.should_release == 'true'",
+  );
 });
 
 test("normalizes Windows runner paths before extracting the compiler cache", () => {


### PR DESCRIPTION
## Summary

- allow publication to run after the optional version-preparation job is skipped
- require every direct build and validation dependency to succeed
- refuse publication or public verification when the workflow is canceled
- lock the complete job conditions and dependency lists in a regression test

## Root cause

v0.4.3 was already prepared in the repository, so `Prepare next patch release` was intentionally skipped. GitHub propagated that skipped dependency through the otherwise successful validation and platform build chain. The publish job had no explicit status function, so GitHub skipped it and then skipped public verification.

## Verification

- production release workflow contract: 5 passed
- full release-script suite: 126 passed; the one local failure is the pre-existing macOS `/var` versus `/private/var` temp-path issue in the nightly dry-run fixture, which runs on Linux in CI
- independent release review confirmed the direct dependency guards and cancellation safety

No release assets or public feeds are changed by this PR itself.
