### PR TITLE
Fix Windows release checksum manifests

### DIFF
--- a/.github/workflows/production-release.yml
+++ b/.github/workflows/production-release.yml
@@ -544,7 +544,15 @@ jobs:
           # signature last even when no Windows certificate is configured.
           ./node_modules/.bin/tauri signer sign "$output/$expected"
           test -s "$output/$expected.sig"
-          (cd "$output" && sha256sum "$expected" "$expected.sig" > SHA256SUMS.txt)
+          # Git for Windows prefixes binary-mode filenames with `*`. Compute
+          # the digest in binary mode, then write a platform-neutral manifest.
+          (
+            cd "$output"
+            for artifact in "$expected" "$expected.sig"; do
+              digest="$(sha256sum --binary "$artifact" | awk '{print $1}')"
+              printf '%s  %s\n' "$digest" "$artifact"
+            done > SHA256SUMS.txt
+          )
           node scripts/verify-updater-signature.mjs "$output/$expected" "$output/$expected.sig" apps/desktop/src-tauri/tauri.conf.json
       - name: Verify macOS release asset set
         if: matrix.platform == 'macos'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,7 +963,7 @@ checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "dakia-cli"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
@@ -983,7 +983,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-core"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1017,7 +1017,7 @@ dependencies = [
 
 [[package]]
 name = "dakia-desktop"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.3"
+version = "0.4.4"
 edition = "2021"
 license = "MPL-2.0"
 repository = "https://github.com/DakiaMail/dakia-desktop"

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Dakia",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "identifier": "dev.dakia.mail",
   "build": {
     "beforeDevCommand": "npm run dev:desktop-web",

--- a/docs/releases/v0.4.4.md
+++ b/docs/releases/v0.4.4.md
@@ -1,0 +1,16 @@
+# Dakia v0.4.4
+
+This update makes Dakia faster and more reliable with large or changing mailboxes, improves attachment names and people organization, and adds privacy-preserving usage analytics.
+
+## What changed
+
+- **Resend sent messages.** Use the new Send again action to resend a message you have already sent.
+- **Faster archiving and read updates.** Archiving a message or marking it as read now updates instantly, with no wait on the network.
+- **More reliable mailbox syncing.** Large IMAP mailboxes now sync in bounded batches, recover more safely from interrupted rebuilds, and handle mailbox resets and server changes without leaving partial local state.
+- **Correct attachment filenames.** Encoded attachment names from more email providers are now decoded before they are shown or saved.
+- **Better people categorization.** People are now grouped more consistently across the desktop app, the CLI, and the core engine.
+- **Privacy-preserving usage analytics.** Dakia now collects minimal, privacy-preserving usage analytics to help guide development.
+
+## Download
+
+Dakia v0.4.4 is available for macOS, Linux, and Windows.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dakia",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dakia",
-      "version": "0.4.3",
+      "version": "0.4.4",
       "dependencies": {
         "@browsermt/bergamot-translator": "^0.4.9",
         "@mantine/core": "^8.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dakia",
   "private": true,
-  "version": "0.4.3",
+  "version": "0.4.4",
   "type": "module",
   "scripts": {
     "dev": "./scripts/dev.sh",

--- a/scripts/production-release-workflow.node-test.mjs
+++ b/scripts/production-release-workflow.node-test.mjs
@@ -44,7 +44,9 @@ test("release builds run after the optional preparation job is skipped", () => {
 });
 
 test("release publication runs after the optional preparation job is skipped", () => {
-  const publishJob = workflow.match(/\n  publish:\n([\s\S]*?)\n  verify-public:\n/)?.[1];
+  const publishJob = workflow.match(
+    /\n  publish:\n([\s\S]*?)\n  verify-public:\n/,
+  )?.[1];
   assert.ok(publishJob, "production release publish job is missing");
   assert.match(publishJob, /needs: \[decide, validate, build\]/);
   assert.equal(
@@ -76,6 +78,23 @@ test("normalizes Windows runner paths before extracting the compiler cache", () 
     /archive="\$RUNNER_TEMP\/\$\{\{ matrix\.sccache_archive \}\}"/,
   );
 });
+
+test("writes canonical Windows checksums while hashing binary bytes", () => {
+  const windowsAssets = workflow.match(
+    /- name: Sign and assemble Windows release assets([\s\S]*?)- name: Verify macOS release asset set/,
+  )?.[1];
+  assert.ok(windowsAssets, "Windows release asset step is missing");
+  assert.match(
+    windowsAssets,
+    /sha256sum --binary "\$artifact" \| awk '\{print \$1\}'/,
+  );
+  assert.match(windowsAssets, /printf '%s  %s\\n' "\$digest" "\$artifact"/);
+  assert.doesNotMatch(
+    windowsAssets,
+    /sha256sum "\$expected" "\$expected\.sig" > SHA256SUMS\.txt/,
+  );
+});
+
 test("preserves the exact bytes of every pinned classifier asset", () => {
   const binaryPaths = new Set(
     gitAttributes
@@ -103,8 +122,5 @@ test("keeps the tokenizer C++ training accelerator out of release builds", () =>
     pullRequestWorkflow,
     /cargo tree --locked --target x86_64-pc-windows-msvc -p dakia-cli -e features -i esaxx-rs/,
   );
-  assert.match(
-    pullRequestWorkflow,
-    /grep -Fq 'esaxx-rs feature "cpp"'/,
-  );
+  assert.match(pullRequestWorkflow, /grep -Fq 'esaxx-rs feature "cpp"'/);
 });


### PR DESCRIPTION
## Summary

- hash Windows installer artifacts in binary mode while writing portable checksum records
- add a regression guard for the exact Windows manifest format
- prepare v0.4.4 metadata and reader-facing release notes without moving the signed v0.4.3 tag

## Verification

- `node --test scripts/production-release-workflow.node-test.mjs` (6 passed)
- canonical checksum generation and verification round-trip (2 artifacts passed)
- Prettier check passed
- Cargo metadata and all release version authorities are 0.4.4
- `git diff --check` passed
- `npm run test:release-scripts` (127 passed, 1 known macOS `/var` versus `/private/var` temp-path identity failure; hosted Linux CI is authoritative)